### PR TITLE
Review the layouts restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,11 +387,11 @@ The following config options are available:
 
 - __`layout_fixed_sidebar`__
 
-    Enables/Disables the fixed sidebar mmode. Can't be used with `layout_topnav`. 
+    Enables/Disables the fixed sidebar mode. Can't be used with `layout_topnav`. 
 
 - __`layout_fixed_navbar`__
 
-    Enables/Disables the fixed navbar mode (top navigation), here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
+    Enables/Disables the fixed navbar (top navigation) mode, here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
 
 - __`layout_fixed_footer`__
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ It's possible to change the layout, you can use a top navigation (navbar) only l
 
 > **NOTE:** Currently, you cannot use a boxed layout with a fixed navbar or a fixed footer. Also, do not enable `layout_topnav` and `layout_boxed` at the same time. Anything else can be mixed together.
 
-The following config options available:
+The following config options are available:
 - __`layout_topnav`__
 
     Enables/Disables the top navigation only layout, to remove the sidebar and have your links at the top navbar. Can't be used with `layout_boxed`.
@@ -387,15 +387,15 @@ The following config options available:
 
 - __`layout_fixed_sidebar`__
 
-    Enables/Disables fixed sidebar. Can't be used with `layout_topnav`. 
+    Enables/Disables the fixed sidebar mmode. Can't be used with `layout_topnav`. 
 
 - __`layout_fixed_navbar`__
 
-    Enables/Disables fixed navbar (top navigation), here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
+    Enables/Disables the fixed navbar mode (top navigation), here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
 
 - __`layout_fixed_footer`__
 
-    Enables/Disables fixed footer, here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
+    Enables/Disables the fixed footer mode, here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
 
 
 __Responsive Usage for `layout_fixed_navbar` & `layout_fixed_footer`__

--- a/README.md
+++ b/README.md
@@ -372,35 +372,37 @@ Example code for the `App/User` with custom image & description functions.
 ```
 
 ### 6.5 Layout
-It's possible change the layout, you can use a top navigation (navbar) only layout, a boxed layout with sidebar and you can enable fixed mode for sidebar, navbar and footer.
+It's possible to change the layout, you can use a top navigation (navbar) only layout, a boxed layout with sidebar, and also you can enable fixed mode for the sidebar, the navbar or the footer.
+
+> **NOTE:** Currently, you cannot use a boxed layout with a fixed navbar or a fixed footer. Also, do not enable `layout_topnav` and `layout_boxed` at the same time. Anything else can be mixed together.
 
 The following config options available:
 - __`layout_topnav`__
 
-    Enables/Disables top navigation only layout.
+    Enables/Disables the top navigation only layout, to remove the sidebar and have your links at the top navbar. Can't be used with `layout_boxed`.
 
 - __`layout_boxed`__
 
-    Enables/Disables Enables/Disables boxed layout, can't used with `layout_topnav`.
+    Enables/Disables the boxed layout. Can't be used with `layout_topnav`.
 
 - __`layout_fixed_sidebar`__
 
-    Enables/Disables fixed sidebar, can't used with `layout_topnav`. 
+    Enables/Disables fixed sidebar. Can't be used with `layout_topnav`. 
 
 - __`layout_fixed_navbar`__
 
-    Enables/Disables fixed navbar (top navigation), here you can set `true` or pass an array for responsive usage.
+    Enables/Disables fixed navbar (top navigation), here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
 
 - __`layout_fixed_footer`__
 
-    Enables/Disables fixed footer, here you can set `true` or pass an array for responsive usage.
+    Enables/Disables fixed footer, here you can set `true` or pass an array for responsive usage. Can't be used with `layout_boxed`.
 
 
 __Responsive Usage for `layout_fixed_navbar` & `layout_fixed_footer`__
 
 With responsive you can disable or enable the fixed navbar/footer for specific viewport sizes.
 
-The array the following keys available, you can set them to `true` or `false`:
+An array with the following keys is available, you can set them to `true` or `false`:
 - `xs` from 0px to 575.99px
 - `sm` from 576px to 767.99px
 - `md` from 768px to 991.99px

--- a/src/AdminLte.php
+++ b/src/AdminLte.php
@@ -37,6 +37,9 @@ class AdminLte
         return $this->menu;
     }
 
+    /**
+     * Gets the body classes, in relation to the config options.
+     */
     public function getBodyClasses()
     {
         $body_classes = [];
@@ -58,7 +61,7 @@ class AdminLte
 
         // Add classes related to the "layout_boxed" configuration.
 
-        if (config('adminlte.layout_boxed')) {
+        if (config('adminlte.layout_boxed') || View::getSection('layout_boxed')) {
             $body_classes[] = 'layout-boxed';
         }
 
@@ -74,15 +77,22 @@ class AdminLte
             $body_classes[] = 'control-sidebar-push';
         }
 
-        // Add classes related to the fixed layout configuration, these are not
-        // compatible with "layout_topnav".
+        // Add classes related to fixed sidebar, these are not compatible with
+        // "layout_topnav".
 
         if (! config('adminlte.layout_topnav') && ! View::getSection('layout_topnav')) {
+
             // Check for fixed sidebar configuration.
 
             if (config('adminlte.layout_fixed_sidebar')) {
                 $body_classes[] = 'layout-fixed';
             }
+        }
+
+        // Add classes related to fixed footer and navbar, these are not
+        // compatible with "layout_boxed".
+
+        if (! config('adminlte.layout_boxed') && ! View::getSection('layout_boxed')) {
 
             // Check for fixed navbar configuration.
 
@@ -119,14 +129,18 @@ class AdminLte
             }
         }
 
+        // Add custom classes, related to the "classes_body" configuration.
+
         $body_classes[] = config('adminlte.classes_body', '');
 
-        // Add classes related to the "classes_body" configuration and return the
-        // set of configured classes for the body tag.
+        // Return the set of configured classes for the body tag.
 
         return trim(implode(' ', $body_classes));
     }
 
+    /**
+     * Gets the body data attributes, in relation to the config options.
+     */
     public function getBodyData()
     {
         $body_data = [];


### PR DESCRIPTION
Currently, it is not possible to use a fixed navbar (top navigation) and/or a fixed footer when `layout_topnav` is enabled (set to `true`). Those restrictions are not imposed by [AdminLTE](https://adminlte.io/docs/3.0/layout.html), in its site the documentation says:

> **Note!**
> You cannot use both layout-boxed and layout-navbar-fixed or layout-footer-fixed at the same time. Anything else can be mixed together.

So, this **PR** review the logic of the method `getBodyClasses()` to make restrictions consistent with the **AdminLTE** ones.

# Summary

1. Allows fixed navbar and/or fixed footer with `layout_topnav`.
2. Restricts the fixed navbar and the fixed footer with `layout_boxed`.
3. Improves the documentation to be more clear about these restrictions.