### PR TITLE
Improve the Alert component

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,8 +1,16 @@
-<div class="alert alert-{{$type}} {{($dismissable) ? 'alert-dismissible' : ''}}">
-    @if($dismissable)
-    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-    @endif
+<div {{ $attributes->merge(['class' => $makeAlertClass()]) }}>
 
-    <h5><i class="icon fas fa-{{$icon}}"></i> {{$title}}</h5>
-    {{$slot}}
+    {{-- Dismiss button --}}
+    @isset($dismissable)
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
+            &times;
+        </button>
+    @endisset
+
+    {{-- Alert title --}}
+    <h5><i class="icon {{ $icon }}"></i> {{ $title }}</h5>
+
+    {{-- Alert content --}}
+    {{ $slot }}
+
 </div>

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -6,28 +6,86 @@ use Illuminate\View\Component;
 
 class Alert extends Component
 {
-    public $type;
+    /**
+     * The default icon for each alert theme.
+     *
+     * @var array
+     */
+    protected $icons = [
+        'dark'      => 'fas fa-bolt',
+        'light'     => 'far fa-lightbulb',
+        'primary'   => 'fas fa-bell',
+        'secondary' => 'fas fa-tag',
+        'info'      => 'fas fa-info-circle',
+        'success'   => 'fas fa-check-circle',
+        'warning'   => 'fas fa-exclamation-triangle',
+        'danger'    => 'fas fa-ban',
+    ];
+
+    /**
+     * The alert icon (a Font Awesome icon).
+     *
+     * @var string
+     */
+    public $icon;
+
+    /**
+     * The alert theme (dark, light, primary, secondary, info, success, warning
+     * or danger).
+     *
+     * @var string
+     */
+    public $theme;
+
+    /**
+     * The alert title.
+     *
+     * @var string
+     */
     public $title;
+
+    /**
+     * Indicates if the alert is dismissable.
+     *
+     * @var bool|mixed
+     */
     public $dismissable;
 
-    public function __construct($type = 'info', $dismissable = false, $title = 'Alert')
-    {
-        $this->type = $type;
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        $theme = 'info', $icon = null, $title = null, $dismissable = null
+    ) {
+        $this->theme = $theme;
+        $this->icon = $icon ?? $this->icons[$theme];
         $this->title = $title;
         $this->dismissable = $dismissable;
     }
 
-    public function icon()
+    /**
+     * Make the class attribute for the alert item.
+     *
+     * @return string
+     */
+    public function makeAlertClass()
     {
-        switch ($this->type) {
-            case 'info': return 'info'; break;
-            case 'warning': return 'exclamation-triangle'; break;
-            case 'success': return 'check'; break;
-            case 'danger': return 'ban'; break;
-            default: return 'exclamation'; break;
+        $classes = ['alert', "alert-{$this->theme}"];
+
+        if (! empty($this->dismissable)) {
+            $classes[] = 'alert-dismissable';
         }
+
+        return implode(' ', $classes);
     }
 
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.alert');

--- a/src/Components/InputDate.php
+++ b/src/Components/InputDate.php
@@ -6,6 +6,8 @@ class InputDate extends InputGroupComponent
 {
     /**
      * The default set of icons for the Tempus Dominus plugin configuration.
+     *
+     * @var array
      */
     protected $icons = [
         'time'     => 'fas fa-clock',
@@ -21,6 +23,8 @@ class InputDate extends InputGroupComponent
 
     /**
      * The default set of buttons for the Tempus Dominus plugin configuration.
+     *
+     * @var array
      */
     protected $buttons = [
         'showClose' => true,

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -163,12 +163,13 @@ class ComponentsTest extends TestCase
 
     public function testAlertComponent()
     {
-        $types = ['info', 'warning', 'success', 'danger', 'unknown'];
+        $component = new Components\Alert('danger', null, null, true);
 
-        foreach ($types as $type) {
-            $component = new Components\Alert($type);
-            $this->assertIsString($component->icon());
-        }
+        $aClass = $component->makeAlertClass();
+
+        $this->assertStringContainsString('alert', $aClass);
+        $this->assertStringContainsString('alert-danger', $aClass);
+        $this->assertStringContainsString('alert-dismissable', $aClass);
     }
 
     public function testDatatableComponent()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the **alert** component in relation to issue #732 
- Add new `icon` attribute.
- Every alert theme now have a default icon associated with it.
- Now, you can add extra attributes to the alert, like `id` or additional classes using `class`.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
