### PR TITLE
Fix: activechecker for url params

### DIFF
--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -52,7 +52,7 @@ class ActiveChecker
 
     protected function checkSub($url)
     {
-        return $this->checkPattern($url.'/*');
+        return $this->checkPattern($url.'/*') or $this->checkPattern($url.'?*');
     }
 
     protected function checkPattern($pattern)


### PR DESCRIPTION
Detect active menu items when url params are added. ex.: example.test/menu1?param=option