### PR TITLE
Translate menu items using filter class

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -203,6 +203,7 @@ return [
         JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class,
+        JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter::class,
     ],
 
     /*

--- a/src/Menu/Filters/LangFilter.php
+++ b/src/Menu/Filters/LangFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Menu\Filters;
+
+use JeroenNoten\LaravelAdminLte\Menu\Builder;
+use Illuminate\Contracts\Translation\Translator;
+
+class LangFilter implements FilterInterface
+{
+    protected $langGenerator;
+
+    public function __construct(Translator $langGenerator)
+    {
+        $this->langGenerator = $langGenerator;
+    }
+
+    public function transform($item, Builder $builder)
+    {
+        if (isset($item['header'])) {
+            $item['header'] = $this->langGenerator->trans($item['header']);
+        }
+        if (isset($item['text'])) {
+            $item['text'] = $this->langGenerator->trans($item['text']);
+        }
+        return $item;
+    }
+}

--- a/src/Menu/Filters/LangFilter.php
+++ b/src/Menu/Filters/LangFilter.php
@@ -22,6 +22,7 @@ class LangFilter implements FilterInterface
         if (isset($item['text'])) {
             $item['text'] = $this->langGenerator->trans($item['text']);
         }
+
         return $item;
     }
 }

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -273,4 +273,21 @@ class BuilderTest extends TestCase
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('HEADER', $builder->menu[0]);
     }
+
+    public function testLangTranslate()
+    {
+        $builder = $this->makeMenuBuilder('http://example.com');
+        $translationloader = $this->getTranslationLoader();
+        $t= array('home' => 'translatedHome', 'header' => 'translatedHeader');
+        $translationloader->addMessages('en', 'test', $t);
+        $builder->add(['header' => 'HEADER']);
+        $builder->add(['text' => 'test.home', 'url' => '/']);
+        $builder->add(['header' => 'test.header']);
+        $builder->add(['text' => 'About', 'url' => '/about']);
+        $this->assertCount(4, $builder->menu);
+        $this->assertEquals('HEADER', $builder->menu[0]);
+        $this->assertEquals('translatedHeader', $builder->menu[2]);
+        $this->assertEquals('translatedHome', $builder->menu[1]['text']);
+        $this->assertEquals('About', $builder->menu[3]['text']);
+    }
 }

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -278,7 +278,7 @@ class BuilderTest extends TestCase
     {
         $builder = $this->makeMenuBuilder('http://example.com');
         $translationloader = $this->getTranslationLoader();
-        $t= array('home' => 'translatedHome', 'header' => 'translatedHeader');
+        $t= ['home' => 'translatedHome', 'header' => 'translatedHeader'];
         $translationloader->addMessages('en', 'test', $t);
         $builder->add(['header' => 'HEADER']);
         $builder->add(['text' => 'test.home', 'url' => '/']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\GenericUser;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Translation\Translator;
 use JeroenNoten\LaravelAdminLte\AdminLte;
 use JeroenNoten\LaravelAdminLte\Menu\Builder;
 use JeroenNoten\LaravelAdminLte\Menu\ActiveChecker;
@@ -15,6 +16,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\ActiveFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter;
+use JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TestCase extends PHPUnit_Framework_TestCase
@@ -22,6 +24,8 @@ class TestCase extends PHPUnit_Framework_TestCase
     private $dispatcher;
 
     private $routeCollection;
+
+    private $translationLoader;
 
     protected function makeMenuBuilder($uri = 'http://example.com', GateContract $gate = null)
     {
@@ -31,7 +35,19 @@ class TestCase extends PHPUnit_Framework_TestCase
             new SubmenuFilter(),
             new ClassesFilter(),
             new GateFilter($gate ?: $this->makeGate()),
+            new LangFilter($this->makeTranslator()),
         ]);
+    }
+
+    protected function makeTranslator()
+    {
+        $this->translationLoader = new \Illuminate\Translation\ArrayLoader();
+        return new Translator($this->translationLoader, 'en');
+    }
+
+    public function getTranslationLoader()
+    {
+        return $this->translationLoader;
     }
 
     protected function makeActiveChecker($uri = 'http://example.com')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,18 +5,18 @@ use Illuminate\Auth\Access\Gate;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\UrlGenerator;
-use Illuminate\Routing\RouteCollection;
 use Illuminate\Translation\Translator;
+use Illuminate\Routing\RouteCollection;
 use JeroenNoten\LaravelAdminLte\AdminLte;
 use JeroenNoten\LaravelAdminLte\Menu\Builder;
 use JeroenNoten\LaravelAdminLte\Menu\ActiveChecker;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter;
+use JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\ActiveFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter;
-use JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TestCase extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
The code adds a new filter class to translate menu items
For [text] and [header] entries just use the standard laravel language dot notation
e.g 'text' => 'dashboard.bannersassignentry'
To translate menu headers you must explicitly derfine a header
e.g. rather than doing

'menu' => [
    'MAIN NAVIGATION',
    [
        'text' => 'Blog',
        'url' => 'admin/blog',
    ],

you have to do something like

'menu' => [
    [
      'header' => 'group.mainnavigation'
    ]
    [
        'text' => 'group.blogmenuentry',
        'url' => 'admin/blog',
    ],