### PR TITLE
Added regex evaluation for active menu items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,13 +312,15 @@ By default, a menu item is considered active if any of the following holds:
 - The current path is a sub-path of the `url` parameter
 - If it has a submenu containing an active menu item
 
-To override this behavior, you can specify an `active` parameter with an array of active URLs, asterisks and regular expressions are supported. Example:
+To override this behavior, you can specify an `active` parameter with an array of active URLs, asterisks and regular expressions are supported. 
+
+To utilize regex, simply prefix your pattern with `regex:` and it will get evaluated automatically. The pattern will attempt to match the path of the URL, returned by `request()->path()`, which returns the current URL without the domain name. Example:
 
 ```php
 [
     'text' => 'Pages'
     'url' => 'pages',
-    'active' => ['pages', 'content', 'content/*']
+    'active' => ['pages', 'content', 'content/*', 'regex:@^content/[0-9]+$@']
 ]
 ```
 

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -67,10 +67,10 @@ class ActiveChecker
             if (preg_match($regex, request()->path()) == 1) {
                 return true;
             }
-            
+
             return false;
         }
-        
+
         return Str::is($fullUrlPattern, $fullUrl);
     }
 

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -61,15 +61,14 @@ class ActiveChecker
 
         $fullUrl = $this->request->fullUrl();
 
-        if(mb_substr($pattern, 0, 6) === "regex:") {
+        if(mb_substr($pattern, 0, 6) === 'regex:') {
+            $regex = mb_substr($pattern, 6);
 
-          $regex = mb_substr($pattern, 6);
-
-          if(preg_match($regex, request()->path()) == 1) {
-            return true;
-          }
-
-          return false;
+            if(preg_match($regex, request()->path()) == 1) {
+                return true;
+            }
+            
+            return false;
         }
         return Str::is($fullUrlPattern, $fullUrl);
     }

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -61,6 +61,16 @@ class ActiveChecker
 
         $fullUrl = $this->request->fullUrl();
 
+        if(mb_substr($pattern, 0, 6) === "regex:") {
+
+          $regex = mb_substr($pattern, 6);
+
+          if(preg_match($regex, request()->path()) == 1) {
+            return true;
+          }
+
+          return false;
+        }
         return Str::is($fullUrlPattern, $fullUrl);
     }
 

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -61,10 +61,10 @@ class ActiveChecker
 
         $fullUrl = $this->request->fullUrl();
 
-        if(mb_substr($pattern, 0, 6) === 'regex:') {
+        if (mb_substr($pattern, 0, 6) === 'regex:') {
             $regex = mb_substr($pattern, 6);
 
-            if(preg_match($regex, request()->path()) == 1) {
+            if (preg_match($regex, request()->path()) == 1) {
                 return true;
             }
             

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -64,7 +64,7 @@ class ActiveChecker
         if (mb_substr($pattern, 0, 6) === 'regex:') {
             $regex = mb_substr($pattern, 6);
 
-            if (preg_match($regex, request()->path()) == 1) {
+            if (preg_match($regex, $this->request->path()) == 1) {
                 return true;
             }
 

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -70,6 +70,7 @@ class ActiveChecker
             
             return false;
         }
+        
         return Str::is($fullUrlPattern, $fullUrl);
     }
 

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -140,11 +140,11 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
     }
-    
+
     public function testExplicitActiveRegexEvaluation()
     {
         $checker = $this->makeActiveChecker('http://example.com/posts/1');
 
         $this->assertTrue($checker->isActive(['active' => ['regex:@^posts/[0-9]+$@']]));
-	}
+    }
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -143,8 +143,8 @@ class ActiveCheckerTest extends TestCase
     
     public function testRegex()
     {
-		$checker = $this->makeActiveChecker('http://example.com/post/1');
+        $checker = $this->makeActiveChecker('http://example.com/posts/1');
 
-        $this->assertTrue($checker->isActive(['active' => 'regex:@^post/[0-9]+$@']));
+        $this->assertTrue($checker->isActive(['active' => ['regex:@^posts/[0-9]+$@']]));
 	}
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -141,7 +141,7 @@ class ActiveCheckerTest extends TestCase
         $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
     }
     
-    public function testRegex()
+    public function testExplicitActiveRegex()
     {
         $checker = $this->makeActiveChecker('http://example.com/posts/1');
 

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -140,4 +140,11 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
     }
+    
+    public function testRegex()
+    {
+		$checker = $this->makeActiveChecker('http://example.com/post/1');
+
+        $this->assertTrue($checker->isActive(['active' => 'regex:@^post/[0-9]+$@']));
+	}
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -141,7 +141,7 @@ class ActiveCheckerTest extends TestCase
         $this->assertTrue($checker->isActive(['url' => 'menu/item1']));
     }
     
-    public function testExplicitActiveRegex()
+    public function testExplicitActiveRegexEvaluation()
     {
         $checker = $this->makeActiveChecker('http://example.com/posts/1');
 


### PR DESCRIPTION
The old version used `Str::is` which can not evaluate regex, it only has support for wildcards such as `*`.

I have edited `ActiveChecker` so that you can simply add `regex:` followed by the regex in your config file and it will proces the regex automatically.

For example:
```php
'active'  => ['/posts', 'regex:@^posts/[0-9]+$@'],
```

This will make these links active:
- /posts
- /posts/1
- /posts/65402

But not these links:
- /posts/create
- /posts/1abc

If there's any questions, please add them below :)

[Please refer to this issue.](https://github.com/jeroennoten/Laravel-AdminLTE/issues/299)