### PR TITLE
Improve Select2 component for compatibility with AdminLTE v3.1

### DIFF
--- a/src/Components/Select2.php
+++ b/src/Components/Select2.php
@@ -40,7 +40,7 @@ class Select2 extends InputGroupComponent
      */
     public function makeItemClass($invalid)
     {
-        $classes = ['form-control', 'w-100'];
+        $classes = ['form-control'];
 
         if (! empty($invalid) && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -141,7 +141,6 @@ class ComponentsTest extends TestCase
         $iClass = $component->makeItemClass(true);
 
         $this->assertStringContainsString('form-control', $iClass);
-        $this->assertStringContainsString('w-100', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Remove the `w-100` class to fix display issue with **AdminLTE v.3.1.0**

#### Checklist

- [x] I tested these changes.