### PR TITLE
Add brand classes when using logo XL

### DIFF
--- a/resources/views/partials/common/brand-logo-xl.blade.php
+++ b/resources/views/partials/common/brand-logo-xl.blade.php
@@ -10,9 +10,9 @@
 
 <a href="{{ $dashboard_url }}"
     @if($layoutHelper->isLayoutTopnavEnabled())
-        class="navbar-brand logo-switch"
+        class="navbar-brand logo-switch {{ config('adminlte.classes_brand') }}"
     @else
-        class="brand-link logo-switch"
+        class="brand-link logo-switch {{ config('adminlte.classes_brand') }}"
     @endif>
 
     {{-- Small brand logo --}}


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix the `brand-logo-xl.blade.php` blade file to correctly include configuration option `classes_brand`. This way you can add extra classes to the brand link, like a background color with `bg-<color>` or change border color with `border-<color>` as examples.

Related to issue #783 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.