### PR TITLE
Fix Issue 657

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -193,19 +193,15 @@ class Builder
      *
      * @param mixed $itemKey The key that represents the specific menu item
      * @param int $where Where to add the new items
-     * @param mixed $newItems Items to be added
+     * @param mixed $items Items to be added
      */
-    protected function addItem($itemKey, $where, ...$newItems)
+    protected function addItem($itemKey, $where, ...$items)
     {
         // Find the specific menu item. Return if not found.
 
         if (! ($itemPath = $this->findItem($itemKey, $this->menu))) {
             return;
         }
-
-        // Apply the filters to the new items.
-
-        $items = $this->transformItems($newItems);
 
         // Get the target array and add the new items there.
 
@@ -224,5 +220,9 @@ class Builder
         }
 
         Arr::set($this->menu, $targetPath, $targetArr);
+
+        // Apply the filters because the menu now have new items.
+
+        $this->menu = $this->transformItems($this->menu);
     }
 }

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -573,6 +573,24 @@ class BuilderTest extends TestCase
         $this->assertEquals('active', $builder->menu[0]['class']);
     }
 
+    public function testSubmenuClassWhenAddInMultipleItems()
+    {
+        $builder = $this->makeMenuBuilder();
+
+        // Add a new link item.
+
+        $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
+
+        // Add elements inside the previous one, now it will be a submenu item.
+
+        $builder->addIn('home', ['text' => 'Profile', 'url' => '/profile']);
+        $builder->addIn('home', ['text' => 'About', 'url' => '/about']);
+
+        // Check the "submenu_class" attribute is added.
+
+        $this->assertTrue(isset($builder->menu[0]['submenu_class']));
+    }
+
     public function testCan()
     {
         $gate = $this->makeGate();


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Changes to apply, correctly, the filters on the menu items when new items are added. In particular, the `submenu_class` (from the `ClassesFilter`) attribute is not added when new items are added inside a menu item that wasn't previously a **"submenu"** item.

Related issue: #657 

Also, a new test has been added to contemplate this particular case.

#### Checklist

- [X] I tested these changes.
- [X] I have linked the related issues.
