### PR TITLE
Move set header menu title to the builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ php artisan vendor:publish --provider="JeroenNoten\LaravelAdminLte\ServiceProvid
 
 Now, edit `config/adminlte.php` to configure the title, skin, menu, URLs etc. All configuration options are explained in the comments. However, I want to shed some light on the `menu` configuration.
 
-### 5.1 Menu 
+### 5.1 Menu
 
 You can configure your menu as follows:
 
@@ -214,7 +214,7 @@ Use the `can` option if you want conditionally show the menu item. This integrat
 
 #### Custom Menu Filters
 
-If you need custom filters, you can easily add your own menu filters to this package. This can be useful when you are using a third-party package for authorization (instead of Laravel's `Gate` functionality).  
+If you need custom filters, you can easily add your own menu filters to this package. This can be useful when you are using a third-party package for authorization (instead of Laravel's `Gate` functionality).
 
 For example with Laratrust:
 
@@ -233,10 +233,6 @@ class MyMenuFilter implements FilterInterface
     {
         if (isset($item['permission']) && ! Laratrust::can($item['permission'])) {
             return false;
-        }
-        
-        if (isset($item['header'])) {
-            $item = $item['header'];
         }
 
         return $item;
@@ -283,7 +279,7 @@ class AppServiceProvider extends ServiceProvider
             ]);
         });
     }
-    
+
 }
 ```
 The configuration options are the same as in the static configuration files.

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -40,6 +40,10 @@ class Builder
             $item = $filter->transform($item, $this);
         }
 
+        if (isset($item['header'])) {
+            $item = $item['header'];
+        }
+
         return $item;
     }
 }

--- a/src/Menu/Filters/GateFilter.php
+++ b/src/Menu/Filters/GateFilter.php
@@ -20,10 +20,6 @@ class GateFilter implements FilterInterface
             return false;
         }
 
-        if (isset($item['header'])) {
-            $item = $item['header'];
-        }
-
         return $item;
     }
 


### PR DESCRIPTION
Now the set menu header text is on the Gate filter, but if you want to have more that one filters to a header in the menu you have to set that piece of code (see below) on the last filter, so why no add that code on the Builder.

```
        if (isset($item['header'])) {
            $item = $item['header'];
        }
```
