### PR TITLE
Improve the input-slider component

### DIFF
--- a/resources/views/components/input-slider.blade.php
+++ b/resources/views/components/input-slider.blade.php
@@ -1,28 +1,101 @@
-<div class="form-group {{$topclass}}">
-    <label for="{{$id}}">{{$label}}</label>
-    <div class="slider-{{$color}}">
-    <input type="text" id="{{$id}}" name="{{$name}}"
-    class="slider form-control {{$inputclass}}" 
-    data-slider-min="{{$min}}" data-slider-max="{{$max}}"
-    data-slider-step="{{$step}}" data-slider-value="{{$value}}" data-slider-orientation="{{$vertical ? 'vertical' : 'horizontal'}}"
-    data-slider-selection="before" data-slider-tooltip="show"
-    @if($tick)
-    data-slider-ticks="{!!$ticks!!}"
-    data-slider-ticks-labels='{!!$tickLabels!!}'
-    @endif
-    {{($required) ? 'required' : '' }} 
-    {{($disabled) ? 'disabled' : '' }}>
-    </div>
-    @error($name)
-        <span class="invalid-feedback d-block" role="alert">
-            <strong>{{ $message }}</strong>
-        </span>
-    @enderror
-</div>
+@extends('adminlte::components.input-group-component')
 
-@section('js')
-    @parent
-    <script>$(()=>{
-        $('#{{$id}}').bootstrapSlider();
-    })</script>
-@endsection
+@section('input_group_item')
+
+    {{-- Input Slider --}}
+    <input id="{{ $name }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+
+@overwrite
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+        let usrCfg = @json($config);
+
+        // Check for disabled attribute (alternative to data-slider-enable).
+
+        @isset($attributes['disabled'])
+            usrCfg.enabled = false;
+        @endisset
+
+        // Check for min, max and step attributes (alternatives to
+        // data-slider-min, data-slider-max and data-slider-step).
+
+        @isset($attributes['min'])
+            usrCfg.min = {{ $attributes['min'] }};
+        @endisset
+
+        @isset($attributes['max'])
+            usrCfg.max = {{ $attributes['max'] }};
+        @endisset
+
+        @isset($attributes['step'])
+            usrCfg.step = {{ $attributes['step'] }};
+        @endisset
+
+        // Check for value attribute (alternative to data-slider-value).
+
+        @isset($attributes['value'])
+            usrCfg.value = {{ $attributes['value'] }};
+        @endisset
+
+        // Initialize the plugin.
+
+        let slider = $('#{{ $name }}').bootstrapSlider(usrCfg);
+
+        // Fix height conflict when orientation is vertical.
+
+        let or = slider.bootstrapSlider('getAttribute', 'orientation');
+
+        if (or == 'vertical') {
+            $('#' + usrCfg.id).css('height', '210px');
+            slider.bootstrapSlider('relayout');
+        }
+    })
+
+</script>
+@endpush
+
+{{-- Add CSS workarounds for the plugin --}}
+{{-- NOTE: this may change with newer plugin versions --}}
+
+@push('css')
+<style type="text/css">
+
+    {{-- Setup plugin color --}}
+
+    @isset($color)
+
+        #{{ $config['id'] }} .slider-handle {
+            background: {{ $color }};
+        }
+        #{{ $config['id'] }} .slider-selection {
+            background: {{ $color }};
+            opacity: 0.5;
+        }
+        #{{ $config['id'] }} .slider-tick.in-selection {
+            background: {{ $color }};
+            opacity: 0.9;
+        }
+
+    @endisset
+
+    {{-- Set flex property when using addons slots --}}
+
+    @if(isset($appendSlot) || isset($prependSlot))
+
+        #{{ $config['id'] }} {
+            flex: 1 1 0;
+            align-self: center;
+            @isset($appendSlot) margin-right: 5px; @endisset
+            @isset($prependSlot) margin-left: 5px; @endisset
+        }
+
+    @endif
+
+</style>
+@endpush

--- a/src/Components/InputSlider.php
+++ b/src/Components/InputSlider.php
@@ -2,54 +2,51 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components;
 
-use Illuminate\View\Component;
-
-class InputSlider extends Component
+class InputSlider extends InputGroupComponent
 {
-    public $id;
-    public $name;
-    public $label;
-    public $topclass;
-    public $inputclass;
-    public $value;
-    public $disabled;
-    public $required;
-    public $min;
-    public $max;
-    public $step;
-    public $vertical;
-    public $tick;
-    public $ticks;
-    public $tickLabels;
+    /**
+     * The bootstrap-slider plugin configuration parameters. Array with
+     * key => value pairs, where the key should be an existing configuration
+     * property of the plugin.
+     *
+     * @var array
+     */
+    public $config;
+
+    /**
+     * The slider color. One of the available html colors.
+     *
+     * @var string
+     */
     public $color;
 
+    /**
+     * Create a new component instance.
+     * Note this component requires the 'bootstrap-slider' plugin.
+     *
+     * @return void
+     */
     public function __construct(
-            $id, $name = null,
-            $label = 'Input Label',
-            $topclass = null, $inputclass = null,
-            $value = null, $disabled = false, $required = false,
-            $min = 0, $max = 100, $step = 1, $vertical = false,
-            $tick = false, $ticks = null, $tickLabels = null,
-            $color = 'blue'
-        ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->label = $label;
-        $this->topclass = $topclass;
-        $this->inputclass = $inputclass;
-        $this->required = $required;
-        $this->disabled = $disabled;
-        $this->value = $value;
-        $this->min = $min;
-        $this->max = $max;
-        $this->step = $step;
-        $this->vertical = $vertical;
-        $this->tick = $tick;
-        $this->ticks = $ticks;
-        $this->tickLabels = $tickLabels;
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $disableFeedback = null, $config = [], $color = null
+    ) {
+        parent::__construct(
+            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+        );
+
+        $this->config = is_array($config) ? $config : [];
         $this->color = $color;
+
+        // Set a default plugin 'id' option.
+
+        $this->config['id'] = $this->config['id'] ?? "{$name}-slider";
     }
 
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.input-slider');

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -35,7 +35,7 @@ class ComponentsTest extends TestCase
             "{$base}.input-color"  => new Components\InputColor('name'),
             "{$base}.input-date"   => new Components\InputDate('id'),
             "{$base}.input-file"   => new Components\InputFile('name'),
-            "{$base}.input-slider" => new Components\InputSlider('id'),
+            "{$base}.input-slider" => new Components\InputSlider('name'),
             "{$base}.input-switch" => new Components\InputSwitch(),
             "{$base}.input-tag"    => new Components\InputTag(),
             "{$base}.select"       => new Components\Select('name'),


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the **input-slider** component in relation to issue #732
- The component now extends from the **input-group-component**.
- A new `config` attribute is available to pass plugin configuration.
- The `disabled` attribute is now mapped correctly as a shortcut for `data-slider-enabled`.
- The slider `color` attribute is improved to change multiple elements of the plugin.
- The `value`, `step`, `max` and `min` attributes are now mapped as shortcuts for `data-slider-value`, `data-slider-step`, `data-slider-min` and `data-slider-max`.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
