### PR TITLE
Improve Input-Color Component

### DIFF
--- a/resources/views/components/input-color.blade.php
+++ b/resources/views/components/input-color.blade.php
@@ -1,29 +1,40 @@
-<div class="form-group {{$topclass}}">
-    <label for="{{$id}}">{{$label}}</label>
-    <div class="input-group" id="{{$id}}-picker">
-        <input type="text" class="{{$inputclass}} form-control @error($name) is-invalid @enderror" 
-        name="{{$name}}" id="{{$id}}" value="{{$value}}" placeholder="{{$placeholder}}"
-        {{($required) ? 'required' : '' }}
-        {{($disabled) ? 'disabled' : '' }}>
+@extends('adminlte::components.input-group-component')
 
-        <div class="input-group-append">
-            <span class="input-group-text"><i class="fas fa-square"></i></span>
-        </div>
-    </div>
-    @error($name)
-        <span class="invalid-feedback" role="alert">
-            <strong>{{ $message }}</strong>
-        </span>
-    @enderror
-</div>
+@section('input_group_item')
 
-@section('js')
-    @parent
-    <script>
-        $('#{{$id}}-picker').colorpicker();
-        $('#{{$id}}-picker .fa-square').css('color', $('#{{$id}}').val());
-        $('#{{$id}}-picker').on('colorpickerChange', function(event) {
-            $('#{{$id}}-picker .fa-square').css('color', event.color.toString());
-        });
-    </script>
-@endsection
+    {{-- Input Color --}}
+    <input id="{{ $name }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+
+@overwrite
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+
+        // Create a method to set the addon color.
+
+        let setAddonColor = function()
+        {
+            let color = $('#{{ $name }}').data('colorpicker').getValue();
+
+            $('#{{ $name }}').closest('.input-group')
+                .find('.input-group-text > i')
+                .css('color', color);
+        }
+
+        // Init the plugin and register the change event listener.
+
+        $('#{{ $name }}').colorpicker( @json($config) )
+            .on('change', setAddonColor);
+
+        // Set the initial color for the addon.
+
+        setAddonColor();
+    })
+
+</script>
+@endpush

--- a/src/Components/InputColor.php
+++ b/src/Components/InputColor.php
@@ -2,37 +2,39 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components;
 
-use Illuminate\View\Component;
-
-class InputColor extends Component
+class InputColor extends InputGroupComponent
 {
-    public $id;
-    public $name;
-    public $label;
-    public $placeholder;
-    public $topclass;
-    public $inputclass;
-    public $value;
-    public $disabled;
-    public $required;
+    /**
+     * The Bootstrap Colorpicker plugin configuration parameters. Array with
+     * key => value pairs, where the key should be an existing configuration
+     * property of the plugin.
+     *
+     * @var array
+     */
+    public $config;
 
+    /**
+     * Create a new component instance.
+     * Note this component requires the 'Bootstrap Colorpicker' plugin.
+     *
+     * @return void
+     */
     public function __construct(
-            $id, $name = null,
-            $label = 'Input Label', $placeholder = null,
-            $topclass = null, $inputclass = null,
-            $value = null, $disabled = false, $required = false
-        ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->label = $label;
-        $this->placeholder = $placeholder;
-        $this->topclass = $topclass;
-        $this->inputclass = $inputclass;
-        $this->value = $value;
-        $this->required = $required;
-        $this->disabled = $disabled;
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $disableFeedback = null, $config = []
+    ) {
+        parent::__construct(
+            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+        );
+
+        $this->config = is_array($config) ? $config : [];
     }
 
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.input-color');


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the `input-color` component in relation to issue #732 :

- Now extends from the **input-group-component**.
- Provides a way to setup the plugin configuration from `php`.
- When an `addon` icon is used on the underlying `input-group`, the icon color will be automatically set.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
