### PR TITLE
Fix Signature of adminlte:status Artisan Command.

### DIFF
--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -7,7 +7,7 @@ use JeroenNoten\LaravelAdminLte\Http\Helpers\CommandHelper;
 
 class AdminLteStatusCommand extends Command
 {
-    protected $signature = 'adminlte:status'.
+    protected $signature = 'adminlte:status '.
         '{--include-images : Includes AdminLTE asset images to the checkup}';
 
     protected $description = 'Checks the install status for AdminLTE assets, routes & views.';


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Minor fix to the signature of the `adminlte:status` artisan command. With the current signature, executing the next code (inside a Laravel application context) will store `false` on the `$exists` variable, instead a `true` is expected. Note, this works as expected for the other commands (`install`, `plugins` and `update`):

```php
$commands = Artisan::all();
$exists = Arr::has($commands, 'adminlte:status');
```

#### Checklist

- [x] I tested these changes.