### PR TITLE
Change menu icon color for information label on configs

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -285,7 +285,7 @@ return [
         ],
         [
             'text'       => 'information',
-            'icon_color' => 'aqua',
+            'icon_color' => 'cyan',
         ],
     ],
 


### PR DESCRIPTION
Actually, **aqua** is not a supported `text-<color>` by AdminLTE. So this was replaced by **cyan** on the menu configuration options.