### PR TITLE
Avoid some tests that can't be run with some Laravel versions

### DIFF
--- a/tests/Console/InstallTest.php
+++ b/tests/Console/InstallTest.php
@@ -67,6 +67,12 @@ class InstallTest extends CommandTestCase
             return;
         }
 
+        if (! method_exists('Illuminate\Testing\PendingCommand', 'expectsConfirmation')) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
         // Test installation of the resources when using --interactive.
 
         foreach ($this->getResources() as $name => $res) {
@@ -108,6 +114,12 @@ class InstallTest extends CommandTestCase
         // We can't do these test on old laravel versions.
 
         if (! class_exists('Illuminate\Testing\PendingCommand')) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        if (! method_exists('Illuminate\Testing\PendingCommand', 'expectsConfirmation')) {
             $this->assertTrue(true);
 
             return;

--- a/tests/Console/PluginsTest.php
+++ b/tests/Console/PluginsTest.php
@@ -118,6 +118,12 @@ class PluginsTest extends CommandTestCase
             return;
         }
 
+        if (! method_exists('Illuminate\Testing\PendingCommand', 'expectsConfirmation')) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
         // Uninstall the plugin.
 
         $plugins->uninstall($pluginKey);
@@ -163,6 +169,12 @@ class PluginsTest extends CommandTestCase
         // We can't do these test on old laravel versions.
 
         if (! class_exists('Illuminate\Testing\PendingCommand')) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        if (! method_exists('Illuminate\Testing\PendingCommand', 'expectsConfirmation')) {
             $this->assertTrue(true);
 
             return;


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix to avoid some particular Artisan Console tests that can't be run with some versions of the Laravel framework.