### PR TITLE
Fix "Active" class in dynamic submenu's

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -123,11 +123,9 @@ class Builder
                     array_splice($menuItems, $lastKey + ($direction == 'after' ? 1 : 0), 0, $items);
                 }
 
-                Arr::set($this->menu, $arrayPath, $menuItems);
+                Arr::set($this->menu, $arrayPath, $this->applyFilters($menuItems));
             }
         }
-
-        $this->menu[$position] = $this->applyFilters($this->menu[$position]);
     }
 
     protected function findItem($itemKey, $items, $childPositionOld = null)

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -126,6 +126,8 @@ class Builder
                 Arr::set($this->menu, $arrayPath, $menuItems);
             }
         }
+
+        $this->menu[$position] = $this->applyFilters($this->menu[$position]);
     }
 
     protected function findItem($itemKey, $items, $childPositionOld = null)


### PR DESCRIPTION
I'm not really sure what the impact is of this change, but in my case it seem's to fix my issue.

When you use `addIn` to add sub-menu items, the top menu item doesn't get the active class as it should.

As mentioned in issue: https://github.com/jeroennoten/Laravel-AdminLTE/issues/509