### PR TITLE
Renamed MakeAuthCommand to AuthMakeCommand.

### DIFF
--- a/src/Console/MakeAdminLteCommand.php
+++ b/src/Console/MakeAdminLteCommand.php
@@ -2,9 +2,9 @@
 
 namespace JeroenNoten\LaravelAdminLte\Console;
 
-use Illuminate\Auth\Console\MakeAuthCommand;
+use Illuminate\Auth\Console\AuthMakeCommand;
 
-class MakeAdminLteCommand extends MakeAuthCommand
+class MakeAdminLteCommand extends AuthMakeCommand
 {
     protected $signature = 'make:adminlte {--views : Only scaffold the authentication views}{--force : Overwrite existing views by default}';
 


### PR DESCRIPTION
Laravel 5.4 it seems there has been a change: MakeAuthCommand has been renamed to AuthMakeCommand.