### PR TITLE
Improve the input-switch component

### DIFF
--- a/resources/views/components/input-switch.blade.php
+++ b/resources/views/components/input-switch.blade.php
@@ -1,10 +1,52 @@
-<div class="form-group {{$topclass}}">
-    <div class="custom-control custom-switch">
-        <input type="checkbox" class="custom-control-input {{$inputclass}}" 
-        id="{{$id}}" name="{{$name}}" 
-        {{$checked ? 'checked' : ''}}
-        {{$disabled ? 'disabled' : ''}}
-        {{$required ? 'required' : ''}}>
-        <label class="custom-control-label" for="{{$id}}">{{$label}}</label>
-    </div>
-</div>
+@extends('adminlte::components.input-group-component')
+
+@section('input_group_item')
+
+    {{-- Input Switch --}}
+    <input type="checkbox" id="{{ $name }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+
+@overwrite
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+        $('#{{ $name }}').bootstrapSwitch( @json($config) );
+    })
+
+</script>
+@endpush
+
+{{-- Setup the height/font of the plugin when using sm/lg sizes --}}
+{{-- NOTE: this may change with newer plugin versions --}}
+
+@once
+@push('css')
+<style type="text/css">
+
+    {{-- MD (default) size setup --}}
+    .input-group .bootstrap-switch-handle-on,
+    .input-group .bootstrap-switch-handle-off {
+        height: 2.25rem !important;
+    }
+
+    {{-- LG size setup --}}
+    .input-group-lg .bootstrap-switch-handle-on,
+    .input-group-lg .bootstrap-switch-handle-off {
+        height: 2.875rem !important;
+        font-size: 1.25rem !important;
+    }
+
+    {{-- SM size setup --}}
+    .input-group-sm .bootstrap-switch-handle-on,
+    .input-group-sm .bootstrap-switch-handle-off {
+        height: 1.8125rem !important;
+        font-size: .875rem !important;
+    }
+
+</style>
+@endpush
+@endonce

--- a/src/Components/InputSwitch.php
+++ b/src/Components/InputSwitch.php
@@ -2,35 +2,56 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components;
 
-use Illuminate\View\Component;
-
-class InputSwitch extends Component
+class InputSwitch extends InputGroupComponent
 {
-    public $id;
-    public $name;
-    public $label;
-    public $topclass;
-    public $inputclass;
-    public $checked;
-    public $disabled;
-    public $required;
+    /**
+     * The Bootstrap Switch plugin configuration parameters. Array with
+     * key => value pairs, where the key should be an existing configuration
+     * property of the plugin.
+     *
+     * @var array
+     */
+    public $config;
 
+    /**
+     * Create a new component instance.
+     * Note this component requires the 'Bootstrap Switch' plugin.
+     *
+     * @return void
+     */
     public function __construct(
-            $id = 'checkbox', $name = null,
-            $label = 'Input Label',
-            $topclass = null, $inputclass = null,
-            $checked = false, $disabled = false, $required = false
-        ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->label = $label;
-        $this->topclass = $topclass;
-        $this->inputclass = $inputclass;
-        $this->checked = $checked;
-        $this->required = $required;
-        $this->disabled = $disabled;
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $disableFeedback = null, $config = []
+    ) {
+        parent::__construct(
+            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+        );
+
+        $this->config = is_array($config) ? $config : [];
     }
 
+    /**
+     * Make the class attribute for the input group item.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeItemClass($invalid)
+    {
+        $classes = [];
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'is-invalid';
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.input-switch');

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -36,7 +36,7 @@ class ComponentsTest extends TestCase
             "{$base}.input-date"   => new Components\InputDate('id'),
             "{$base}.input-file"   => new Components\InputFile('name'),
             "{$base}.input-slider" => new Components\InputSlider('name'),
-            "{$base}.input-switch" => new Components\InputSwitch(),
+            "{$base}.input-switch" => new Components\InputSwitch('name'),
             "{$base}.input-tag"    => new Components\InputTag(),
             "{$base}.select"       => new Components\Select('name'),
             "{$base}.select2"      => new Components\Select2('name'),
@@ -105,6 +105,14 @@ class ComponentsTest extends TestCase
         $iClass = $component->makeItemClass(true);
 
         $this->assertStringContainsString('custom-file-input', $iClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testInputSwitchComponent()
+    {
+        $component = new Components\InputSwitch('name');
+        $iClass = $component->makeItemClass(true);
+
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the **input-switch** component in relation to issue #732 
- The component now extends from the **input-group-component**.
- The component now uses the **Bootstrap Switch** plugin.
- Add support to `LG` and `SM` sizes.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
