### PR TITLE
Fix menu builder tests for php 7.2.13 compatibility

### DIFF
--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -861,7 +861,7 @@ class BuilderTest extends TestCase
             [
                 // Test case with non-array parameters.
                 'header' => ['header_with_params', 'non-array-value'],
-            ],
+            ]
         );
 
         $this->assertCount(5, $builder->menu);


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Remove extra `,` character on function call when running tests of the **Menu Builder**. This add compatibility when running the tests with **php v7.2.13** and maybe with other versions too.

#### Checklist

- [x] I tested these changes.