### PR TITLE
Adjusting the translation of sign_in key for pt-BR locale

### DIFF
--- a/resources/lang/pt-br/adminlte.php
+++ b/resources/lang/pt-br/adminlte.php
@@ -11,7 +11,7 @@ return [
     'register_a_new_membership'   => 'Registrar um novo membro',
     'i_forgot_my_password'        => 'Esqueci minha senha',
     'i_already_have_a_membership' => 'Já sou um membro',
-    'sign_in'                     => 'Assinar',
+    'sign_in'                     => 'Entrar',
     'log_out'                     => 'Sair',
     'toggle_navigation'           => 'Trocar navegação',
     'login_message'               => 'Entre para iniciar uma nova sessão',


### PR DESCRIPTION
Recently started using the project (congrats by the way) and noticed that the value for the sign_in key in the pt-BR locale could be improved.

Sign In usually means that the user will make an action to "Enter" or "Access" the system, so instead of "Assinar" which would be better translated to English as "Subscribe", I changed to "Entrar", which means in English "Enter".

Also, I have noticed that the folder uses "pt-br" in all lowercase. Shouldn't it be "pt-BR"? Other packages (like this one https://github.com/caouecs/Laravel-lang) uses uppercase in the second part. I think this RFC could explain more https://tools.ietf.org/html/bcp47#section-2.2.4