### PR TITLE
Add simple Gate functionality

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -162,5 +162,18 @@ return [
             'icon_color' => 'aqua',
         ],
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Plugins Initialization
+    |--------------------------------------------------------------------------
+    |
+    | Set any option below to true in order to enable the plugin by default
+    | in the master.blade.php file. For instance using an @if directive
+    | setting datatables to true will include the cdn assets for dt.
+    |
+    */
+    'plugins'=>[
+        'datatables'=>true,
+    ],
 
 ];

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -77,6 +77,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Enable Gate Checking
+    |--------------------------------------------------------------------------
+    |
+    | Simple authorization checking to remove menu items based on user
+    | permission. Set menu item 'permission' to the permission that
+    | you would like to check for.  Must be  implemented by Gate
+    |
+    */
+   'check_auth'=>false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Menu Items
     |--------------------------------------------------------------------------
     |
@@ -108,15 +120,17 @@ return [
         [
             'text' => 'Change Password',
             'url' => 'admin/settings',
-            'icon' => 'lock'
+            'icon' => 'lock',
+            'permission'=>'no-access',
         ],
         [
             'text' => 'Multilevel',
             'icon' => 'share',
             'submenu' => [
                 [
-                    'text' => 'Level One',
+                    'text' => 'Level One - no-access',
                     'url' => '#',
+                    'permission'=>'no-access',
                 ],
                 [
                     'text' => 'Level One',

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -79,18 +79,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Enable Gate Checking
-    |--------------------------------------------------------------------------
-    |
-    | Simple authorization checking to remove menu items based on user
-    | permission. Set menu item 'permission' to the permission that
-    | you would like to check for.  Must be  implemented by Gate
-    |
-    */
-   'check_auth'=>false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Menu Items
     |--------------------------------------------------------------------------
     |
@@ -123,16 +111,16 @@ return [
             'text' => 'Change Password',
             'url' => 'admin/settings',
             'icon' => 'lock',
-            //'permission'=>'no-access',
+            
         ],
         [
             'text' => 'Multilevel',
             'icon' => 'share',
             'submenu' => [
                 [
-                    'text' => 'Level One - no-access',
+                    'text' => 'Level One',
                     'url' => '#',
-                    //'permission'=>'no-access',
+                    
                 ],
                 [
                     'text' => 'Level One',

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -123,7 +123,7 @@ return [
             'text' => 'Change Password',
             'url' => 'admin/settings',
             'icon' => 'lock',
-            'permission'=>'no-access',
+            //'permission'=>'no-access',
         ],
         [
             'text' => 'Multilevel',
@@ -132,7 +132,7 @@ return [
                 [
                     'text' => 'Level One - no-access',
                     'url' => '#',
-                    'permission'=>'no-access',
+                    //'permission'=>'no-access',
                 ],
                 [
                     'text' => 'Level One',

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -14,6 +14,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
+    
+    @if(config('adminlte.plugins.datatables'))
+        <!-- DataTables -->
+        <link rel="stylesheet" href="//cdn.datatables.net/1.10.12/css/jquery.dataTables.min.css">
+    @endif
 
     @yield('adminlte_css')
 
@@ -28,6 +33,10 @@
 
 <script src="{{ asset('vendor/adminlte/plugins/jQuery/jquery-2.2.3.min.js') }}"></script>
 <script src="{{ asset('vendor/adminlte/bootstrap/js/bootstrap.min.js') }}"></script>
+@if(config('adminlte.plugins.datatables'))
+    <!-- DataTables -->
+    <script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js"></script>
+@endif
 
 @yield('adminlte_js')
 

--- a/src/AdminLte.php
+++ b/src/AdminLte.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
 use JeroenNoten\LaravelAdminLte\Menu\ActiveChecker;
 use JeroenNoten\LaravelAdminLte\Menu\Builder;
+use Illuminate\Contracts\Auth\Access\Gate;
 
 class AdminLte
 {
@@ -20,11 +21,14 @@ class AdminLte
 
     private $activeChecker;
 
-    public function __construct(Dispatcher $events, UrlGenerator $urlGenerator, ActiveChecker $activeChecker)
+    private $gate;
+
+    public function __construct(Dispatcher $events, UrlGenerator $urlGenerator, ActiveChecker $activeChecker, Gate $gate)
     {
         $this->events = $events;
         $this->urlGenerator = $urlGenerator;
         $this->activeChecker = $activeChecker;
+        $this->gate = $gate;
     }
 
     public function menu()
@@ -38,7 +42,7 @@ class AdminLte
 
     protected function buildMenu()
     {
-        $builder = new Builder($this->urlGenerator, $this->activeChecker);
+        $builder = new Builder($this->urlGenerator, $this->activeChecker, $this->gate);
         
         $this->events->fire(new BuildingMenu($builder));
 

--- a/tests/AdminLteTest.php
+++ b/tests/AdminLteTest.php
@@ -1,12 +1,16 @@
 <?php
 
 use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Foundation\Application as App;
 
 class AdminLteTest extends TestCase
 {
+	
     public function testMenu()
     {
-        $adminLte = $this->makeAdminLte();
+
+        $adminLte = $this->makeAdminLte($this->gate);
 
         $this->getDispatcher()->listen(BuildingMenu::class, function (BuildingMenu $event) {
             $event->menu->add(['text' => 'Home']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,10 +9,13 @@ use JeroenNoten\LaravelAdminLte\AdminLte;
 use JeroenNoten\LaravelAdminLte\Menu\ActiveChecker;
 use JeroenNoten\LaravelAdminLte\Menu\Builder;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Illuminate\Auth\Access\Gate;
+
 
 class TestCase extends PHPUnit_Framework_TestCase
 {
     private $dispatcher;
+    
 
     protected function makeMenuBuilder($uri = 'http://example.com')
     {
@@ -31,13 +34,15 @@ class TestCase extends PHPUnit_Framework_TestCase
     {
         return Request::createFromBase(SymfonyRequest::create($uri));
     }
-
-    protected function makeAdminLte()
+    
+    protected function makeAdminLte(Gate $gate)
     {
         return new AdminLte(
             $this->getDispatcher(),
             $this->makeUrlGenerator(),
-            $this->makeActiveChecker()
+            $this->makeActiveChecker(),
+            $gate
+            
         );
     }
 


### PR DESCRIPTION
Simple gate functionality when building menu. Allows to add 'permission' item to menu array and check against a configured gate. 