### PR TITLE
Improve logic on the plugins blade file

### DIFF
--- a/resources/views/plugins.blade.php
+++ b/resources/views/plugins.blade.php
@@ -2,11 +2,18 @@
     @if($plugin['active'] || View::getSection('plugins.' . ($plugin['name'] ?? $pluginName)))
         @foreach($plugin['files'] as $file)
 
+            {{-- Setup the file location  --}}
+            @php
+                if (! empty($file['asset'])) {
+                    $file['location'] = asset($file['location']);
+                }
+            @endphp
+
             {{-- Check requested file type --}}
             @if($file['type'] == $type && $type == 'css')
-                <link rel="stylesheet" href="{{ $file['asset'] ? asset($file['location']) : $file['location'] }}">
+                <link rel="stylesheet" href="{{ $file['location'] }}">
             @elseif($file['type'] == $type && $type == 'js')
-                <script src="{{ $file['asset'] ? asset($file['location']) : $file['location'] }}" {{ ! empty($file['defer']) ? 'defer' : '' }} ></script>
+                <script src="{{ $file['location'] }}" @if(! empty($file['defer'])) defer @endif></script>
             @endif
 
         @endforeach


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Improve code logic on the `plugins.blade.php` file.
- The `asset` property of the plugin files is now optional. This may reduce the number of lines on the plugins configuration.

#### Checklist

- [x] I tested these changes.