### PR TITLE
Fix issue #795 on the menu builder

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -175,6 +175,14 @@ class Builder
             return $item;
         }
 
+        // If the item is a submenu, transform all the submenu items first.
+        // These items need to be transformed first because some of the submenu
+        // filters (like the ActiveFilter) depends on these results.
+
+        if (MenuItemHelper::isSubmenu($item)) {
+            $item['submenu'] = $this->transformItems($item['submenu']);
+        }
+
         // Now, apply all the filters on the item.
 
         foreach ($this->filters as $filter) {
@@ -187,12 +195,6 @@ class Builder
             }
 
             $item = $filter->transform($item);
-        }
-
-        // If the item is a submenu, transform all submenu items too.
-
-        if (MenuItemHelper::isSubmenu($item)) {
-            $item['submenu'] = $this->transformItems($item['submenu']);
         }
 
         return $item;

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -536,6 +536,47 @@ class BuilderTest extends TestCase
         $this->assertStringNotContainsString('active', $builder->menu[1]['class']);
     }
 
+    public function testActiveClassWithSubmenuAndUrl()
+    {
+        $builder = $this->makeMenuBuilder('http://example.com/about');
+
+        $builder->add(
+            [
+                'text'    => 'Menu',
+                'submenu' => [
+                    [
+                        'text'  => 'About',
+                        'url'   => '/about',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertStringContainsString('active', $builder->menu[0]['class']);
+        $this->assertStringContainsString('active', $builder->menu[0]['submenu'][0]['class']);
+    }
+
+    public function testActiveClassWithSubmenuAndRoute()
+    {
+        $builder = $this->makeMenuBuilder('http://example.com/about');
+        $this->getRouteCollection()->add(new Route('GET', 'about', ['as' => 'pages.about']));
+
+        $builder->add(
+            [
+                'text'    => 'Menu',
+                'submenu' => [
+                    [
+                        'text'    => 'About',
+                        'route'   => 'pages.about',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertStringContainsString('active', $builder->menu[0]['class']);
+        $this->assertStringContainsString('active', $builder->menu[0]['submenu'][0]['class']);
+    }
+
     public function testSubmenuActiveWithHash()
     {
         $builder = $this->makeMenuBuilder('http://example.com/home');


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Fix the issue #795 related to the menu builder class. When the item is a **submenu**, we need to transform all the **child** items first. These items need to be transformed first because some of the **submenu** filters (like the `ActiveFilter`) depends on these results.

In addition, some test are created to cover these cases.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.