### PR TITLE
added boolean to enable datatables easily in app

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -162,5 +162,18 @@ return [
             'icon_color' => 'aqua',
         ],
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Plugins Initialization
+    |--------------------------------------------------------------------------
+    |
+    | Set any option below to true in order to enable the plugin by default
+    | in the master.blade.php file. For instance using an @if directive
+    | setting datatables to true will include the cdn assets for dt.
+    |
+    */
+    'plugins'=>[
+        'datatables'=>true,
+    ],
 
 ];

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -14,6 +14,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
+    
+    @if(config('adminlte.plugins.datatables'))
+        <!-- DataTables -->
+        <link rel="stylesheet" href="//cdn.datatables.net/1.10.12/css/jquery.dataTables.min.css">
+    @endif
 
     @yield('adminlte_css')
 
@@ -28,6 +33,10 @@
 
 <script src="{{ asset('vendor/adminlte/plugins/jQuery/jquery-2.2.3.min.js') }}"></script>
 <script src="{{ asset('vendor/adminlte/bootstrap/js/bootstrap.min.js') }}"></script>
+@if(config('adminlte.plugins.datatables'))
+    <!-- DataTables -->
+    <script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js"></script>
+@endif
 
 @yield('adminlte_js')
 


### PR DESCRIPTION
Added an @if directive in master.blade.php to include CDN for datatables. Pretty common usage. Added array in config 'plugins'=>['datatables'=>false] -- do not inculde by default, set to true to enable datatables in project. 

This keeps the project light but easy to add datatables to it. 