### PR TITLE
Fix multiple submenu's in submenu's.

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -136,6 +136,10 @@ class Builder
                 return $key;
             } elseif (isset($item['submenu'])) {
                 $newKey = $this->findItem($itemKey, $item['submenu']);
+                
+                if ($newKey === null) {
+                    continue;
+                }
 
                 $childPositions[] = $key;
                 if (! is_array($newKey)) {

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -136,7 +136,7 @@ class Builder
                 return $key;
             } elseif (isset($item['submenu'])) {
                 $newKey = $this->findItem($itemKey, $item['submenu']);
-                
+
                 if ($newKey === null) {
                     continue;
                 }


### PR DESCRIPTION
If you have multiple submenu's in submenu's, lets say:
- Gallery
   - 2017
      -Jan
      -Feb
      -March
   - 2018
      -Jan  <-- Crashes here
      -Feb
      -March

It'll give you a error about the key text not being found. This fix fixes that. (It's looking in a sub-menu, not finding the 2018 key, and thus adding a null key. The correct behavior is to continue the loop.

Code to replicate:
```            
            foreach(range(2016, date('Y')) as $year) {
                $event->menu->addIn('gallery', [
                    'text' => $year,
                    'key' => 'gallery_'.$year,
                    'icon' => 'far fa-fw fa-caret-right',
                ]);

                foreach (range(1,12) as $month) {
                    $event->menu->addIn('gallery_'.$year, [
                        'text' => $month,
                        'key' => 'gallery_'.$year.'_'.$month,
                        'url' => route('admin.gallery.show', [$year, $month]),
                        'icon' => 'far fa-fw fa-caret-right',
                    ]);
                }
            }`