### PR TITLE
Improve the Datatables component

### DIFF
--- a/resources/views/components/datatable.blade.php
+++ b/resources/views/components/datatable.blade.php
@@ -1,44 +1,60 @@
-@if($buttons)
-    @section('css')
-    @parent 
-    <link rel="stylesheet" href="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.20/b-1.6.1/b-html5-1.6.1/b-print-1.6.1/datatables.min.css" />
-    <style>.printer table{counter-reset: rowNumber}.printer tr{counter-increment: rowNumber}.printer tr td:first-child::before{content: counter(rowNumber);min-width: 1em;margin-right: 0.5em} div.dt-buttons.btn-group.flex-wrap {float:right}</style>
-    @endsection
+{{-- Table --}}
 
-    @section('js')
-    @parent 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>
-    <script src="https://cdn.datatables.net/v/bs4/jszip-2.5.0/dt-1.10.20/b-1.6.1/b-html5-1.6.1/b-print-1.6.1/datatables.min.js"></script>
-    @endsection
-@endif
+<div class="table-responsive">
 
-@if($beautify)
-<style>#{{$id}} tbody tr td { vertical-align: middle; text-align: center; }</style>
-@endif  
-<table id="{{$id}}" class="table {{$border}} {{$hover}}">
-    <thead>
+<table id="{{ $id }}" style="width:100%" {{ $attributes->merge(['class' => $makeTableClass()]) }}>
+
+    {{-- Table head --}}
+    <thead @isset($headTheme) class="thead-{{ $headTheme }}" @endisset>
         <tr>
             @foreach($heads as $th)
-            @if(isset($th->name))
-            <td style="width:{{$th->width}}%">{{$th->name}}</td>
-            @else
-            <td>{{$th}}</td>
-            @endif
+                <th @isset($th['width']) style="width:{{ $th['width'] }}%" @endisset
+                    @isset($th['no-export']) dt-no-export @endisset>
+                    {{ is_array($th) ? ($th['label'] ?? '') : $th }}
+                </th>
             @endforeach
         </tr>
     </thead>
-    <tbody>
 
-    </tbody>
+    {{-- Table body --}}
+    <tbody>{{ $slot }}</tbody>
 
-    @if($footer)
-    <tfoot>
-        <tr>
-            @foreach($heads as $foot)
-            <th></th>
-            @endforeach
-        </tr>
-    </tfoot>
-    @endif
+    {{-- Table footer --}}
+    @isset($withFooter)
+        <tfoot @isset($footerTheme) class="thead-{{ $footerTheme }}" @endisset>
+            <tr>
+                @foreach($heads as $th)
+                    <th>{{ is_array($th) ? ($th['label'] ?? '') : $th }}</th>
+                @endforeach
+            </tr>
+        </tfoot>
+    @endisset
+
 </table>
+
+</div>
+
+{{-- Add plugin initialization and configuration code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+        $('#{{ $id }}').DataTable( @json($config) );
+    })
+
+</script>
+@endpush
+
+{{-- Add CSS styling --}}
+
+@isset($beautify)
+    @push('css')
+    <style type="text/css">
+        #{{ $id }} tr td,  #{{ $id }} tr th {
+            vertical-align: middle;
+            text-align: center;
+        }
+    </style>
+    @endpush
+@endisset

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -177,15 +177,20 @@ class AdminLteServiceProvider extends BaseServiceProvider
             Components\TextEditor::class,
         ]);
 
