### PR TITLE
Enables make:adminlte Command on Laravel 6

### DIFF
--- a/src/Console/L6MakeAdminLteCommand.php
+++ b/src/Console/L6MakeAdminLteCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Console;
+
+use Illuminate\Console\Command;
+
+class L6MakeAdminLteCommand extends Command
+{
+
+    protected $signature = 'make:adminlte {--views : Only scaffold the authentication views}{--force : Overwrite existing views by default}';
+
+    protected $description = 'Scaffold basic AdminLTE login and registration views and routes';
+
+    protected $adminLteViews = [
+        'auth/login.stub'           => 'auth/login.blade.php',
+        'auth/register.stub'        => 'auth/register.blade.php',
+        'auth/passwords/email.stub' => 'auth/passwords/email.blade.php',
+        'auth/passwords/reset.stub' => 'auth/passwords/reset.blade.php',
+        'home.stub'                 => 'home.blade.php',
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->createDirectories();
+
+        $this->exportViews();
+
+        if (! $this->option('views')) {
+
+            file_put_contents(
+                base_path('routes/web.php'),
+                file_get_contents(__DIR__.'/stubs/make/routes.stub'),
+                FILE_APPEND
+            );
+        }
+
+        $this->info('Authentication scaffolding generated successfully.');
+    }
+
+    /**
+     * Create the directories for the files.
+     *
+     * @return void
+     */
+    protected function createDirectories()
+    {
+        if (!is_dir($directory = $this->getViewPath('auth/passwords'))) {
+            mkdir($directory, 0755, true);
+        }
+    }
+
+    protected function exportViews()
+    {
+        foreach ($this->adminLteViews as $key => $value) {
+            copy(__DIR__.'/stubs/make/views/'.$key,
+                base_path('resources/views/'.$value));
+        }
+    }
+
+    /**
+     * Get full view path relative to the app's configured view path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function getViewPath($path)
+    {
+        return implode(DIRECTORY_SEPARATOR, [
+            config('view.paths')[0] ?? resource_path('views'), $path,
+        ]);
+    }
+
+}

--- a/src/Console/L6MakeAdminLteCommand.php
+++ b/src/Console/L6MakeAdminLteCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 
 class L6MakeAdminLteCommand extends Command
 {
-
     protected $signature = 'make:adminlte {--views : Only scaffold the authentication views}{--force : Overwrite existing views by default}';
 
     protected $description = 'Scaffold basic AdminLTE login and registration views and routes';
@@ -31,7 +30,6 @@ class L6MakeAdminLteCommand extends Command
         $this->exportViews();
 
         if (! $this->option('views')) {
-
             file_put_contents(
                 base_path('routes/web.php'),
                 file_get_contents(__DIR__.'/stubs/make/routes.stub'),
@@ -49,7 +47,7 @@ class L6MakeAdminLteCommand extends Command
      */
     protected function createDirectories()
     {
-        if (!is_dir($directory = $this->getViewPath('auth/passwords'))) {
+        if (! is_dir($directory = $this->getViewPath('auth/passwords'))) {
             mkdir($directory, 0755, true);
         }
     }
@@ -74,5 +72,4 @@ class L6MakeAdminLteCommand extends Command
             config('view.paths')[0] ?? resource_path('views'), $path,
         ]);
     }
-
 }

--- a/src/Console/stubs/make/routes.stub
+++ b/src/Console/stubs/make/routes.stub
@@ -1,0 +1,6 @@
+
+Auth::routes();
+
+Route::get('/home', function() {
+    return view('home');
+})->name('home')->middleware('auth');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -97,6 +97,9 @@ class ServiceProvider extends BaseServiceProvider
             $this->commands(MakeAdminLteCommand::class);
         } elseif (class_exists('Illuminate\\Auth\\Console\\AuthMakeCommand')) {
             $this->commands(AdminLteMakeCommand::class);
+        } else {
+            //Laravel 6 don't have those classes, so we can't extend and need a class that do everything
+            $this->commands(L6MakeAdminLteCommand::class);
         }
     }
 


### PR DESCRIPTION
Enables make:adminlte Command on Laravel 6
* This requires further testing (Linux), because i copy pasted some mkdir commands.
* Working on my test enviroment, W10, L6, PHP 7.3

Issue #355 