### PR TITLE
drop support for laravel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/38200433/shield?branch=master)](https://styleci.io/repos/38200433)
 [![Total Downloads](https://img.shields.io/packagist/dt/jeroennoten/Laravel-AdminLTE.svg?style=flat-square)](https://packagist.org/packages/jeroennoten/Laravel-AdminLTE)
 
-This package provides an easy way to quickly set up [AdminLTE](https://adminlte.io) with Laravel 5 and 6. It has no requirements and dependencies besides Laravel, so you can start building your admin panel immediately. The package just provides a Blade template that you can extend and advanced menu configuration possibilities. A replacement for the `make:auth` Artisan command that uses AdminLTE styled views instead of the default Laravel ones is also included.
+This package provides an easy way to quickly set up [AdminLTE v2](https://adminlte.io) with Laravel 5. It has no requirements and dependencies besides Laravel, so you can start building your admin panel immediately. The package just provides a Blade template that you can extend and advanced menu configuration possibilities. A replacement for the `make:auth` Artisan command that uses AdminLTE styled views instead of the default Laravel ones is also included.
 
 1. [Requirements](#1-requirements)
 2. [Installation](#2-installation)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This package provides an easy way to quickly set up [AdminLTE v2](https://adminl
 
 ## 1. Requirements
 
-- Laravel 5.5.x to 6.0.x
+- Laravel 5.5.x
 - PHP >= 7.0
 
 ## 2. Installation

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
       }
   },
   "require": {
-    "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0.0",
+    "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
     "php": ">=7.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
This PR drop the support of Laravel 6. The support for Laravel 6 will be come with a new branch and version of this project.