### PR TITLE
Change default value for config classes_topnav_nav

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -129,7 +129,7 @@ return [
     'classes_sidebar' => 'sidebar-dark-primary elevation-4',
     'classes_sidebar_nav' => '',
     'classes_topnav' => 'navbar-white navbar-light',
-    'classes_topnav_nav' => 'navbar-expand-md',
+    'classes_topnav_nav' => 'navbar-expand',
     'classes_topnav_container' => 'container',
 
     /*

--- a/resources/views/partials/navbar/navbar-layout-topnav.blade.php
+++ b/resources/views/partials/navbar/navbar-layout-topnav.blade.php
@@ -1,5 +1,5 @@
 <nav class="main-header navbar
-    {{ config('adminlte.classes_topnav_nav', 'navbar-expand-md') }}
+    {{ config('adminlte.classes_topnav_nav', 'navbar-expand') }}
     {{ config('adminlte.classes_topnav', 'navbar-white navbar-light') }}">
 
     <div class="{{ config('adminlte.classes_topnav_container', 'container') }}">

--- a/resources/views/partials/navbar/navbar.blade.php
+++ b/resources/views/partials/navbar/navbar.blade.php
@@ -1,5 +1,5 @@
 <nav class="main-header navbar
-    {{ config('adminlte.classes_topnav_nav', 'navbar-expand-md') }}
+    {{ config('adminlte.classes_topnav_nav', 'navbar-expand') }}
     {{ config('adminlte.classes_topnav', 'navbar-white navbar-light') }}">
 
     {{-- Navbar left links --}}


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Changes the default value of the configuration option `classes_topnav_nav` from `navbar-expand-md` to `navbar-expand` to solve the issue #623

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
