### PR TITLE
Propagate the new input-group-class attribute to all components

### DIFF
--- a/src/Components/DateRange.php
+++ b/src/Components/DateRange.php
@@ -30,11 +30,12 @@ class DateRange extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = [],
-        $enableDefaultRanges = null
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = [], $enableDefaultRanges = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/Input.php
+++ b/src/Components/Input.php
@@ -10,11 +10,12 @@ class Input extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null,
-        $labelClass = null, $topClass = null, $disableFeedback = null
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
     }
 

--- a/src/Components/InputColor.php
+++ b/src/Components/InputColor.php
@@ -21,10 +21,12 @@ class InputColor extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/InputDate.php
+++ b/src/Components/InputDate.php
@@ -47,10 +47,12 @@ class InputDate extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/InputFile.php
+++ b/src/Components/InputFile.php
@@ -25,11 +25,13 @@ class InputFile extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null, $topClass = null,
-        $disableFeedback = null, $placeholder = '', $legend = null
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $placeholder = '', $legend = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->legend = $legend;

--- a/src/Components/InputSlider.php
+++ b/src/Components/InputSlider.php
@@ -28,10 +28,12 @@ class InputSlider extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = [], $color = null
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = [], $color = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/InputSwitch.php
+++ b/src/Components/InputSwitch.php
@@ -21,10 +21,12 @@ class InputSwitch extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -10,11 +10,12 @@ class Select extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null,
-        $labelClass = null, $topClass = null, $disableFeedback = null
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
     }
 

--- a/src/Components/Select2.php
+++ b/src/Components/Select2.php
@@ -22,10 +22,12 @@ class Select2 extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/TextEditor.php
+++ b/src/Components/TextEditor.php
@@ -22,10 +22,12 @@ class TextEditor extends InputGroupComponent
      */
     public function __construct(
         $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
+        $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/Textarea.php
+++ b/src/Components/Textarea.php
@@ -10,11 +10,12 @@ class Textarea extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null,
-        $labelClass = null, $topClass = null, $disableFeedback = null
+        $name, $label = null, $size = null, $labelClass = null,
+        $topClass = null, $inputGroupClass = null, $disableFeedback = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $label, $size, $labelClass, $topClass,
+            $inputGroupClass, $disableFeedback
         );
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Propagate the new **input-group-class** attribute to all components that extends from **InputGroupComponent**.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.