### PR TITLE
Improve the invalid style for input-switch and input-slider components

### DIFF
--- a/resources/views/components/input-slider.blade.php
+++ b/resources/views/components/input-slider.blade.php
@@ -99,3 +99,24 @@
 
 </style>
 @endpush
+
+{{-- Setup custom invalid style  --}}
+{{-- NOTE: this may change with newer plugin versions --}}
+
+@once
+@push('css')
+<style type="text/css">
+
+    .adminlte-invalid-islgroup .slider-track,
+    .adminlte-invalid-islgroup > .input-group-prepend > *,
+    .adminlte-invalid-islgroup > .input-group-append > * {
+        box-shadow: 0 .25rem 0.5rem rgba(255,0,0,.25);
+    }
+
+    .adminlte-invalid-islgroup .slider-vertical {
+        margin-bottom: 1rem;
+    }
+
+</style>
+@endpush
+@endonce

--- a/resources/views/components/input-switch.blade.php
+++ b/resources/views/components/input-switch.blade.php
@@ -47,6 +47,14 @@
         font-size: .875rem !important;
     }
 
+    {{-- Custom invalid style setup --}}
+
+    .adminlte-invalid-iswgroup > .bootstrap-switch-wrapper,
+    .adminlte-invalid-iswgroup > .input-group-prepend > *,
+    .adminlte-invalid-iswgroup > .input-group-append > * {
+        box-shadow: 0 .25rem 0.5rem rgba(255,0,0,.25);
+    }
+
 </style>
 @endpush
 @endonce

--- a/resources/views/components/input-switch.blade.php
+++ b/resources/views/components/input-switch.blade.php
@@ -3,7 +3,7 @@
 @section('input_group_item')
 
     {{-- Input Switch --}}
-    <input type="checkbox" id="{{ $name }}" name="{{ $name }}"
+    <input type="checkbox" id="{{ $name }}" name="{{ $name }}" value="true"
         {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
 
 @overwrite

--- a/resources/views/components/text-editor.blade.php
+++ b/resources/views/components/text-editor.blade.php
@@ -56,6 +56,13 @@
         line-height: 1.5;
     }
 
+    {{-- Setup custom invalid style  --}}
+
+    .adminlte-invalid-itegroup .note-editor {
+        box-shadow: 0 .25rem 0.5rem rgba(0,0,0,.25);
+        border-color: #dc3545 !important;
+    }
+
 </style>
 @endpush
 @endonce

--- a/src/Components/InputSlider.php
+++ b/src/Components/InputSlider.php
@@ -45,6 +45,32 @@ class InputSlider extends InputGroupComponent
     }
 
     /**
+     * Make the class attribute for the "input-group" element. Note we overwrite
+     * the method of the parent class.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeInputGroupClass($invalid = null)
+    {
+        $classes = ['input-group'];
+
+        if (isset($this->size) && in_array($this->size, ['sm', 'lg'])) {
+            $classes[] = "input-group-{$this->size}";
+        }
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'adminlte-invalid-islgroup';
+        }
+
+        if (isset($this->inputGroupClass)) {
+            $classes[] = $this->inputGroupClass;
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Get the view / contents that represent the component.
      *
      * @return \Illuminate\View\View|string

--- a/src/Components/InputSwitch.php
+++ b/src/Components/InputSwitch.php
@@ -33,6 +33,32 @@ class InputSwitch extends InputGroupComponent
     }
 
     /**
+     * Make the class attribute for the "input-group" element. Note we overwrite
+     * the method of the parent class.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeInputGroupClass($invalid = null)
+    {
+        $classes = ['input-group'];
+
+        if (isset($this->size) && in_array($this->size, ['sm', 'lg'])) {
+            $classes[] = "input-group-{$this->size}";
+        }
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'adminlte-invalid-iswgroup';
+        }
+
+        if (isset($this->inputGroupClass)) {
+            $classes[] = $this->inputGroupClass;
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Make the class attribute for the input group item.
      *
      * @param string $invalid

--- a/src/Components/TextEditor.php
+++ b/src/Components/TextEditor.php
@@ -38,6 +38,32 @@ class TextEditor extends InputGroupComponent
     }
 
     /**
+     * Make the class attribute for the "input-group" element. Note we overwrite
+     * the method of the parent class.
+     *
+     * @param string $invalid
+     * @return string
+     */
+    public function makeInputGroupClass($invalid = null)
+    {
+        $classes = ['input-group'];
+
+        if (isset($this->size) && in_array($this->size, ['sm', 'lg'])) {
+            $classes[] = "input-group-{$this->size}";
+        }
+
+        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+            $classes[] = 'adminlte-invalid-itegroup';
+        }
+
+        if (isset($this->inputGroupClass)) {
+            $classes[] = $this->inputGroupClass;
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Get the view / contents that represent the component.
      *
      * @return \Illuminate\View\View|string

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -120,11 +120,35 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 
-    public function testInputSwitchComponent()
+    public function testInputSliderComponent()
     {
-        $component = new Components\InputSwitch('name');
+        $component = new Components\InputSlider(
+            'name', null, 'lg', null, null, 'igroup-custom-class'
+        );
+
+        $iGroupClass = $component->makeInputGroupClass(true);
         $iClass = $component->makeItemClass(true);
 
+        $this->assertStringContainsString('input-group', $iGroupClass);
+        $this->assertStringContainsString('input-group-lg', $iGroupClass);
+        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('adminlte-invalid-islgroup', $iGroupClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testInputSwitchComponent()
+    {
+        $component = new Components\InputSwitch(
+            'name', null, 'lg', null, null, 'igroup-custom-class'
+        );
+
+        $iGroupClass = $component->makeInputGroupClass(true);
+        $iClass = $component->makeItemClass(true);
+
+        $this->assertStringContainsString('input-group', $iGroupClass);
+        $this->assertStringContainsString('input-group-lg', $iGroupClass);
+        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('adminlte-invalid-iswgroup', $iGroupClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -180,6 +180,20 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 
+    public function testTextEditorComponent()
+    {
+        $component = new Components\TextEditor(
+            'name', null, 'lg', null, null, 'igroup-custom-class'
+        );
+
+        $iGroupClass = $component->makeInputGroupClass(true);
+
+        $this->assertStringContainsString('input-group', $iGroupClass);
+        $this->assertStringContainsString('input-group-lg', $iGroupClass);
+        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('adminlte-invalid-itegroup', $iGroupClass);
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Individual tool components tests.


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Improve the invalid style for **input-switch**, **input-slider** and **text-editor** components.
- Add tests to cover these changes.

**Previously:**

![switch_prev](https://user-images.githubusercontent.com/63609705/113206198-8bc0d000-9245-11eb-8c01-799c635fe631.png)
![slider_prev](https://user-images.githubusercontent.com/63609705/113206204-8cf1fd00-9245-11eb-88d3-f800d626873c.png)
![Screenshot_2021-03-31 Laradmin Tests(1)](https://user-images.githubusercontent.com/63609705/113222802-29c09480-925e-11eb-8530-4d0ebd643469.png)

**Now:**

![slider_now](https://user-images.githubusercontent.com/63609705/113206201-8c596680-9245-11eb-901a-3a10593cd774.png)
![switch_now](https://user-images.githubusercontent.com/63609705/113206199-8c596680-9245-11eb-85b7-1dbd56eca4c0.png)
![Screenshot_2021-03-31 Laradmin Tests](https://user-images.githubusercontent.com/63609705/113222830-347b2980-925e-11eb-8bce-79e921b2a89c.png)

#### Checklist

- [x] I tested these changes.
