### PR TITLE
Improve menu translations with parameters feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,28 +1371,32 @@ This will setup the `@livewireStyles` and the `@livewireScripts` directives corr
 
 ## 10. Translations
 
-At the moment, English, German, French, Dutch, Portuguese, Spanish and Turkish translations are available out of the box. Just specify the `locale` configuration option in `config/app.php` file of your Laravel project. If you need to modify the texts or add other languages, you can publish the language files:
+At the moment, English, German, French, Dutch, Portuguese, Spanish, Turkish among other translations are available out of the box. Just specify the `locale` configuration option in `config/app.php` file of your Laravel project. If you need to modify the texts or add support for other languages, you can publish the language files with the next command:
 
 ```sh
 php artisan adminlte:install --only=translations
 ```
 
-Now, you are able to edit translations or add languages in the `resources/lang/vendor/adminlte` folder.
+Now, you are able to edit translations or add new languages in the `resources/lang/vendor/adminlte` folder.
 
 ### 10.1 Menu Translations
 
 The menu translations are enabled by default and allows you to use `lang` files for menu items translation.
 
-#### Configure Menu Item for Translation:
+#### Configure Menu Item for Translation
 
-You need to configure the menu items to support translations. For this, you need to add translation `keys` to the `text` and/or `header` attributes. These are the currently supported menu attributes for translations. This is an example of the configuration you need:
+You need to configure the menu items to support translations. For this, you need to add translation `keys` to the `text`, `header` or `label` attributes. Currently, these are the only menu attributes supported for translations.
+
+Translation strings with parameters are supported using an array on the menu attribute, where the first value is the translation `key` and the second value is an array with the translation `parameters`. At next, we show an example of the menu configuration for both cases:
 
 ```php
 [
+    // Example using a translation key.
     'header' => 'account_settings_trans_key',
 ],
 [
-    'text' => 'profile_trans_key',
+    // Example using translation key with parameters.
+    'text' => ['profile_trans_key', ['name' => 'User']],
     'url'  => 'admin/settings',
     'icon' => 'user',
 ],
@@ -1400,35 +1404,15 @@ You need to configure the menu items to support translations. For this, you need
 
 #### Lang Files
 
-All the translation strings keys configured must be added in the `menu.php` file of each locale needed. You need to declare a `key` for each one of the menu items you want to translate. The translations files are located at the `resources/lang/vendor/adminlte/` folder. This is an example of the `resources/lang/vendor/adminlte/en/menu.php` lang file for the previous sample of configuration:
+All the translation strings keys configured on the menu items must be added in the `menu.php` file of each locale needed. You need to declare a `key` for each one of the menu items you want to translate. The translations files are located at the `resources/lang/vendor/adminlte/` folder. At next, we show an example of the `resources/lang/vendor/adminlte/en/menu.php` language file for the previous sample of configuration:
 
 ```php
 return [
     'account_settings_trans_key'  => 'ACCOUNT SETTINGS',
-    'profile_trans_key'           => 'Profile',
+    'profile_trans_key'           => ':name Profile',
 ];
 ```
 
-Even more, you can define a translation string with parameters using an array where the first value is the translation key and the second value is an array with the translation parameters, as shown next:
-
-```php
-[
-    'header' => ['account_settings_trans_key_with_params', ['social' => 'Google']],
-],
-[
-    'text' => ['profile_trans_key_with_params', ['name' => 'User']],
-    'url'  => 'admin/settings',
-    'icon' => 'user',
-],
-```
-where
-
-```php
-return [
-    'account_settings_trans_key_with_params'  => ':social ACCOUNT SETTINGS',
-    'profile_trans_key_with_params'           => 'Profile :name',
-];
-```
 
 ## 11. Customize Views
 

--- a/resources/lang/en/menu.php
+++ b/resources/lang/en/menu.php
@@ -16,8 +16,4 @@ return [
     'important'                     => 'Important',
     'warning'                       => 'Warning',
     'information'                   => 'Information',
-    //
-    'account_settings_with_params'  => ':social ACCOUNT SETTINGS',
-    'profile_with_params'           => 'Profile :name',
-    'labels_with_params'            => ':type LABELS',
 ];

--- a/src/Menu/Filters/LangFilter.php
+++ b/src/Menu/Filters/LangFilter.php
@@ -42,13 +42,21 @@ class LangFilter implements FilterInterface
         // Translate the menu item properties.
 
         foreach ($this->itemProperties as $prop) {
-            if (isset($item[$prop])) {
-                if (is_array($item[$prop])) {
-                    $params = (isset($item[$prop][1]) && is_array($item[$prop][1])) ? $item[$prop][1] : [];
-                    $item[$prop] = $this->getTranslation($item[$prop][0], $params);
-                } elseif (is_string($item[$prop])) {
-                    $item[$prop] = $this->getTranslation($item[$prop]);
-                }
+
+            // Check if the property exists for the item.
+
+            if (! isset($item[$prop])) {
+                continue;
+            }
+
+            // Check if the property value is valid for be translated.
+
+            if (is_array($item[$prop])) {
+                $params = $item[$prop][1] ?? [];
+                $params = is_array($params) ? $params : [];
+                $item[$prop] = $this->getTranslation($item[$prop][0], $params);
+            } elseif (is_string($item[$prop])) {
+                $item[$prop] = $this->getTranslation($item[$prop]);
             }
         }
 

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -789,8 +789,9 @@ class BuilderTest extends TestCase
         $builder = $this->makeMenuBuilder('http://example.com', null, 'es');
 
         $lines = [
-            'menu.header_with_params' => 'MENU :label',
+            'menu.header_with_params' => 'MENU :cat / :subcat',
             'menu.profile_with_params' => 'Perfil de :name',
+            'menu.label_with_params' => 'Etiqueta :type',
         ];
 
         $translator = $this->getTranslator();
@@ -798,11 +799,19 @@ class BuilderTest extends TestCase
 
         $builder->add(
             [
-                'header' => ['header_with_params', ['label' => 'SECUNDARIO']],
+                'header' => [
+                    'header_with_params',
+                    ['cat' => 'CAT', 'subcat' => "SUBCAT"],
+                ],
             ],
             [
                 'text' => ['profile_with_params', ['name' => 'Diego']],
                 'url' => '/profile',
+                'label' => ['label_with_params', ['type' => 'Tipo']],
+            ],
+            [
+                // Test case with partial parameters.
+                'header' => ['header_with_params', ['subcat' => 'SUBCAT']],
             ],
             [
                 // Test case with empty parameters.
@@ -810,15 +819,17 @@ class BuilderTest extends TestCase
             ],
             [
                 // Test case with non-array parameters.
-                'header' => ['header_with_params', 'param'],
+                'header' => ['header_with_params', 'non-array-value'],
             ],
         );
 
-        $this->assertCount(4, $builder->menu);
-        $this->assertEquals('MENU SECUNDARIO', $builder->menu[0]['header']);
+        $this->assertCount(5, $builder->menu);
+        $this->assertEquals('MENU CAT / SUBCAT', $builder->menu[0]['header']);
         $this->assertEquals('Perfil de Diego', $builder->menu[1]['text']);
-        $this->assertEquals('MENU :label', $builder->menu[2]['header']);
-        $this->assertEquals('MENU :label', $builder->menu[3]['header']);
+        $this->assertEquals('Etiqueta Tipo', $builder->menu[1]['label']);
+        $this->assertEquals('MENU :cat / SUBCAT', $builder->menu[2]['header']);
+        $this->assertEquals('MENU :cat / :subcat', $builder->menu[3]['header']);
+        $this->assertEquals('MENU :cat / :subcat', $builder->menu[4]['header']);
     }
 
     public function testDataAttributes()

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -801,7 +801,7 @@ class BuilderTest extends TestCase
             [
                 'header' => [
                     'header_with_params',
-                    ['cat' => 'CAT', 'subcat' => "SUBCAT"],
+                    ['cat' => 'CAT', 'subcat' => 'SUBCAT'],
                 ],
             ],
             [

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -786,13 +786,39 @@ class BuilderTest extends TestCase
 
     public function testLangTranslateWithExtraParams()
     {
-        $builder = $this->makeMenuBuilder('http://example.com');
-        $builder->add(['header' => ['account_settings_with_params', ['social' => 'Google']]]);
-        $builder->add(['text' => ['profile_with_params', ['name' => 'User']], 'url' => '/profile', 'label' => ['labels_with_params', ['type' => 'Blank']]]);
-        $this->assertCount(2, $builder->menu);
-        $this->assertEquals('Google ACCOUNT SETTINGS', $builder->menu[0]['header']);
-        $this->assertEquals('Profile User', $builder->menu[1]['text']);
-        $this->assertEquals('Blank LABELS', $builder->menu[1]['label']);
+        $builder = $this->makeMenuBuilder('http://example.com', null, 'es');
+
+        $lines = [
+            'menu.header_with_params' => 'MENU :label',
+            'menu.profile_with_params' => 'Perfil de :name',
+        ];
+
+        $translator = $this->getTranslator();
+        $translator->addLines($lines, 'es', 'adminlte');
+
+        $builder->add(
+            [
+                'header' => ['header_with_params', ['label' => 'SECUNDARIO']],
+            ],
+            [
+                'text' => ['profile_with_params', ['name' => 'Diego']],
+                'url' => '/profile',
+            ],
+            [
+                // Test case with empty parameters.
+                'header' => ['header_with_params'],
+            ],
+            [
+                // Test case with non-array parameters.
+                'header' => ['header_with_params', 'param'],
+            ],
+        );
+
+        $this->assertCount(4, $builder->menu);
+        $this->assertEquals('MENU SECUNDARIO', $builder->menu[0]['header']);
+        $this->assertEquals('Perfil de Diego', $builder->menu[1]['text']);
+        $this->assertEquals('MENU :label', $builder->menu[2]['header']);
+        $this->assertEquals('MENU :label', $builder->menu[3]['header']);
     }
 
     public function testDataAttributes()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,8 @@ class TestCase extends BaseTestCase
 
     private $routeCollection;
 
+    private $translator;
+
     protected function makeMenuBuilder($uri = 'http://example.com', GateContract $gate = null, $locale = 'en')
     {
         return new Builder([
@@ -43,10 +45,10 @@ class TestCase extends BaseTestCase
     {
         $translationLoader = new Illuminate\Translation\FileLoader(new Illuminate\Filesystem\Filesystem, 'resources/lang/');
 
-        $translator = new Illuminate\Translation\Translator($translationLoader, $locale);
-        $translator->addNamespace('adminlte', 'resources/lang/');
+        $this->translator = new Illuminate\Translation\Translator($translationLoader, $locale);
+        $this->translator->addNamespace('adminlte', 'resources/lang/');
 
-        return $translator;
+        return $this->translator;
     }
 
     protected function makeActiveChecker($uri = 'http://example.com', $scheme = null)
@@ -113,5 +115,10 @@ class TestCase extends BaseTestCase
         }
 
         return $this->routeCollection;
+    }
+
+    protected function getTranslator()
+    {
+        return $this->translator;
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improves the recent included feature that provides support for menu items translation with parameters. Summary:
- Documentation was updated.
- Remove translation lines from file `resources/lang/en/menu.php` that are used only for testing purposes. These lines should not be available on the published language files.
- Improve the new feature testing. Lines needed for test this feature are now added dynamically using `Translator` instance.
- Improve the logic on the `LangFilter` class.

#### Checklist

- [X] I tested these changes.
