### PR TITLE
Fix Issue 693

### DIFF
--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -132,10 +132,16 @@ class ActiveChecker
         }
 
         // If pattern is not a regex, check if the requested url matches the
-        // absolute path to the given pattern.
+        // absolute path to the given pattern. When the pattern uses query
+        // parameters, compare with the full url request.
 
         $pattern = preg_replace('@^https?://@', '*', $this->url->to($pattern));
+        $request = $this->request->url();
 
-        return Str::is($pattern, $this->request->url());
+        if (isset(parse_url($pattern)['query'])) {
+            $request = $this->request->fullUrl();
+        }
+
+        return Str::is($pattern, $request);
     }
 }

--- a/tests/Menu/ActiveCheckerTest.php
+++ b/tests/Menu/ActiveCheckerTest.php
@@ -144,6 +144,8 @@ class ActiveCheckerTest extends TestCase
 
         $this->assertTrue($checker->isActive(['url' => 'menu']));
         $this->assertTrue($checker->isActive(['active' => ['menu']]));
+        $this->assertTrue($checker->isActive(['active' => ['menu?param=option']]));
+        $this->assertFalse($checker->isActive(['active' => ['menu?param=foo']]));
     }
 
     public function testSubParams()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Improve the `ActiveChecker` module to support `active` field of menu items using urls with query parameters, example:

```php
[
    'text' => 'Categories',
    'url'  => 'url?type=category',
    'icon' => 'far fa-circle',
    'active' => ['url?type=category'],
],
[
    'text' => 'Tags',
    'url'  => 'url?type=tag',
    'icon' => 'far fa-circle',
    'active' => ['url?type=tag'],
],
```

Related issue: #693 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