+        // Tool components.
+
+        $this->loadViewComponentsAs('adminlte', [
+            Components\Datatable::class,
+            Components\Modal::class,
+        ]);
+
         // Widgets components.
 
         $this->loadViewComponentsAs('adminlte', [
             Components\Alert::class,
             Components\Callout::class,
             Components\Card::class,
-            Components\Datatable::class,
             Components\InfoBox::class,
-            Components\Modal::class,
             Components\ProfileColItem::class,
             Components\ProfileRowItem::class,
             Components\ProfileWidget::class,

--- a/src/Components/Datatable.php
+++ b/src/Components/Datatable.php
@@ -6,45 +6,274 @@ use Illuminate\View\Component;
 
 class Datatable extends Component
 {
-    public $beautify;
-    public $buttons;
+    /**
+     * The table identification (id) attribute. Required in order to manage
+     * the internal or external (JS) initialization.
+     *
+     * @var string
+     */
     public $id;
-    public $bordered;
-    public $hoverable;
-    public $condensed;
-    public $heads;
-    public $footer;
 
+    /**
+     * An array with the set of headers (titles) for the table columns. Each
+     * header can be a string or an array with next properties: label, width
+     * and no-export.
+     *
+     * @var array
+     */
+    public $heads;
+
+    /**
+     * The table theme (light, dark, primary, secondary, info, warning or
+     * danger).
+     *
+     * @var string
+     */
+    public $theme;
+
+    /**
+     * The table head theme (light or dark).
+     *
+     * @var string
+     */
+    public $headTheme;
+
+    /**
+     * The datatables plugin configuration parameters. Array with key => value
+     * pairs, where the key should be an existing configuration property of
+     * the datatables plugin.
+     *
+     * @var array
+     */
+    public $config;
+
+    /**
+     * Enables a footer with header cells. The footer can be fully customized
+     * using the 'footerCallback' option.
+     *
+     * @var mixed
+     */
+    public $withFooter;
+
+    /**
+     * The table footer theme (light or dark).
+     *
+     * @var string
+     */
+    public $footerTheme;
+
+    /**
+     * When enabled, borders will be used around the table.
+     *
+     * @var mixed
+     */
+    public $bordered;
+
+    /**
+     * When enabled, a hover effect will be available for the table rows.
+     *
+     * @var mixed
+     */
+    public $hoverable;
+
+    /**
+     * When enabled, a striped effect will be available for the table rows.
+     *
+     * @var mixed
+     */
+    public $striped;
+
+    /**
+     * When enabled, the table will be compressed using less white space between
+     * cells and rows.
+     *
+     * @var mixed
+     */
+    public $compressed;
+
+    /**
+     * When enabled, the table cells with be vertically and horizontally
+     * centered.
+     *
+     * @var mixed
+     */
+    public $beautify;
+
+    /**
+     * When enabled, a set of tool buttons for export the table will be
+     * available.
+     *
+     * @var mixed
+     */
+    public $withButtons;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
     public function __construct(
-        $beautify = true, $id,
-        $bordered = true, $hoverable = true, $condensed = false,
-        $heads, $footer = false, $buttons = false
-        ) {
+        $id, $heads, $theme = null, $headTheme = null, $bordered = null,
+        $hoverable = null, $striped = null, $compressed = null,
+        $withFooter = null, $footerTheme = null, $beautify = null,
+        $withButtons = null, $config = []
+    ) {
         $this->id = $id;
-        $this->beautify = $beautify;
+        $this->heads = $heads;
+        $this->theme = $theme;
+        $this->headTheme = $headTheme;
         $this->bordered = $bordered;
         $this->hoverable = $hoverable;
-        $this->condensed = $condensed;
-        $this->heads = json_decode(json_encode($heads));
-        $this->footer = $footer;
-        $this->buttons = $buttons;
+        $this->striped = $striped;
+        $this->compressed = $compressed;
+        $this->withFooter = $withFooter;
+        $this->footerTheme = $footerTheme;
+        $this->beautify = $beautify;
+        $this->withButtons = $withButtons;
+
+        $this->config = is_array($config) ? $config : [];
+
+        // When buttons are enabled, change the default table layout.
+
+        if (isset($withButtons) && ! isset($this->config['dom'])) {
+            $this->config['dom'] = $this->makeDomCfg();
+        }
+
+        // When buttons are enabled, setup the set of visible buttons and they
+        // default style.
+
+        if (isset($withButtons) && ! isset($this->config['buttons'])) {
+            $this->config['buttons'] = $this->makeButtonsCfg();
+        }
     }
 
-    public function border()
+    /**
+     * Make the table class.
+     *
+     * @return string
+     */
+    public function makeTableClass()
     {
-        return ($this->bordered) ? 'table-bordered' : null;
+        $classes = ['table'];
+
+        if (isset($this->bordered)) {
+            $classes[] = 'table-bordered';
+        }
+
+        if (isset($this->hoverable)) {
+            $classes[] = 'table-hover';
+        }
+
+        if (isset($this->striped)) {
+            $classes[] = 'table-striped';
+        }
+
+        if (isset($this->compressed)) {
+            $classes[] = 'table-sm';
+        }
+
+        if (isset($this->theme)) {
+            $classes[] = "table-{$this->theme}";
+        }
+
+        return implode(' ', $classes);
     }
 
-    public function hover()
+    /**
+     * Make the Datatables 'dom' configuration with the buttons extension.
+     *
+     * @return string
+     */
+    protected function makeDomCfg()
     {
-        return ($this->hoverable) ? 'table-hover' : null;
+        // Give bootstrap style to table elements.
+        // The built-in table control elements in DataTables are:
+        // l - Length changing input control.
+        // f - Filtering input.
+        // t - The table!
+        // i - Table information summary.
+        // p - Pagination control.
+        // r - Processing display element.
+        // B - buttons extension.
+
+        return '<"row" <"col-sm-6" B> <"col-sm-6" f> >
+                <"row" <"col-12" tr> >
+                <"row" <"col-sm-5" i> <"col-sm-7" p> >';
     }
 
-    public function condense()
+    /**
+     * Make the Datatables 'buttons' configuration object to define the set of
+     * visible buttons and they style.
+     *
+     * @return array
+     */
+    protected function makeButtonsCfg()
     {
-        return ($this->condensed) ? 'table-condensed' : null;
+        // Configure the export columns selector. We are not going to export
+        // columns that explicity have the 'dt-no-export' attribute.
+
+        $colSelector = ':not([dt-no-export])';
+
+        // Button to change the page length of tables.
+
+        $lengthBtn = [
+            'extend' => 'pageLength',
+            'className' => 'btn-default',
+        ];
+
+        // Button to print the data.
+
+        $printBtn = [
+            'extend' => 'print',
+            'className' => 'btn-default',
+            'text' => '<i class="fas fa-fw fa-lg fa-print"></i>',
+            'titleAttr' => 'Print',
+            'exportOptions' => ['columns' => $colSelector],
+        ];
+
+        // Button to export data to CSV file.
+
+        $csvBtn = [
+            'extend' => 'csv',
+            'className' => 'btn-default',
+            'text' => '<i class="fas fa-fw fa-lg fa-file-csv text-primary"></i>',
+            'titleAttr' => 'Export to CSV',
+            'exportOptions' => ['columns' => $colSelector],
+        ];
+
+        // Button to export data to Excel file.
+
+        $excelBtn = [
+            'extend' => 'excel',
+            'className' => 'btn-default',
+            'text' => '<i class="fas fa-fw fa-lg fa-file-excel text-success"></i>',
+            'titleAttr' => 'Export to Excel',
+            'exportOptions' => ['columns' => $colSelector],
+        ];
+
+        // Button to export data to PDF file.
+
+        $pdfBtn = [
+            'extend' => 'pdf',
+            'className' => 'btn-default',
+            'text' => '<i class="fas fa-fw fa-lg fa-file-pdf text-danger"></i>',
+            'titleAttr' => 'Export to PDF',
+            'exportOptions' => ['columns' => $colSelector],
+        ];
+
+        // Return the set of configured buttons.
+
+        return [
+            'dom' => ['button' => ['className' => 'btn']],
+            'buttons' => [$lengthBtn, $printBtn, $csvBtn, $excelBtn, $pdfBtn],
+        ];
     }
 
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
         return view('adminlte::components.datatable');

--- a/src/Components/Datatable.php
+++ b/src/Components/Datatable.php
@@ -49,7 +49,7 @@ class Datatable extends Component
 
     /**
      * Enables a footer with header cells. The footer can be fully customized
-     * using the 'footerCallback' option.
+     * using the 'footerCallback' option of the plugin.
      *
      * @var mixed
      */
@@ -63,7 +63,7 @@ class Datatable extends Component
     public $footerTheme;
 
     /**
-     * When enabled, borders will be used around the table.
+     * When enabled, borders will be displayed around the table.
      *
      * @var mixed
      */
@@ -101,7 +101,7 @@ class Datatable extends Component
 
     /**
      * When enabled, a set of tool buttons for export the table will be
-     * available.
+     * displayed.
      *
      * @var mixed
      */
@@ -210,7 +210,7 @@ class Datatable extends Component
     protected function makeButtonsCfg()
     {
         // Configure the export columns selector. We are not going to export
-        // columns that explicity have the 'dt-no-export' attribute.
+        // columns that explicitly have the 'dt-no-export' attribute.
 
         $colSelector = ':not([dt-no-export])';
 

--- a/src/Components/Datatable.php
+++ b/src/Components/Datatable.php
@@ -92,7 +92,7 @@ class Datatable extends Component
     public $compressed;
 
     /**
-     * When enabled, the table cells with be vertically and horizontally
+     * When enabled, the table cells will be vertically and horizontally
      * centered.
      *
      * @var mixed

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -43,14 +43,17 @@ class ComponentsTest extends TestCase
             "{$base}.textarea"     => new Components\Textarea('name'),
             "{$base}.text-editor"  => new Components\TextEditor('name'),
 
+            // Tool components.
+
+            "{$base}.datatable"    => new Components\Datatable('id', []),
+            "{$base}.modal"        => new Components\Modal('id'),
+
             // Widget components.
 
             "{$base}.alert"            => new Components\Alert(),
             "{$base}.callout"          => new Components\Callout(),
             "{$base}.card"             => new Components\Card(),
-            "{$base}.datatable"        => new Components\Datatable(null, 'id', null, null, null, '[]'),
             "{$base}.info-box"         => new Components\InfoBox(),
-            "{$base}.modal"            => new Components\Modal('id'),
             "{$base}.profile-col-item" => new Components\ProfileColItem(),
             "{$base}.profile-row-item" => new Components\ProfileRowItem(),
             "{$base}.profile-widget"   => new Components\ProfileWidget(),
@@ -155,6 +158,79 @@ class ComponentsTest extends TestCase
 
     /*
     |--------------------------------------------------------------------------
+    | Individual tool components tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testDatatableComponent()
+    {
+        // Test basic component.
+        $component = new Components\Datatable('id', []);
+
+        $tClass = $component->makeTableClass();
+        $this->assertStringContainsString('table', $tClass);
+
+        // Test advanced component.
+        // $id, $heads, $theme, $headTheme, $bordered, $hoverable, $striped,
+        // $compressed, $withFooter, $footerTheme, $beautify, $withButtons,
+        // $config
+        $component = new Components\Datatable(
+            'id', [], 'primary', null, true, true, true, true, null, null,
+            null, true, null
+        );
+
+        $tClass = $component->makeTableClass();
+        $this->assertStringContainsString('table-bordered', $tClass);
+        $this->assertStringContainsString('table-hover', $tClass);
+        $this->assertStringContainsString('table-striped', $tClass);
+        $this->assertStringContainsString('table-sm', $tClass);
+        $this->assertStringContainsString('table-primary', $tClass);
+    }
+
+    public function testModalComponent()
+    {
+        // Test basic component.
+
+        $component = new Components\Modal('id');
+
+        $mClass = $component->makeModalClass();
+        $this->assertStringContainsString('modal', $mClass);
+        $this->assertStringContainsString('fade', $mClass);
+
+        $mdClass = $component->makeModalDialogClass();
+        $this->assertStringContainsString('modal-dialog', $mdClass);
+
+        $mhClass = $component->makeModalHeaderClass();
+        $this->assertStringContainsString('modal-header', $mhClass);
+
+        $cbClass = $component->makeCloseButtonClass();
+        $this->assertStringContainsString('bg-secondary', $cbClass);
+
+        // Test with all constructor arguments:
+        // $id, $title, $icon, $size, $theme, $vCentered, $scrollable,
+        // $staticBackdrop, $disableAnimations.
+
+        $component = new Components\Modal(
+            'id', 'title', null, 'lg', 'info', true, true, true, true
+        );
+
+        $mClass = $component->makeModalClass();
+        $this->assertStringNotContainsString('fade', $mClass);
+
+        $mdClass = $component->makeModalDialogClass();
+        $this->assertStringContainsString('modal-dialog-centered', $mdClass);
+        $this->assertStringContainsString('modal-dialog-scrollable', $mdClass);
+        $this->assertStringContainsString('modal-lg', $mdClass);
+
+        $mhClass = $component->makeModalHeaderClass();
+        $this->assertStringContainsString('bg-info', $mhClass);
+
+        $cbClass = $component->makeCloseButtonClass();
+        $this->assertStringContainsString('bg-info', $cbClass);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
     | Individual widget components tests.
     |--------------------------------------------------------------------------
     */
@@ -219,17 +295,6 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('text-teal', $ctClass);
     }
 
-    public function testDatatableComponent()
-    {
-        $component = new Components\Datatable(
-            null, 'id', true, true, true, '[]'
-        );
-
-        $this->assertIsString($component->border());
-        $this->assertIsString($component->hover());
-        $this->assertIsString($component->condense());
-    }
-
     public function testInfoBoxComponent()
     {
         $component = new Components\InfoBox(
@@ -243,48 +308,6 @@ class ComponentsTest extends TestCase
         $iClass = $component->makeIconClass();
         $this->assertStringContainsString('info-box-icon', $iClass);
         $this->assertStringContainsString('bg-primary', $iClass);
-    }
-
-    public function testModalComponent()
-    {
-        // Test basic component.
-
-        $component = new Components\Modal('id');
-
-        $mClass = $component->makeModalClass();
-        $this->assertStringContainsString('modal', $mClass);
-        $this->assertStringContainsString('fade', $mClass);
-
-        $mdClass = $component->makeModalDialogClass();
-        $this->assertStringContainsString('modal-dialog', $mdClass);
-
-        $mhClass = $component->makeModalHeaderClass();
-        $this->assertStringContainsString('modal-header', $mhClass);
-
-        $cbClass = $component->makeCloseButtonClass();
-        $this->assertStringContainsString('bg-secondary', $cbClass);
-
-        // Test with all constructor arguments:
-        // $id, $title, $icon, $size, $theme, $vCentered, $scrollable,
-        // $staticBackdrop, $disableAnimations.
-
-        $component = new Components\Modal(
-            'id', 'title', null, 'lg', 'info', true, true, true, true
-        );
-
-        $mClass = $component->makeModalClass();
-        $this->assertStringNotContainsString('fade', $mClass);
-
-        $mdClass = $component->makeModalDialogClass();
-        $this->assertStringContainsString('modal-dialog-centered', $mdClass);
-        $this->assertStringContainsString('modal-dialog-scrollable', $mdClass);
-        $this->assertStringContainsString('modal-lg', $mdClass);
-
-        $mhClass = $component->makeModalHeaderClass();
-        $this->assertStringContainsString('bg-info', $mhClass);
-
-        $cbClass = $component->makeCloseButtonClass();
-        $this->assertStringContainsString('bg-info', $cbClass);
     }
 
     public function testProfileColItemComponent()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improves the **datatables** component in relation to issue #732 :
- Add a new `config` attribute to provide a way to make `datatables` plugin configuration.
- Add several new attributes to provide theme configuration.
- Add a new set of styled tool buttons for export the data (when enabled).
- Fix some issues with the markup.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.