### PR TITLE
Add Search menu item

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -108,6 +108,10 @@ return [
     */
 
     'menu' => [
+        [
+            'search' => true,
+            'text' => 'Search...',
+        ],
         'MAIN NAVIGATION',
         [
             'text' => 'Blog',
@@ -199,6 +203,7 @@ return [
 
     'filters' => [
         JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter::class,
+        JeroenNoten\LaravelAdminLte\Menu\Filters\SearchFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\ActiveFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter::class,

--- a/resources/views/partials/menu-item.blade.php
+++ b/resources/views/partials/menu-item.blade.php
@@ -1,5 +1,16 @@
 @if (is_string($item))
     <li class="header">{{ $item }}</li>
+@elseif ($item['search'] === true)
+    <form action="{{ $item['href'] }}" method="{{ $item['method'] }}" class="sidebar-form">
+        <div class="input-group">
+          <input type="text" name="{{ $item['input_name'] }}" class="form-control" placeholder="{{ $item['text'] }}">
+          <span class="input-group-btn">
+                <button type="submit" name="search" id="search-btn" class="btn btn-flat">
+                  <i class="fa fa-search"></i>
+                </button>
+              </span>
+        </div>
+      </form>
 @else
     <li class="{{ $item['class'] }}">
         <a href="{{ $item['href'] }}"

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Menu\Filters;
+
+use JeroenNoten\LaravelAdminLte\Menu\Builder;
+
+class SearchFilter implements FilterInterface
+{
+    public function transform($item, Builder $builder)
+    {
+        if (! isset($item['search'])) {
+            $item['search'] = false;
+        } elseif ($item['search'] === true) {
+            if (! isset($item['method'])) {
+                $item['method'] = 'get';
+            }
+            if (! isset($item['input_name'])) {
+                $item['input_name'] = 'q';
+            }
+        }
+        return $item;
+    }
+}

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -13,6 +13,8 @@ class SearchFilter implements FilterInterface
         } elseif ($item['search'] === true) {
             if (! isset($item['method'])) {
                 $item['method'] = 'get';
+            } elseif (isset($item['method']) && $item['method'] !== 'post' && $item['method'] !== 'get') {
+                $item['method'] = 'get';
             }
             if (! isset($item['input_name'])) {
                 $item['input_name'] = 'q';

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -20,7 +20,7 @@ class SearchFilter implements FilterInterface
                 $item['input_name'] = 'q';
             }
         }
-        
+
         return $item;
     }
 }

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -20,6 +20,7 @@ class SearchFilter implements FilterInterface
                 $item['input_name'] = 'q';
             }
         }
+        
         return $item;
     }
 }


### PR DESCRIPTION
Hello,

As reported in the issue #119, the Search menu item was missing. I created a new filter. Now we can add it as any other menu item.

**New config option documentation**
```php
[
	// This option is only here to tell the system that this is a search menu item
	// as we coud not rely on the 'text' value.
    'search' => true,

    // The "text" option is used now as value for the placeholder
    'text' => 'Search...',

    // Another option (not implemented) would be to create a "placeholder" option but I thought it would be more
    // consistant from a configurat point of view to keep "text" (less consistant from a HTML point of view though)
    // 'placeholder' => 'Search...',
    
    // OPTIONAL

    // Same as the HREF filter:
    'url' => '',
    // Or
    'route' => '',

    // Must be post or get otherwise it set to the default "get"
    // https://www.w3.org/TR/html401/interact/forms.html#h-17.3
    'method' => 'post', 

    // Set the name of the search input field. Default= "q"
    'input_name' => 'q',
],
````

More options could be added to change things such as input id, icon, etc. if needed.