### PR TITLE
Fix default value for classes_topnav_nav config

### DIFF
--- a/resources/views/partials/navbar/navbar-layout-topnav.blade.php
+++ b/resources/views/partials/navbar/navbar-layout-topnav.blade.php
@@ -1,5 +1,5 @@
 <nav class="main-header navbar
-    {{ config('adminlte.classes_topnav_nav', 'navbar-expand') }}
+    {{ config('adminlte.classes_topnav_nav', 'navbar-expand-md') }}
     {{ config('adminlte.classes_topnav', 'navbar-white navbar-light') }}">
 
     <div class="{{ config('adminlte.classes_topnav_container', 'container') }}">


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Changes the default value that will be used when configuration option `classes_topnav_nav` do not exists on the layout topnav mode. The default value should be `navbar-expand-md` as dictated on the [documentation](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/7.-Layout-and-Styling-Configuration#722-admin-panel-classes):

> **classes_topnav_nav**: Extra classes for the top navigation. Classes will be added to element `nav.main-header.navbar`. When enabling `layout_topnav` the recommendation is to use `navbar-expand-md` to get items auto collapsed into a menu button on low screen sizes. Otherwise, stay with `navbar-expand` class.

#### Checklist

- [x] I tested these changes.