### PR TITLE
Enable laravel-mix version method

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -22,7 +22,7 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
     @else
-    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+    <link rel="stylesheet" href="{{ mix('css/app.css') }}">
     @endif
 	
     @yield('meta_tags')
@@ -62,7 +62,7 @@
 
 @yield('adminlte_js')
 @else
-<script src="{{ asset('js/app.js') }}"></script>
+<script src="{{ mix('js/app.js') }}"></script>
 @endif
 
 </body>


### PR DESCRIPTION
Hello.

When I tried to use the laravel mix [version method](https://laravel.com/docs/6.x/mix#versioning-and-cache-busting), it could not be used because app.js and app.css were loaded by the asset method.

This PR is a modification to use the above version method.

I'd be happy if you could ask for a review.

Thank you.