### PR TITLE
Fix slide-down visual issue on sidebar after loading

### DIFF
--- a/resources/views/partials/sidebar/left-sidebar.blade.php
+++ b/resources/views/partials/sidebar/left-sidebar.blade.php
@@ -9,7 +9,7 @@
 
     {{-- Sidebar menu --}}
     <div class="sidebar">
-        <nav class="mt-2">
+        <nav class="pt-2">
             <ul class="nav nav-pills nav-sidebar flex-column {{ config('adminlte.classes_sidebar_nav', '') }}"
                 data-widget="treeview" role="menu"
                 @if(config('adminlte.sidebar_nav_animation_speed') != 300)


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix a **slide-down** visual issue on the sidebar after loading page due to use `mt-2` class on the `<nav>` element inside the `.sidebar`. The issue can be seen on next video. Note how the elements on the sidebar are displaced down after the page loads, like if the `mt-2` class is applied some milliseconds after the page loads.

https://user-images.githubusercontent.com/63609705/113611028-4f65e900-9624-11eb-80ba-7de96eefd748.mp4

The problem disappear if we use `pt-2` class instead of the previous `mt-2`

#### Checklist

- [ ] I tested these changes.