### PR TITLE
New laravel mix options for compiled JS and CSS paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,17 +667,17 @@ After preparing the Laravel Mix vendor files, set `enabled_laravel_mix` to `true
 
 - __`enabled_laravel_mix`__
 
-    Enables Laravel Mix specific css/js load in master layout.
+    Enables Laravel Mix specific `css/js` load in master layout.
 
 Also, you can change the paths used to lookup for the compiled `JS` and `CSS` files using the next configuration options.
 
 - __`laravel_mix_css_path`__
 
-    Path (including file name) to the compiled CSS file. This path should be relative to the public folder. Default value is `css/app.css`
+    Path (including file name) to the compiled `CSS` file. This path should be relative to the public folder. Default value is `css/app.css`
 
 - __`laravel_mix_js_path`__
 
-    Path (including file name) to the compiled JS file. This path should be relative to the public folder. Default value is `js/app.js`
+    Path (including file name) to the compiled `JS` file. This path should be relative to the public folder. Default value is `js/app.js`
 
 ### 6.11 Menu
 Specify your menu items to display in the left sidebar. Each menu item should have a text and a URL. You can also specify an icon from Font Awesome. A string instead of an array represents a header in sidebar layout. The 'can' is a filter on Laravel's built in Gate functionality.

--- a/README.md
+++ b/README.md
@@ -663,11 +663,21 @@ Replace your `app.scss` content by the following:
 //@import '~bootstrap/scss/bootstrap';
 ```
 
-After preparing the Laravel Mix vendor files, set `enabled_laravel_mix` to `true` to enable load app.css & app.js .
+After preparing the Laravel Mix vendor files, set `enabled_laravel_mix` to `true` to enable load `app.css` & `app.js` files.
 
 - __`enabled_laravel_mix`__
 
     Enables Laravel Mix specific css/js load in master layout.
+
+Also, you can change the paths used to lookup for the compiled `JS` and `CSS` files using the next configuration options.
+
+- __`laravel_mix_css_path`__
+
+    Path (including file name) to the compiled CSS file. This path should be relative to the public folder. Default value is `css/app.css`
+
+- __`laravel_mix_js_path`__
+
+    Path (including file name) to the compiled JS file. This path should be relative to the public folder. Default value is `js/app.js`
 
 ### 6.11 Menu
 Specify your menu items to display in the left sidebar. Each menu item should have a text and a URL. You can also specify an icon from Font Awesome. A string instead of an array represents a header in sidebar layout. The 'can' is a filter on Laravel's built in Gate functionality.

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -214,6 +214,8 @@ return [
     */
 
     'enabled_laravel_mix' => false,
+    'laravel_mix_css_path' => 'css/app.css',
+    'laravel_mix_js_path' => 'js/app.js',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -33,7 +33,7 @@
         <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
     @else
-        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @endif
 
     {{-- Custom Stylesheets (post AdminLTE) --}}
@@ -78,7 +78,7 @@
         {{-- Configured Scripts --}}
         @include('adminlte::plugins', ['type' => 'js'])
     @else
-        <script src="{{ mix('js/app.js') }}"></script>
+        <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @endif
 
     {{-- Custom Scripts --}}


### PR DESCRIPTION
Adds new configuration options related to **Laravel Mix**, in order to provide a way to change the paths related to the compiled `CSS` and `JS` files:

- **laravel_mix_css_path**

    Path (including file name) to the compiled `CSS` file. This path should be relative to the public folder. Default value is `css/app.css`

- **laravel_mix_js_path**

    Path (including file name) to the compiled `JS` file. This path should be relative to the public folder. Default value is `js/app.js`