### PR TITLE
Another fix for issue 693

### DIFF
--- a/src/Menu/ActiveChecker.php
+++ b/src/Menu/ActiveChecker.php
@@ -142,6 +142,6 @@ class ActiveChecker
             $request = $this->request->fullUrl();
         }
 
-        return Str::is($pattern, $request);
+        return Str::is(trim($pattern), trim($request));
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Improve the `ActiveChecker` class to remove whitespace (and other non-visible characters) before performing the comparison between the url pattern and the requested url. 
Related issue: #693 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
