### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ And then add to `config/adminlte.php`:
     JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter::class,
     JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter::class,
     JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter::class,
-    JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class, // Comment this line out if you want
+    //JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class, Comment this line out
     MyApp\MyMenuFilter::class,
 ]
 ```


### PR DESCRIPTION
The comment of the filter JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class should be labeled differently than "If you want".  The issue is if you don't comment the GateFilter and use your newly created Laratrust filter, the headers will still show because the array(permissions) is removed with $item = $item['header']; in the GateFilter