### PR TITLE
Add translation on menu items

### DIFF
--- a/resources/views/partials/menu-item-top-nav.blade.php
+++ b/resources/views/partials/menu-item-top-nav.blade.php
@@ -5,9 +5,9 @@
            @if (isset($item['target'])) target="{{ $item['target'] }}" @endif
         >
             <i class="fa fa-fw fa-{{ $item['icon'] or 'circle-o' }} {{ isset($item['icon_color']) ? 'text-' . $item['icon_color'] : '' }}"></i>
-            {{ $item['text'] }}
+            {{ trans($item['text') }}
             @if (isset($item['label']))
-                <span class="label label-{{ $item['label_color'] or 'primary' }}">{{ $item['label'] }}</span>
+                <span class="label label-{{ $item['label_color'] or 'primary' }}">{{ trans($item['label']) }}</span>
             @elseif (isset($item['submenu']))
                 <span class="caret"></span>
             @endif
@@ -19,15 +19,15 @@
                         @if($subitem == '-')
                             <li role="separator" class="divider"></li>
                         @else
-                            <li class="dropdown-header">{{ $subitem }}</li>
+                            <li class="dropdown-header">{{ trans($subitem) }}</li>
                         @endif
                     @else
                     <li class="{{ $subitem['top_nav_class'] }}">
                         <a href="{{ $subitem['href'] }}">
                             <i class="fa fa-{{ $subitem['icon'] or 'circle-o' }} {{ isset($subitem['icon_color']) ? 'text-' . $subitem['icon_color'] : '' }}"></i>
-                            {{ $subitem['text'] }}
+                            {{ trans($subitem['text']) }}
                             @if (isset($subitem['label']))
-                                <span class="label label-{{ $subitem['label_color'] or 'primary' }}">{{ $subitem['label'] }}</span>
+                                <span class="label label-{{ $subitem['label_color'] or 'primary' }}">{{ trans($subitem['label']) }}</span>
                             @endif
                         </a>
                     </li>

--- a/resources/views/partials/menu-item-top-nav.blade.php
+++ b/resources/views/partials/menu-item-top-nav.blade.php
@@ -5,7 +5,7 @@
            @if (isset($item['target'])) target="{{ $item['target'] }}" @endif
         >
             <i class="fa fa-fw fa-{{ $item['icon'] or 'circle-o' }} {{ isset($item['icon_color']) ? 'text-' . $item['icon_color'] : '' }}"></i>
-            {{ trans($item['text') }}
+            {{ trans($item['text']) }}
             @if (isset($item['label']))
                 <span class="label label-{{ $item['label_color'] or 'primary' }}">{{ trans($item['label']) }}</span>
             @elseif (isset($item['submenu']))

--- a/resources/views/partials/menu-item.blade.php
+++ b/resources/views/partials/menu-item.blade.php
@@ -1,15 +1,15 @@
 @if (is_string($item))
-    <li class="header">{{ $item }}</li>
+    <li class="header">{{ trans($item) }}</li>
 @else
     <li class="{{ $item['class'] }}">
         <a href="{{ $item['href'] }}"
            @if (isset($item['target'])) target="{{ $item['target'] }}" @endif
         >
             <i class="fa fa-fw fa-{{ $item['icon'] or 'circle-o' }} {{ isset($item['icon_color']) ? 'text-' . $item['icon_color'] : '' }}"></i>
-            <span>{{ $item['text'] }}</span>
+            <span>{{ trans($item['text']) }}</span>
             @if (isset($item['label']))
                 <span class="pull-right-container">
-                    <span class="label label-{{ $item['label_color'] or 'primary' }} pull-right">{{ $item['label'] }}</span>
+                    <span class="label label-{{ $item['label_color'] or 'primary' }} pull-right">{{ trans($item['label']) }}</span>
                 </span>
             @elseif (isset($item['submenu']))
                 <span class="pull-right-container">


### PR DESCRIPTION
I added translation to the menu items text. 

This is necessary because the helper function `trans()` is not available on config file.

In this way, you can directly put your translation keys on the configuration file:

```
'menu' => [
        [
            'text' => 'sidebar.home', // The corresponding translation will be used
            'url'  => 'dashboard',
            'icon' => 'home'
        ],
      ...

```