### PR TITLE
Improve the invalid style for components that extend the input group

### DIFF
--- a/resources/views/components/input-group-component.blade.php
+++ b/resources/views/components/input-group-component.blade.php
@@ -8,7 +8,7 @@
     @endisset
 
     {{-- Input group --}}
-    <div class="{{ $makeInputGroupClass() }}">
+    <div class="{{ $makeInputGroupClass($errors->first($name)) }}">
 
         {{-- Input prepend slot --}}
         @isset($prependSlot)
@@ -35,3 +35,27 @@
     @endif
 
 </div>
+
+{{-- Extra style customization for invalid input groups --}}
+
+@once
+@push('css')
+<style type="text/css">
+
+    {{-- Highlight invalid input groups with a box-shadow --}}
+
+    .adminlte-invalid-igroup {
+        box-shadow: 0 .25rem 0.5rem rgba(0,0,0,.1);
+    }
+
+    {{-- Setup a red border on elements inside prepend/append add-ons --}}
+
+    .adminlte-invalid-igroup > .input-group-prepend > *,
+    .adminlte-invalid-igroup > .input-group-append > * {
+        border-color: #dc3545 !important;
+    }
+
+</style>
+@endpush
+@endonce
+

--- a/src/Components/InputDate.php
+++ b/src/Components/InputDate.php
@@ -70,7 +70,7 @@ class InputDate extends InputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['form-control', 'datetimepicker'];
 

--- a/src/Components/InputFile.php
+++ b/src/Components/InputFile.php
@@ -42,7 +42,7 @@ class InputFile extends InputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['custom-file-input'];
 

--- a/src/Components/InputGroupComponent.php
+++ b/src/Components/InputGroupComponent.php
@@ -69,22 +69,6 @@ class InputGroupComponent extends Component
     }
 
     /**
-     * Make the class attribute for the "input-group" element.
-     *
-     * @return string
-     */
-    public function makeInputGroupClass()
-    {
-        $classes = ['input-group'];
-
-        if (isset($this->size) && in_array($this->size, ['sm', 'lg'])) {
-            $classes[] = "input-group-{$this->size}";
-        }
-
-        return implode(' ', $classes);
-    }
-
-    /**
      * Make the class attribute for the "form-group" element.
      *
      * @return string
@@ -101,12 +85,33 @@ class InputGroupComponent extends Component
     }
 
     /**
+     * Make the class attribute for the "input-group" element.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeInputGroupClass($invalid = null)
+    {
+        $classes = ['input-group'];
+
+        if (isset($this->size) && in_array($this->size, ['sm', 'lg'])) {
+            $classes[] = "input-group-{$this->size}";
+        }
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'adminlte-invalid-igroup';
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Make the class attribute for the input group item.
      *
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['form-control'];
 

--- a/src/Components/InputSwitch.php
+++ b/src/Components/InputSwitch.php
@@ -36,7 +36,7 @@ class InputSwitch extends InputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = [];
 

--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -24,7 +24,7 @@ class Select extends InputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['form-control'];
 

--- a/src/Components/Select2.php
+++ b/src/Components/Select2.php
@@ -38,7 +38,7 @@ class Select2 extends InputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['form-control'];
 

--- a/src/Components/SelectBs.php
+++ b/src/Components/SelectBs.php
@@ -36,7 +36,7 @@ class SelectBs extends inputGroupComponent
      * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid)
+    public function makeItemClass($invalid = null)
     {
         $classes = ['form-control'];
 

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -82,12 +82,13 @@ class ComponentsTest extends TestCase
             'name', null, 'lg', null, 'top-class'
         );
 
-        $iGroupClass = $component->makeInputGroupClass();
+        $iGroupClass = $component->makeInputGroupClass(true);
         $fGroupClass = $component->makeFormGroupClass();
         $iClass = $component->makeItemClass(true);
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
+        $this->assertStringContainsString('adminlte-invalid-igroup', $iGroupClass);
         $this->assertStringContainsString('form-group', $fGroupClass);
         $this->assertStringContainsString('top-class', $fGroupClass);
         $this->assertStringContainsString('form-control', $iClass);


### PR DESCRIPTION
| Question              | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Improve the invalid style for the components that extends the **input-group-component**

Example of the old invalid style:

![Screenshot_2021-03-25 Laradmin Tests](https://user-images.githubusercontent.com/63609705/112565363-add8cf00-8dbb-11eb-8bc6-28ff8e484023.png)

Example of the new invalid style:

![Screenshot_2021-03-25 Laradmin Tests(1)](https://user-images.githubusercontent.com/63609705/112565361-ad403880-8dbb-11eb-9d6e-4833699e0ddc.png)

- Add a default `null` value for some parameters of components methods.

#### Checklist

- [x] I tested these changes.