### PR TITLE
Integrate the new navbar search provided by AdminLTE v3.1.0

### DIFF
--- a/resources/views/partials/navbar/menu-item-search-form.blade.php
+++ b/resources/views/partials/navbar/menu-item-search-form.blade.php
@@ -1,13 +1,35 @@
-<form action="{{ $item['href'] }}" method="{{ $item['method'] }}" class="form-inline mx-2">
-    {{ csrf_field() }}
-    <div class="input-group">
-        <input class="form-control form-control-navbar" type="search" name="{{ $item['input_name'] }}"
-               placeholder="{{ $item['text'] }}" aria-label="{{ $item['aria-label'] ?? $item['text'] }}">
-        <div class="input-group-append">
-            <button class="btn btn-navbar" type="submit">
-                <i class="fas fa-search"></i>
-            </button>
-        </div>
-    </div>
-</form>
+<li class="nav-item">
 
+    {{-- Search toggle button --}}
+    <a class="nav-link" data-widget="navbar-search" href="#" role="button">
+        <i class="fas fa-search"></i>
+    </a>
+
+    {{-- Search bar --}}
+    <div class="navbar-search-block">
+        <form class="form-inline" action="{{ $item['href'] }}" method="{{ $item['method'] }}">
+            {{ csrf_field() }}
+
+            <div class="input-group">
+
+                {{-- Search input --}}
+                <input class="form-control form-control-navbar" type="search"
+                    placeholder="{{ $item['text'] }}"
+                    name="{{ $item['input_name'] }}"
+                    aria-label="{{ $item['text'] }}">
+
+                {{-- Search buttons --}}
+                <div class="input-group-append">
+                    <button class="btn btn-navbar" type="submit">
+                        <i class="fas fa-search"></i>
+                    </button>
+                    <button class="btn btn-navbar" type="button" data-widget="navbar-search">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+
+            </div>
+        </form>
+    </div>
+
+</li>

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -7,6 +7,13 @@ use JeroenNoten\LaravelAdminLte\Helpers\MenuItemHelper;
 class SearchFilter implements FilterInterface
 {
     /**
+     * The default name attribute to be used on the search input.
+     *
+     * @var string
+     */
+    protected $defInputName = 'adminlteSearch';
+
+    /**
      * Transforms a menu item. Makes the proper search bar configuration.
      *
      * @param array $item A menu item
@@ -29,7 +36,7 @@ class SearchFilter implements FilterInterface
         // Configure search bar input name.
 
         if (! isset($item['input_name'])) {
-            $item['input_name'] = 'q';
+            $item['input_name'] = $this->defInputName;
         }
 
         return $item;

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -908,7 +908,7 @@ class BuilderTest extends TestCase
         $builder->add(['text' => 'search', 'search' => true]);
         $builder->add(['text' => 'Search', 'search' => true, 'input_name' => 'foo']);
 
-        $this->assertEquals('q', $builder->menu[0]['input_name']);
+        $this->assertEquals('adminlteSearch', $builder->menu[0]['input_name']);
         $this->assertEquals('foo', $builder->menu[1]['input_name']);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Modifications to integrate the new navbar search available in the new **AdminLTE v3.1.0**. A search icon will be displayed on the navbar:

![Screenshot_2021-04-10 AdminLTE 3 Dashboard 3](https://user-images.githubusercontent.com/63609705/114281448-cb8d7180-9a14-11eb-9e24-1a827d717454.png)

When click on the icon, the search bar will be opened over all the navbar:

![Screenshot_2021-04-10 AdminLTE 3 Dashboard 3(1)](https://user-images.githubusercontent.com/63609705/114281447-caf4db00-9a14-11eb-9538-a42432787a25.png)

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
