### PR TITLE
Add dev-package orchestra/testbench for testing purposes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "almasaeed2010/adminlte": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.3"
+    "phpunit/phpunit": "^8.3",
+    "orchestra/testbench": ">=4.0"
   }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ use JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\SubmenuFilter;
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use Orchestra\Testbench\TestCase as BaseTestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TestCase extends BaseTestCase


### PR DESCRIPTION
Adds the `dev-package` **orchestra/testbench** to the composer dependencies. This package is needed for testing purposes. Also, we use `Orchestra\Testbench\TestCase` as the `BaseTestCase` class in replacement of the previous `PHPUnit\Framework\TestCase`.