### PR TITLE
Select2 as a Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,16 @@ By default the [DataTables](https://datatables.net/) plugin is supported. If set
 ]
 ```
 
+Also the [Select2](https://select2.github.io/) plugin is supported. If set to `true`, the necessary javascript CDN script tags will automatically be injected into the `adminlte::page.blade` file.
+
+```php
+'plugins' => [
+    'datatables' => true,
+    'select2' => true,
+]
+```
+
+
 ## 6. Translations
 
 At the moment, English, German, French, Dutch, Portuguese and Spanish translations are available out of the box.

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -218,5 +218,6 @@ return [
 
     'plugins' => [
         'datatables' => true,
+        'select2'    => true,
     ],
 ];

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -16,7 +16,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
-    
+
+    @if(config('adminlte.plugins.select2'))
+        <!-- Select2 -->
+            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.css">
+    @endif
+
     @if(config('adminlte.plugins.datatables'))
         <!-- DataTables -->
         <link rel="stylesheet" href="//cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css">
@@ -35,6 +40,12 @@
 
 <script src="{{ asset('vendor/adminlte/plugins/jQuery/jquery-2.2.3.min.js') }}"></script>
 <script src="{{ asset('vendor/adminlte/bootstrap/js/bootstrap.min.js') }}"></script>
+
+@if(config('adminlte.plugins.select2'))
+    <!-- Select2 -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+@endif
+
 @if(config('adminlte.plugins.datatables'))
     <!-- DataTables -->
     <script src="//cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
To add Select2 to the project it was required to modify the vendor folder since all custom JS is loaded **after** the theme CSS/JS was loaded, this makes the Select2 to break. So added the library as a plugin so it can be optional and called **before** the theme CSS/JS is called, stopping the need of modifying the vendor's folder to use Select2.