### PR TITLE
Fix Menu Active Checker for url params

### DIFF
--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -52,7 +52,7 @@ class ActiveChecker
 
     protected function checkSub($url)
     {
-        return $this->checkPattern($url.'/*');
+        return $this->checkPattern($url.'/*') || $this->checkPattern($url.'?*');
     }
 
     protected function checkPattern($pattern)

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -126,4 +126,19 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($isActive);
     }
+    
+    public function testParams()
+    {
+        $checker = $this->makeActiveChecker('http://example.com/menu?param=option');
+
+        $this->assertTrue($checker->isActive(['url' => 'menu']));
+    }
+
+    public function testSubParams()
+    {
+        $checker = $this->makeActiveChecker('http://example.com/menu/item1?param=option');
+
+        $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
+    }
+
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -126,7 +126,7 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($isActive);
     }
-    
+
     public function testParams()
     {
         $checker = $this->makeActiveChecker('http://example.com/menu?param=option');
@@ -140,5 +140,4 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
     }
-
 }


### PR DESCRIPTION
Actual behaviour:
example.test/menu/item1?param=option doesn't trigger the active menu condition for the url example.test/menu/item1.

Fix:
example.test/menu/item1?param=option will trigger the active menu condition for the url example.test/menu/item1.