### PR TITLE
Fix Issue 612

### DIFF
--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -135,6 +135,7 @@ class ActiveChecker
         // absolute path to the given pattern.
 
         $pattern = preg_replace('@^https?://@', '*', $this->url->to($pattern));
+
         return Str::is($pattern, $this->request->url());
     }
 }

--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -32,12 +32,11 @@ class ActiveChecker
     /**
      * Constructor.
      *
-     * @param Request $request
      * @param UrlGenerator $url
      */
-    public function __construct(Request $request, UrlGenerator $url)
+    public function __construct(UrlGenerator $url)
     {
-        $this->request = $request;
+        $this->request = $url->getRequest();
         $this->url = $url;
 
         // Fill the map with tests. These tests will check if a menu item is
@@ -135,6 +134,7 @@ class ActiveChecker
         // If pattern is not a regex, check if the requested url matches the
         // absolute path to the given pattern.
 
-        return Str::is($this->url->to($pattern), $this->request->url());
+        $pattern = preg_replace('@^https?://@', '*', $this->url->to($pattern));
+        return Str::is($pattern, $this->request->url());
     }
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -176,4 +176,18 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($isActive);
     }
+
+    public function testWithForcedScheme()
+    {
+        $checker = $this->makeActiveChecker('http://example.com/about', 'https');
+
+        $isActive = $checker->isActive(['url' => 'about']);
+        $this->assertTrue($isActive);
+
+        $isActive = $checker->isActive(['url' => 'http://example.com/about']);
+        $this->assertTrue($isActive);
+
+        $isActive = $checker->isActive(['url' => 'https://example.com/about']);
+        $this->assertTrue($isActive);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,9 +49,9 @@ class TestCase extends BaseTestCase
         return $translator;
     }
 
-    protected function makeActiveChecker($uri = 'http://example.com')
+    protected function makeActiveChecker($uri = 'http://example.com', $scheme = null)
     {
-        return new ActiveChecker($this->makeRequest($uri), $this->makeUrlGenerator($uri));
+        return new ActiveChecker($this->makeUrlGenerator($uri, $scheme));
     }
 
     private function makeRequest($uri)
@@ -64,9 +64,18 @@ class TestCase extends BaseTestCase
         return new AdminLte($this->getFilters(), $this->getDispatcher(), $this->makeContainer());
     }
 
-    protected function makeUrlGenerator($uri = 'http://example.com')
+    protected function makeUrlGenerator($uri = 'http://example.com', $scheme = null)
     {
-        return new UrlGenerator($this->getRouteCollection(), $this->makeRequest($uri));
+        $UrlGenerator = new UrlGenerator(
+            $this->getRouteCollection(),
+            $this->makeRequest($uri)
+        );
+
+        if ($scheme) {
+            $UrlGenerator->forceScheme($scheme);
+        }
+
+        return $UrlGenerator;
     }
 
     protected function makeGate()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix the issue #612 

The **Active Checker** was not able to detect active menu items when `forceScheme('https')` is configured on the `UrlGenerator` instance. To give a solution to this problem, the `scheme` of the compared pattern is replaced by the wildcard `*` on the `checkPattern()` method.

Also, `Request` instance is not longer injected on the **Active Checker** constructor, instead it is obtained from the `UrlGenerator` instance.

Additional test is included to cover this issue.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
