### PR TITLE
Early stop applying filters on a restricted item

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -328,11 +328,11 @@ return [
     */
 
     'filters' => [
+        JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\SearchFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\ActiveFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\ClassesFilter::class,
-        JeroenNoten\LaravelAdminLte\Menu\Filters\GateFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter::class,
         JeroenNoten\LaravelAdminLte\Menu\Filters\DataFilter::class,
     ],

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -183,7 +183,6 @@ class Builder
             // continue applying the filters.
 
             if (! MenuItemHelper::isAllowed($item)) {
-
                 return $item;
             }
 

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -175,16 +175,25 @@ class Builder
             return $item;
         }
 
-        // If the item is a submenu, transform all submenu items first.
-
-        if (MenuItemHelper::isSubmenu($item)) {
-            $item['submenu'] = $this->transformItems($item['submenu']);
-        }
-
         // Now, apply all the filters on the item.
 
         foreach ($this->filters as $filter) {
+
+            // If the item is not allowed to be shown, there is no sense to
+            // continue applying the filters.
+
+            if (! MenuItemHelper::isAllowed($item)) {
+
+                return $item;
+            }
+
             $item = $filter->transform($item);
+        }
+
+        // If the item is a submenu, transform all submenu items too.
+
+        if (MenuItemHelper::isSubmenu($item)) {
+            $item['submenu'] = $this->transformItems($item['submenu']);
         }
 
         return $item;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,11 +31,11 @@ class TestCase extends BaseTestCase
     protected function makeMenuBuilder($uri = 'http://example.com', GateContract $gate = null, $locale = 'en')
     {
         return new Builder([
+            new GateFilter($gate ?: $this->makeGate()),
             new HrefFilter($this->makeUrlGenerator($uri)),
             new ActiveFilter($this->makeActiveChecker($uri)),
             new ClassesFilter(),
             new DataFilter(),
-            new GateFilter($gate ?: $this->makeGate()),
             new LangFilter($this->makeTranslator($locale)),
             new SearchFilter(),
         ]);


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Improves the menu builder to early stop applying filters on a restricted menu item.
- Sets `GateFilter` as the first one to be applied.

This may raise performance a little when the menu contains multiple items with different permissions.

#### Checklist

- [x] I tested these changes.