### PR TITLE
Improve the text-editor component

### DIFF
--- a/resources/views/components/text-editor.blade.php
+++ b/resources/views/components/text-editor.blade.php
@@ -1,25 +1,61 @@
-<div class="form-group {{$topclass}}">
-    <label for="{{$id}}">{{$label}}</label>
-    <textarea class="{{$inputclass}}" name="{{$name}}" id="{{$id}}"
-    {{($required) ? 'required' : '' }}
-    {{($disabled) ? 'disabled' : '' }}
-    ></textarea>
-</div>
+@extends('adminlte::components.input-group-component')
 
-@section('js')
-@parent
+@section('input_group_item')
+
+    {{-- Summernote Textarea --}}
+    <textarea id="{{ $name }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}
+    >{{ $slot }}</textarea>
+
+@overwrite
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
 <script>
-    $(function(){
-        $('#{{$id}}').summernote({
-            placeholder: '{{$placeholder}}',
-            height: {{$height}},
-			dialogsInBody: true,
-			dialogsFade: false,
-            fontNames: {!!$fontarray!!}
-        });
-        @if(!is_null($body))
-        $('#{{$id}}').summernote('code',`{!!$body!!}`);
-        @endif
+
+    $(() => {
+        let usrCfg = @json($config);
+
+        // Check for placeholder attribute.
+
+        @isset($attributes['placeholder'])
+            usrCfg['placeholder'] = "{{ $attributes['placeholder'] }}";
+        @endisset
+
+        // Initialize the plugin.
+
+        $('#{{ $name }}').summernote(usrCfg);
+
+        // Check for disabled attribute.
+
+        @isset($attributes['disabled'])
+            $('#{{ $name }}').summernote('disable');
+        @endisset
     })
+
 </script>
-@endsection
+@endpush
+
+{{-- Setup the font size of the plugin when using sm/lg sizes --}}
+{{-- NOTE: this may change with newer plugin versions --}}
+
+@once
+@push('css')
+<style type="text/css">
+
+    {{-- SM size setup --}}
+    .input-group-sm .note-editor {
+        font-size: .875rem;
+        line-height: 1;
+    }
+
+    {{-- LG size setup --}}
+    .input-group-lg .note-editor {
+        font-size: 1.25rem;
+        line-height: 1.5;
+    }
+
+</style>
+@endpush
+@endonce

--- a/src/Components/TextEditor.php
+++ b/src/Components/TextEditor.php
@@ -2,48 +2,44 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components;
 
-use Illuminate\View\Component;
-
-class TextEditor extends Component
+class TextEditor extends InputGroupComponent
 {
-    public $id;
-    public $name;
-    public $label;
-    public $placeholder;
-    public $topclass;
-    public $inputclass;
-    public $body;
-    public $disabled;
-    public $required;
-    public $height;
-    public $fonts;
-    public $def_fonts = ['Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Impact', 'Montserrat',  'Open Sans', 'Ubuntu', 'Rajdhani'];
+    /**
+     * The Summernote plugin configuration parameters. Array with key => value
+     * pairs, where the key should be an existing configuration property of
+     * the plugin.
+     *
+     * @var array
+     */
+    public $config;
 
+    /**
+     * Create a new component instance.
+     * Note this component requires the 'Summernote' plugin.
+     * TODO: the append/prepend addon slots are not supported.
+     *
+     * @return void
+     */
     public function __construct(
-            $id, $name = null,
-            $label = 'Input Label', $placeholder = null,
-            $topclass = null, $inputclass = null,
-            $body = null, $disabled = false, $required = false,
-            $height = 500, $fonts = null
-        ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->label = $label;
-        $this->placeholder = $placeholder;
-        $this->topclass = $topclass;
-        $this->inputclass = $inputclass;
-        $this->body = $body;
-        $this->required = $required;
-        $this->disabled = $disabled;
-        $this->height = $height;
-        $this->fonts = $fonts;
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $disableFeedback = null, $config = []
+    ) {
+        parent::__construct(
+            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+        );
+
+        $this->config = is_array($config) ? $config : [];
+
+        // Setup the default plugin width option.
+
+        $this->config['width'] = $this->config['width'] ?? 'inherit';
     }
 
-    public function fontarray()
-    {
-        return $this->fonts == null ? json_encode($this->def_fonts) : $this->fonts;
-    }
-
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.text-editor');

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -30,19 +30,19 @@ class ComponentsTest extends TestCase
             // Form components.
 
             "{$base}.button"       => new Components\Button(),
-            "{$base}.date-range"   => new Components\DateRange('id'),
+            "{$base}.date-range"   => new Components\DateRange('name'),
             "{$base}.input"        => new Components\Input('name'),
-            "{$base}.input-color"  => new Components\InputColor('id'),
+            "{$base}.input-color"  => new Components\InputColor('name'),
             "{$base}.input-date"   => new Components\InputDate('id'),
             "{$base}.input-file"   => new Components\InputFile('name'),
             "{$base}.input-slider" => new Components\InputSlider('id'),
             "{$base}.input-switch" => new Components\InputSwitch(),
             "{$base}.input-tag"    => new Components\InputTag(),
             "{$base}.select"       => new Components\Select('name'),
-            "{$base}.select2"      => new Components\Select2('id'),
+            "{$base}.select2"      => new Components\Select2('name'),
             "{$base}.select-bs"  => new Components\SelectBs('name'),
             "{$base}.textarea"     => new Components\Textarea('name'),
-            "{$base}.text-editor"  => new Components\TextEditor('id'),
+            "{$base}.text-editor"  => new Components\TextEditor('name'),
 
             // Widget components.
 
@@ -136,19 +136,6 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('form-control-lg', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
-    }
-
-    public function testTextEditorComponent()
-    {
-        $component = new Components\TextEditor(
-            'id', null, null, null, null, null, null, null,
-            null, null, ['Foo Font', 'Bar Font']
-        );
-
-        $fonts = $component->fontarray();
-        $this->assertIsArray($fonts);
-        $this->assertContains('Foo Font', $fonts);
-        $this->assertContains('Bar Font', $fonts);
     }
 
     /*


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement  | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the **text-editor** component in relation to issue #732 

- The **text-editor** component now extends from the **input-group-component**, however the append/prepend `addon` slots are not supported.
- The `disabled` attribute now works over the plugin.
- A new `config` attribute was added to provide a way to configure the plugin from `php`.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
