### PR TITLE
Add optional yields to content_header

### DIFF
--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -38,7 +38,18 @@
             {{-- Content Header --}}
             <div class="content-header">
                 <div class="{{ config('adminlte.classes_content_header') ?: $def_container_class }}">
-                    @yield('content_header')
+                    @section('content_header')
+                        <div class="row mb-2">
+                            <div class="col-sm-6">
+                                <h1>@yield('content_header_title')</h1>
+                            </div>
+                            <div class="col-sm-6">
+                                <ol class="breadcrumb float-sm-right">
+                                    @yield('content_header_breadcrumbs')
+                                </ol>
+                            </div>
+                        </div>
+                    @show
                 </div>
             </div>
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Allow Separation into Title and Breadcrumbs  
Keeps backwards compatibility and still allows to fully customize content_header  
Code for the header title and breadcrumbs was taken directly from the reference design and modified for use in the template.

#### Checklist

- [x] I tested these changes.
