### PR TITLE
Hard coded link removed in top static-nav site

### DIFF
--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -21,7 +21,7 @@
             <nav class="navbar navbar-static-top">
                 <div class="container">
                     <div class="navbar-header">
-                        <a href="../../index2.html" class="navbar-brand"><b>Admin</b>LTE</a>
+                        <a href="{{ url(config('adminlte.dashboard_url', 'home')) }}" class="navbar-brand">{!! config('adminlte.logo', '<b>Admin</b>LTE') !!}</a>
                         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse">
                             <i class="fa fa-bars"></i>
                         </button>


### PR DESCRIPTION
Previous URL was hard coded for the top-nav site.