### PR TITLE
Resolving minor Select2 CSS conflict with AdminLTE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,16 @@ By default the [DataTables](https://datatables.net/) plugin is supported. If set
 ]
 ```
 
+Also the [Select2](https://select2.github.io/) plugin is supported. If set to `true`, the necessary javascript CDN script tags will automatically be injected into the `adminlte::page.blade` file.
+
+```php
+'plugins' => [
+    'datatables' => true,
+    'select2' => true,
+]
+```
+
+
 ## 6. Translations
 
 At the moment, English, German, French, Dutch, Portuguese and Spanish translations are available out of the box.

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -218,5 +218,6 @@ return [
 
     'plugins' => [
         'datatables' => true,
+        'select2'    => true,
     ],
 ];

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -16,7 +16,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
-    
+
+    @if(config('adminlte.plugins.select2'))
+        <!-- Select2 -->
+            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.css">
+    @endif
+
     @if(config('adminlte.plugins.datatables'))
         <!-- DataTables -->
         <link rel="stylesheet" href="//cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css">
@@ -35,6 +40,12 @@
 
 <script src="{{ asset('vendor/adminlte/plugins/jQuery/jquery-2.2.3.min.js') }}"></script>
 <script src="{{ asset('vendor/adminlte/bootstrap/js/bootstrap.min.js') }}"></script>
+
+@if(config('adminlte.plugins.select2'))
+    <!-- Select2 -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+@endif
+
 @if(config('adminlte.plugins.datatables'))
     <!-- DataTables -->
     <script src="//cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -14,13 +14,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- Ionicons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
-    <!-- Theme style -->
-    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
 
     @if(config('adminlte.plugins.select2'))
         <!-- Select2 -->
             <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.css">
     @endif
+
+    <!-- Theme style -->
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/AdminLTE.min.css') }}">
 
     @if(config('adminlte.plugins.datatables'))
         <!-- DataTables -->


### PR DESCRIPTION
Just started a new project and realized that the placeholder was a little bit out of place. Reviewed the code and realized that even though the plugin was before de DataTable Plugin CSS, it wasn't before AdminLTE CSS, causing the override. Fixed by putting the Select2 call plugin before. 

PD: didn't know how to make a PR without the previous commits, only the last commit - changes on master.blade.php - is needed. (Sorry!)