### PR TITLE
Improve the input-date component

### DIFF
--- a/resources/views/components/input-date.blade.php
+++ b/resources/views/components/input-date.blade.php
@@ -1,25 +1,57 @@
-<div class="form-group {{$topclass}}">
-    <label for="{{$id}}">{{$label}}</label>
-    <input type="text" class="{{$inputclass}} form-control datetimepicker-input @error($name) is-invalid @enderror" 
-    name="{{$name}}" id="{{$id}}" 
-    data-toggle="datetimepicker" data-target="#{{$id}}" 
-    placeholder="{{$placeholder}}" value="{{$value}}" 
-    {{($required) ? 'required' : '' }}
-    {{($disabled) ? 'disabled' : '' }}/>
-    
-    @error($name)
-        <span class="invalid-feedback" role="alert">
-            <strong>{{ $message }}</strong>
-        </span>
-    @enderror
-</div>
+@extends('adminlte::components.input-group-component')
 
-@section('js')
-    @parent
-    <script>
-    $(()=>{
-        $.fn.datetimepicker.Constructor.Default = $.extend({}, $.fn.datetimepicker.Constructor.Default, { icons: { time: 'fas fa-clock', date: 'fas fa-calendar', up: 'fas fa-arrow-up', down: 'fas fa-arrow-down', previous: 'fas fa-caret-left', next: 'fas fa-caret-right', today: 'far fa-calendar-check-o', clear: 'far fa-trash', close: 'far fa-times' } });
-        $('#{{$id}}').datetimepicker({format: '{{$format}}'});
+@section('input_group_item')
+
+    {{-- Input Date --}}
+    <input id="{{ $name }}" name="{{ $name }}" data-target="#{{ $name }}" data-toggle="datetimepicker"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+
+@overwrite
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+        let usrCfg = _adminlte_idUtils.parseCfg( @json($config) );
+        $('#{{ $name }}').datetimepicker(usrCfg);
     })
-    </script>
-@endsection
+
+</script>
+@endpush
+
+{{-- Add utility methods for the plugin --}}
+
+@once
+@push('js')
+<script>
+
+    function ID_Utils() {
+
+        /**
+         * Parse the php plugin configuration to eval javascript code.
+         */
+        this.parseCfg = function(cfg)
+        {
+            for (const prop in cfg) {
+                let v = cfg[prop];
+
+                if (typeof v === 'string' && v.startsWith('js:')) {
+                    cfg[prop] = eval(v.slice(3));
+                } else if (typeof v === 'object') {
+                    cfg[prop] = this.parseCfg(v);
+                }
+            }
+
+            return cfg;
+        }
+    }
+
+    // Create the plugin utililities object.
+
+    var _adminlte_idUtils = new ID_Utils();
+
+</script>
+@endpush
+@endonce

--- a/src/Components/InputDate.php
+++ b/src/Components/InputDate.php
@@ -2,40 +2,86 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components;
 
-use Illuminate\View\Component;
-
-class InputDate extends Component
+class InputDate extends InputGroupComponent
 {
-    public $id;
-    public $name;
-    public $label;
-    public $placeholder;
-    public $topclass;
-    public $inputclass;
-    public $value;
-    public $disabled;
-    public $required;
-    public $format;
+    /**
+     * The default set of icons for the Tempus Dominus plugin configuration.
+     */
+    protected $icons = [
+        'time'     => 'fas fa-clock',
+        'date'     => 'fas fa-calendar-alt',
+        'up'       => 'fas fa-arrow-up',
+        'down'     => 'fas fa-arrow-down',
+        'previous' => 'fas fa-chevron-left',
+        'next'     => 'fas fa-chevron-right',
+        'today'    => 'fas fa-calendar-check-o',
+        'clear'    => 'fas fa-trash',
+        'close'    => 'fas fa-times',
+    ];
 
+    /**
+     * The default set of buttons for the Tempus Dominus plugin configuration.
+     */
+    protected $buttons = [
+        'showClose' => true,
+    ];
+
+    /**
+     * The Tempus Dominus plugin configuration parameters. Array with
+     * key => value pairs, where the key should be an existing configuration
+     * property of the plugin.
+     *
+     * @var array
+     */
+    public $config;
+
+    /**
+     * Create a new component instance.
+     * Note this component requires the 'Tempus Dominus' plugin.
+     *
+     * @return void
+     */
     public function __construct(
-            $id, $name = null,
-            $label = 'Input Label', $placeholder = null,
-            $topclass = null, $inputclass = null,
-            $value = null, $disabled = false, $required = false,
-            $format = 'YYYY-MM-DD'
-        ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->label = $label;
-        $this->placeholder = $placeholder;
-        $this->topclass = $topclass;
-        $this->inputclass = $inputclass;
-        $this->value = $value;
-        $this->required = $required;
-        $this->disabled = $disabled;
-        $this->format = $format;
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $disableFeedback = null, $config = []
+    ) {
+        parent::__construct(
+            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+        );
+
+        $this->config = is_array($config) ? $config : [];
+
+        // Setup the default plugin icons option.
+
+        $this->config['icons'] = $this->config['icons'] ?? $this->icons;
+
+        // Setup the default plugin buttons option.
+
+        $this->config['buttons'] = $this->config['buttons'] ?? $this->buttons;
     }
 
+    /**
+     * Make the class attribute for the input group item.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeItemClass($invalid)
+    {
+        $classes = ['form-control', 'datetimepicker'];
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'is-invalid';
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.input-date');

--- a/src/Console/PackageResources/PluginsResource.php
+++ b/src/Console/PackageResources/PluginsResource.php
@@ -195,7 +195,10 @@ class PluginsResource extends PackageResource
         ],
         'tempusdominusBootstrap4' => [
             'name' => 'Tempus Dominus for Bootstrap 4',
-            'source' => 'tempusdominus-bootstrap-4',
+            'resources' => [
+                ['source' => 'tempusdominus-bootstrap-4'],
+                ['source' => 'moment'],
+            ],
         ],
         'toastr' => [
             'name' => 'Toastr',

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -33,7 +33,7 @@ class ComponentsTest extends TestCase
             "{$base}.date-range"   => new Components\DateRange('name'),
             "{$base}.input"        => new Components\Input('name'),
             "{$base}.input-color"  => new Components\InputColor('name'),
-            "{$base}.input-date"   => new Components\InputDate('id'),
+            "{$base}.input-date"   => new Components\InputDate('name'),
             "{$base}.input-file"   => new Components\InputFile('name'),
             "{$base}.input-slider" => new Components\InputSlider('name'),
             "{$base}.input-switch" => new Components\InputSwitch('name'),
@@ -98,6 +98,15 @@ class ComponentsTest extends TestCase
     | Individual form components tests.
     |--------------------------------------------------------------------------
     */
+
+    public function testInputDateComponent()
+    {
+        $component = new Components\InputDate('name');
+        $iClass = $component->makeItemClass(true);
+
+        $this->assertStringContainsString('datetimepicker', $iClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
 
     public function testInputFileComponent()
     {

--- a/tests/Console/PluginsTest.php
+++ b/tests/Console/PluginsTest.php
@@ -44,7 +44,7 @@ class PluginsTest extends CommandTestCase
 
         // Test install all the plugins.
 
-        $this->artisan('adminlte:plugins install');
+        $this->artisan('adminlte:plugins install --force');
 
         // Check that all the plugins are installed.
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the **input-date** component in relation to issue #732 

- The component now extends from **input-group-component**.
- A new `config` attribute is added to support plugin configuration.
- `Moment` plugin is now included when installing `Tempus Dominus` with artisan command.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
