### PR TITLE
Fix password email url in login form

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -56,7 +56,7 @@
                 </div>
             </form>
             <div class="auth-links">
-                <a href="{{ url(config('adminlte.password_reset_url', 'password/reset')) }}"
+                <a href="{{ url(config('adminlte.password_email_url', 'password/email')) }}"
                    class="text-center"
                 >{{ trans('adminlte::adminlte.i_forgot_my_password') }}</a>
                 <br>


### PR DESCRIPTION
Use `password_email_url` instead of `password_reset_url` in login form