### PR TITLE
Add container to menu items with labels to fix display issue in firefox

### DIFF
--- a/resources/views/partials/menu-item.blade.php
+++ b/resources/views/partials/menu-item.blade.php
@@ -6,7 +6,9 @@
             <i class="fa fa-fw fa-{{ $item['icon'] or 'circle-o' }} {{ isset($item['icon_color']) ? 'text-' . $item['icon_color'] : '' }}"></i>
             <span>{{ $item['text'] }}</span>
             @if (isset($item['label']))
-                <span class="label label-{{ $item['label_color'] or 'primary' }} pull-right">{{ $item['label'] }}</span>
+                <span class="pull-right-container">
+                    <span class="label label-{{ $item['label_color'] or 'primary' }} pull-right">{{ $item['label'] }}</span>
+                </span>
             @elseif (isset($item['submenu']))
                 <span class="pull-right-container">
                 <i class="fa fa-angle-left pull-right"></i>


### PR DESCRIPTION
The current AdminLTE demo uses a `<span class="pull-right-container">` to wrap menu items with a label.

https://github.com/almasaeed2010/AdminLTE/blob/master/index.html#L347