### PR TITLE
Fix Issue 665

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ class MyMenuFilter implements FilterInterface
     public function transform($item)
     {
         if (isset($item['permission']) && ! Laratrust::isAbleTo($item['permission'])) {
-            return false;
+            $item['restricted'] = true;
         }
 
         return $item;

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -43,7 +43,10 @@ class Builder
     public function add(...$newItems)
     {
         $items = $this->transformItems($newItems);
-        array_push($this->menu, ...$items);
+
+        if (! empty($items)) {
+            array_push($this->menu, ...$items);
+        }
     }
 
     /**

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -626,6 +626,29 @@ class BuilderTest extends TestCase
         $this->assertEquals('About', $builder->menu[0]['text']);
     }
 
+    public function testCanAddOneRestrictedItem()
+    {
+        $gate = $this->makeGate();
+        $gate->define(
+            'show-home',
+            function () {
+                return false;
+            }
+        );
+
+        $builder = $this->makeMenuBuilder('http://example.com', $gate);
+
+        $builder->add(
+            [
+                'text' => 'Home',
+                'url'  => '/',
+                'can'  => 'show-home',
+            ]
+        );
+
+        $this->assertCount(0, $builder->menu);
+    }
+
     public function testCanWithInvalidValues()
     {
         $gate = $this->makeGate();


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fixs the issue #665. There was a problem when we `add()` elements on the menu using the `Builder` instance and all the items added are restricted by permissions: This problem is only present with **PHP versions below 7.3.0**, since:

> On PHP 7.3.0 the `array_push()` function can now be called with only one parameter. Formerly, at least two parameters have been required.

Also, the `Laratrust` filter example is now fixed, and a test was added to verify the explained issue.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
