### PR TITLE
Update AdminLTE to v3.1 to start integration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "laravel/framework": ">=6.0",
     "php": ">=7.2.0",
-    "almasaeed2010/adminlte": "3.0.*"
+    "almasaeed2010/adminlte": "3.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.3",

--- a/src/Console/PackageResources/PluginsResource.php
+++ b/src/Console/PackageResources/PluginsResource.php
@@ -105,16 +105,6 @@ class PluginsResource extends PackageResource
             'source' => 'fullcalendar',
             'ignore' => ['*.d.ts', '*.json', '*.md'],
         ],
-        'fullcalendarPlugins' => [
-            'name' => 'Fullcalendar Plugins',
-            'resources' => [
-                ['source' => 'fullcalendar-bootstrap', 'target' => 'fullcalendar-plugins/bootstrap'],
-                ['source' => 'fullcalendar-daygrid', 'target' => 'fullcalendar-plugins/daygrid'],
-                ['source' => 'fullcalendar-interaction', 'target' => 'fullcalendar-plugins/interaction'],
-                ['source' => 'fullcalendar-timegrid', 'target' => 'fullcalendar-plugins/timegrid'],
-            ],
-            'ignore' => ['*.d.ts', '*.json', '*.md'],
-        ],
         'icheckBootstrap' => [
             'name' => 'iCheck Bootstrap',
             'source' => 'icheck-bootstrap',


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue|Enhancement
| License                 | MIT

#### What's in this PR?

- Update AdminLTE to version **3.1.0** in order to start the integration process.
- Remove **FullcalendarPlugins** from the available plugins list. These resources no longer exists on **AdminLTE v3.1.0**

#### Checklist

- [x] I tested these changes.