### PR TITLE
Fix error on the artisan command tests

### DIFF
--- a/tests/Console/CommandTestCase.php
+++ b/tests/Console/CommandTestCase.php
@@ -127,6 +127,13 @@ class CommandTestCase extends TestCase
             return;
         }
 
+        // Check if vendor folder exists on the laravel testing project. If
+        // vendor folder do not exists, create it.
+
+        if (! is_dir(base_path('vendor'))) {
+            mkdir(base_path('vendor'));
+        }
+
         // Create a symbolic link to the required vendor assets.
 
         symlink($resource, $target);


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue|Enhancement
| License                 | MIT

#### What's in this PR?

Fix an error on the artisan command tests. The php `symlink()` method fails when trying to create a symbolic link to the **adminlte assets**. To ensure the symbolic link is created correctly, we need to create the `vendor` folder into the Laravel's testing project.

The error was detected from a build process of a recent PR, see [here](https://github.com/jeroennoten/Laravel-AdminLTE/runs/1832832388) for error details.

#### Checklist

- [x] I tested these changes.