### PR TITLE
Translate group menu items

### DIFF
--- a/resources/views/partials/menu-item.blade.php
+++ b/resources/views/partials/menu-item.blade.php
@@ -1,5 +1,5 @@
 @if (is_string($item))
-    <li class="header">{{ $item }}</li>
+    <li class="header">@lang($item)</li>
 @else
     <li class="{{ $item['class'] }}">
         <a href="{{ $item['href'] }}"


### PR DESCRIPTION
Translate menu group items, for example, item "Menu" (gray) on next screenschot:

![image](https://user-images.githubusercontent.com/829880/48971976-84180d80-f032-11e8-9202-c80d229eae0d.png)
