### PR TITLE
fix issues with alert component

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -7,9 +7,16 @@
         </button>
     @endisset
 
-    {{-- Alert title --}}
-    @if(!is_null($title))
-        <h5>@if($icon)<i class="icon {{ $icon }}"></i>@endif {{ $title }}</h5>
+    @if(! empty($title) || ! empty($icon))
+        <h5>
+            @if(! empty($icon))
+                <i class="icon {{ $icon }}"></i>
+            @endif
+
+            @if(! empty($title))
+                {{ $title }}
+            @endif
+        </h5>
     @endif
 
     {{-- Alert content --}}

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -8,7 +8,9 @@
     @endisset
 
     {{-- Alert title --}}
-    <h5><i class="icon {{ $icon }}"></i> {{ $title }}</h5>
+    @if(!is_null($title))
+        <h5>@if($icon)<i class="icon {{ $icon }}"></i>@endif {{ $title }}</h5>
+    @endif
 
     {{-- Alert content --}}
     {{ $slot }}

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -7,6 +7,7 @@
         </button>
     @endisset
 
+    {{-- Alert header --}}
     @if(! empty($title) || ! empty($icon))
         <h5>
             @if(! empty($icon))

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -83,7 +83,7 @@ class Alert extends Component
         if (! empty($this->theme)) {
             $classes[] = "alert-{$this->theme}";
         } else {
-            $classes[] = "border";
+            $classes[] = 'border';
         }
 
         if (! empty($this->dismissable)) {

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -57,12 +57,18 @@ class Alert extends Component
      * @return void
      */
     public function __construct(
-        $theme = 'info', $icon = null, $title = null, $dismissable = null
+        $theme = null, $icon = null, $title = null, $dismissable = null
     ) {
         $this->theme = $theme;
-        $this->icon = $icon ?? $this->icons[$theme] ?? null;
+        $this->icon = $icon;
         $this->title = $title;
         $this->dismissable = $dismissable;
+
+        // When a theme is provided, use the theme icon if no icon provided.
+
+        if (empty($icon) && ! empty($theme)) {
+            $this->icon = $this->icons[$theme];
+        }
     }
 
     /**
@@ -72,7 +78,13 @@ class Alert extends Component
      */
     public function makeAlertClass()
     {
-        $classes = ['alert', "alert-{$this->theme}"];
+        $classes = ['alert'];
+
+        if (! empty($this->theme)) {
+            $classes[] = "alert-{$this->theme}";
+        } else {
+            $classes[] = "border";
+        }
 
         if (! empty($this->dismissable)) {
             $classes[] = 'alert-dismissable';

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -60,7 +60,7 @@ class Alert extends Component
         $theme = 'info', $icon = null, $title = null, $dismissable = null
     ) {
         $this->theme = $theme;
-        $this->icon = $icon ?? $this->icons[$theme];
+        $this->icon = $icon ?? $this->icons[$theme] ?? null;
         $this->title = $title;
         $this->dismissable = $dismissable;
     }

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -64,9 +64,10 @@ class Alert extends Component
         $this->title = $title;
         $this->dismissable = $dismissable;
 
-        // When a theme is provided, use the theme icon if no icon provided.
+        // When a theme is provided, use the default theme icon if no other
+        // icon is provided.
 
-        if (empty($icon) && ! empty($theme)) {
+        if (! isset($icon) && ! empty($theme)) {
             $this->icon = $this->icons[$theme];
         }
     }

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -275,6 +275,17 @@ class ComponentsTest extends TestCase
 
     public function testAlertComponent()
     {
+        // Test without theme.
+
+        $component = new Components\Alert(null, null, null);
+
+        $aClass = $component->makeAlertClass();
+
+        $this->assertStringContainsString('alert', $aClass);
+        $this->assertStringContainsString('border', $aClass);
+
+        // Test with theme.
+
         $component = new Components\Alert('danger', null, null, true);
 
         $aClass = $component->makeAlertClass();


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?
This PR fixes #859 

Changes in `alert.blade.php` ensure that:
1. If title is not defined, the h5 header with icon and title is not generated
2. Passing `title=""` generates the header with icon and empty title.
3. Passing `icon=""` does not generate the font-awesome icon element.

Change in `Alert.php` ensures that if a custom `theme` attribute is passed, it does not generate an error.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
