### PR TITLE
Fix incorrect html tag closing

### DIFF
--- a/resources/views/passwords/reset.blade.php
+++ b/resources/views/passwords/reset.blade.php
@@ -38,7 +38,7 @@
                         @if ($errors->has('email'))
                             <div class="invalid-feedback">
                                 <strong>{{ $errors->first('email') }}</strong>
-                            </span>
+                            </div>
                         @endif
                     </div>
                     <div class="input-group mb-3">
@@ -51,7 +51,7 @@
                         @if ($errors->has('password'))
                             <div class="invalid-feedback">
                                 <strong>{{ $errors->first('password') }}</strong>
-                            </span>
+                            </div>
                         @endif
                     </div>
                     <div class="input-group mb-3">
@@ -65,7 +65,7 @@
                         @if ($errors->has('password_confirmation'))
                             <div class="invalid-feedback">
                                 <strong>{{ $errors->first('password_confirmation') }}</strong>
-                            </span>
+                            </div>
                         @endif
                     </div>
                     <button type="submit" class="btn btn-primary btn-block btn-flat">


### PR DESCRIPTION
This PR fixes some incorrect html tags closing in  `resources/views/passwords/reset.blade.php` file.

This
```html
<div class="invalid-feedback">
    <strong>{{ $errors->first('password') }}</strong>
</span>
```
Should be

```html
<div class="invalid-feedback">
    <strong>{{ $errors->first('password') }}</strong>
</div>
```