### PR TITLE
Update menu-item-link.blade.php

### DIFF
--- a/resources/views/partials/sidebar/menu-item-link.blade.php
+++ b/resources/views/partials/sidebar/menu-item-link.blade.php
@@ -4,7 +4,7 @@
        href="{{ $item['href'] }}" @if(isset($item['target'])) target="{{ $item['target'] }}" @endif
        {!! $item['data-compiled'] ?? '' !!}>
 
-        <i class="{{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
+        <i class="{{ $item['active'] && isset($item['icon_active']) ? $item['icon_active'] : $item['icon'] ?? 'far fa-fw fa-circle' }} {{
             isset($item['icon_color']) ? 'text-'.$item['icon_color'] : ''
         }}"></i>
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue|Enhancement
| License                 | MIT

#### What's in this PR?

When the sidebar link is active you can use optional icon.

Example (adminlte.php):

'icon' => 'far fa-folder',
'icon_active' => 'far fa-folder-open',

#### Checklist

- [x] I tested these changes.
- [ ] I have linked the related issues.
