### PR TITLE
New classes attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ Attribute      | Description
 ---------------|------------
 `active`       | To define when the item should have the active style.
 `can`          | Permissions of the item for use with Laravel's Gate.
+`classes`      | To add custom classes to a menu item.
 `data`         | Array with `data-*` attributes for the item.
 `header`       | Text representing the name of a header (only for headers).
 `icon`         | A font awesome icon for the item.
@@ -885,6 +886,28 @@ You may use the `can` attribute if you want to conditionally show a menu item. T
 ```
 
 So, for the previous example the header will show only if the user has the `manage-blog` permission, and the link will show if the user has the `add-blog-post` or `other-right` permissions.
+
+#### The __`classes`__ Attribute:
+
+This attribute provides a way to add custom classes to a particular menu item. The value should be a string with one or multiple class names, similar to the HTML `class` attribute. For example, you can make a colorful `HEADER` item centered on the left sidebar with the next definition:
+
+```php
+[
+    'header'   => 'account_settings',
+    'classes'  => 'text-yellow text-bold text-center',
+]
+```
+
+Or you can highlight an important link item with something like this:
+
+```php
+[
+    'text'     => 'Important Link',
+    'url'      => 'important/link',
+    'icon'     => 'fas fa-fw fa-exclamation-triangle',
+    'classes'  => 'text-danger text-uppercase',
+]
+```
 
 #### The __`data`__ Attribute:
 

--- a/resources/views/partials/sidebar/menu-item-header.blade.php
+++ b/resources/views/partials/sidebar/menu-item-header.blade.php
@@ -1,0 +1,5 @@
+<li @if(isset($item['id'])) id="{{ $item['id'] }}" @endif class="nav-header {{ $item['class'] ?? '' }}">
+
+    {{ is_string($item) ? $item : $item['header'] }}
+
+</li>

--- a/resources/views/partials/sidebar/menu-item.blade.php
+++ b/resources/views/partials/sidebar/menu-item.blade.php
@@ -3,9 +3,7 @@
 @if ($menuItemHelper->isHeader($item))
 
     {{-- Header --}}
-    <li @if(isset($item['id'])) id="{{ $item['id'] }}" @endif class="nav-header">
-        {{ is_string($item) ? $item : $item['header'] }}
-    </li>
+    @include('adminlte::partials.sidebar.menu-item-header')
 
 @elseif ($menuItemHelper->isSearchBar($item))
 

--- a/src/Menu/Filters/ClassesFilter.php
+++ b/src/Menu/Filters/ClassesFilter.php
@@ -14,9 +14,7 @@ class ClassesFilter implements FilterInterface
      */
     public function transform($item)
     {
-        if (! MenuItemHelper::isHeader($item)) {
-            $item['class'] = implode(' ', $this->makeClasses($item));
-        }
+        $item['class'] = implode(' ', $this->makeClasses($item));
 
         if (MenuItemHelper::isSubmenu($item)) {
             $item['submenu_class'] = implode(' ', $this->makeSubmenuClasses($item));
@@ -35,9 +33,15 @@ class ClassesFilter implements FilterInterface
     {
         $classes = [];
 
+        // Add custom classes (from menu item configuration).
+
+        if (! empty($item['classes'])) {
+            $classes[] = $item['classes'];
+        }
+
         // Add the active class when the item is active.
 
-        if ($item['active']) {
+        if (! empty($item['active'])) {
             $classes[] = 'active';
         }
 

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -829,7 +829,7 @@ class BuilderTest extends TestCase
 
         $builder->add([
             'text' => 'About',
-            'classes' => 'foo-class'
+            'classes' => 'foo-class',
         ]);
 
         $this->assertStringContainsString('foo-class', $builder->menu[0]['class']);
@@ -842,7 +842,7 @@ class BuilderTest extends TestCase
         $builder->add([
             'text' => 'About',
             'url' => 'about',
-            'classes' => 'foo-class bar-class'
+            'classes' => 'foo-class bar-class',
         ]);
 
         $this->assertStringContainsString('active', $builder->menu[0]['class']);

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -822,4 +822,31 @@ class BuilderTest extends TestCase
         $this->assertEquals('q', $builder->menu[0]['input_name']);
         $this->assertEquals('foo', $builder->menu[1]['input_name']);
     }
+
+    public function testClassesAttribute()
+    {
+        $builder = $this->makeMenuBuilder();
+
+        $builder->add([
+            'text' => 'About',
+            'classes' => 'foo-class'
+        ]);
+
+        $this->assertStringContainsString('foo-class', $builder->menu[0]['class']);
+    }
+
+    public function testClassesAttributeWithActiveClass()
+    {
+        $builder = $this->makeMenuBuilder('http://example.com/about');
+
+        $builder->add([
+            'text' => 'About',
+            'url' => 'about',
+            'classes' => 'foo-class bar-class'
+        ]);
+
+        $this->assertStringContainsString('active', $builder->menu[0]['class']);
+        $this->assertStringContainsString('foo-class', $builder->menu[0]['class']);
+        $this->assertStringContainsString('bar-class', $builder->menu[0]['class']);
+    }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add support for a new `classes` attribute to be used on the menu items (for menu configuration). This is a generalization of the enhancement mentioned on issue #672 

New tests where added for this attribute and documentation was updated on the `README` file:

> This attribute provides a way to add custom classes to a particular menu item. The value should be a string with one or multiple class names, similar to the HTML `class` attribute. For example, you can make a colorful `HEADER` item centered on the left sidebar with the next definition:

> ```php
> [
>    'header'   => 'account_settings',
>    'classes'  => 'text-yellow text-bold text-center',
>]
> ```

> Or you can highlight an important link item with something like this:

> ```php
> [
>    'text'     => 'Important Link',
>    'url'      => 'important/link',
>    'icon'     => 'fas fa-fw fa-exclamation-triangle',
>    'classes'  => 'text-danger text-uppercase',
>]
> ```

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
