### PR TITLE
Improve navbar search to use a new type property

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -225,8 +225,8 @@ return [
 
     'menu' => [
         [
-            'text' => 'search',
-            'search' => true,
+            'type'   => 'navbar-search',
+            'text'   => 'search',
             'topnav' => true,
         ],
         [

--- a/resources/views/partials/navbar/menu-item.blade.php
+++ b/resources/views/partials/navbar/menu-item.blade.php
@@ -1,6 +1,6 @@
 @inject('menuItemHelper', 'JeroenNoten\LaravelAdminLte\Helpers\MenuItemHelper')
 
-@if ($menuItemHelper->isSearchBar($item))
+@if ($menuItemHelper->isNavbarSearch($item))
 
     {{-- Search form --}}
     @include('adminlte::partials.navbar.menu-item-search-form')

--- a/resources/views/partials/sidebar/menu-item.blade.php
+++ b/resources/views/partials/sidebar/menu-item.blade.php
@@ -5,7 +5,7 @@
     {{-- Header --}}
     @include('adminlte::partials.sidebar.menu-item-header')
 
-@elseif ($menuItemHelper->isSearchBar($item))
+@elseif ($menuItemHelper->isSidebarSearch($item))
 
     {{-- Search form --}}
     @include('adminlte::partials.sidebar.menu-item-search-form')

--- a/resources/views/partials/sidebar/menu-item.blade.php
+++ b/resources/views/partials/sidebar/menu-item.blade.php
@@ -5,7 +5,7 @@
     {{-- Header --}}
     @include('adminlte::partials.sidebar.menu-item-header')
 
-@elseif ($menuItemHelper->isSidebarSearch($item))
+@elseif ($menuItemHelper->isLegacySearch($item))
 
     {{-- Search form --}}
     @include('adminlte::partials.sidebar.menu-item-search-form')

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -53,7 +53,9 @@ class MenuItemHelper
      */
     public static function isNavbarCustomSearch($item)
     {
-        return isset($item['type']) && $item['type'] === 'navbar-search';
+        return isset($item['text']) &&
+               isset($item['type']) &&
+               $item['type'] === 'navbar-search';
     }
 
     /**

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -2,6 +2,11 @@
 
 namespace JeroenNoten\LaravelAdminLte\Helpers;
 
+/**
+ * TODO: On the future, all menu items should have a type property. We can use
+ * the type property to easy distinguish the item type and avoid guessing it by
+ * they properties.
+ */
 class MenuItemHelper
 {
     /**
@@ -28,16 +33,27 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a search bar.
+     * Check if a menu item is a sidebar search.
      *
      * @param mixed $item
      * @return bool
      */
-    public static function isSearchBar($item)
+    public static function isSidebarSearch($item)
     {
         return isset($item['text']) &&
                isset($item['search']) &&
                $item['search'];
+    }
+
+    /**
+     * Check if a menu item is a navbar search.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isNavbarSearch($item)
+    {
+        return isset($item['type']) && $item['type'] === 'navbar-search';
     }
 
     /**
@@ -67,6 +83,18 @@ class MenuItemHelper
     }
 
     /**
+     * Check if a menu item is a search item (for sidebar or navbar).
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isSearchItem($item)
+    {
+        return self::isSidebarSearch($item) ||
+               self::isNavbarSearch($item);
+    }
+
+    /**
      * Check if a menu item is valid for the sidebar section.
      *
      * @param mixed $item
@@ -75,7 +103,7 @@ class MenuItemHelper
     public static function isValidSidebarItem($item)
     {
         return self::isHeader($item) ||
-               self::isSearchBar($item) ||
+               self::isSidebarSearch($item) ||
                self::isSubmenu($item) ||
                self::isLink($item);
     }
@@ -88,7 +116,9 @@ class MenuItemHelper
      */
     public static function isValidNavbarItem($item)
     {
-        return self::isValidSidebarItem($item) && ! self::isHeader($item);
+        return self::isNavbarSearch($item) ||
+               self::isSubmenu($item) ||
+               self::isLink($item);
     }
 
     /**

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -33,12 +33,12 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a sidebar search.
+     * Check if a menu item is a legacy search bar.
      *
      * @param mixed $item
      * @return bool
      */
-    public static function isSidebarSearch($item)
+    public static function isLegacySearch($item)
     {
         return isset($item['text']) &&
                isset($item['search']) &&
@@ -46,14 +46,25 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a navbar search.
+     * Check if a menu item is a new navbar search bar.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isNewNavbarSearch($item)
+    {
+        return isset($item['type']) && $item['type'] === 'navbar-search';
+    }
+
+    /**
+     * Check if a menu item is a navbar search item (legacy or new).
      *
      * @param mixed $item
      * @return bool
      */
     public static function isNavbarSearch($item)
     {
-        return isset($item['type']) && $item['type'] === 'navbar-search';
+        return self::isLegacySearch($item) || self::isNewNavbarSearch($item);
     }
 
     /**
@@ -90,7 +101,7 @@ class MenuItemHelper
      */
     public static function isSearchItem($item)
     {
-        return self::isSidebarSearch($item) ||
+        return self::isLegacySearch($item) ||
                self::isNavbarSearch($item);
     }
 
@@ -103,7 +114,7 @@ class MenuItemHelper
     public static function isValidSidebarItem($item)
     {
         return self::isHeader($item) ||
-               self::isSidebarSearch($item) ||
+               self::isLegacySearch($item) ||
                self::isSubmenu($item) ||
                self::isLink($item);
     }

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -46,12 +46,12 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a new navbar search bar.
+     * Check if a menu item is a navbar custom search bar.
      *
      * @param mixed $item
      * @return bool
      */
-    public static function isNewNavbarSearch($item)
+    public static function isNavbarCustomSearch($item)
     {
         return isset($item['type']) && $item['type'] === 'navbar-search';
     }
@@ -64,7 +64,8 @@ class MenuItemHelper
      */
     public static function isNavbarSearch($item)
     {
-        return self::isLegacySearch($item) || self::isNewNavbarSearch($item);
+        return self::isLegacySearch($item) ||
+               self::isNavbarCustomSearch($item);
     }
 
     /**

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -21,7 +21,7 @@ class SearchFilter implements FilterInterface
      */
     public function transform($item)
     {
-        if (! MenuItemHelper::isSearchBar($item)) {
+        if (! MenuItemHelper::isSearchItem($item)) {
             return $item;
         }
 

--- a/tests/AdminLteTest.php
+++ b/tests/AdminLteTest.php
@@ -120,12 +120,11 @@ class AdminLteTest extends TestCase
         config(['adminlte.layout_topnav' => true]);
         $menu = $this->makeAdminLte()->menu('navbar-left');
 
-        $this->assertCount(7, $menu);
+        $this->assertCount(8, $menu);
         $this->assertArrayNotHasKey(0, $menu);
         $this->assertArrayNotHasKey(6, $menu);
         $this->assertArrayNotHasKey(7, $menu);
         $this->assertArrayNotHasKey(10, $menu);
-        $this->assertArrayNotHasKey(11, $menu);
         $this->assertEquals('sidebar', $menu[1]['text']);
         $this->assertEquals('topnavLF', $menu[2]['text']);
         $this->assertEquals('topnavRF', $menu[3]['text']);
@@ -133,6 +132,7 @@ class AdminLteTest extends TestCase
         $this->assertEquals('topnavLT', $menu[5]['text']);
         $this->assertEquals('searchLT', $menu[8]['text']);
         $this->assertEquals('submenu', $menu[9]['text']);
+        $this->assertEquals('search', $menu[11]['text']);
     }
 
     public function testMenuNavbarRightFilter()

--- a/tests/AdminLteTest.php
+++ b/tests/AdminLteTest.php
@@ -41,7 +41,7 @@ class AdminLteTest extends TestCase
 
         // Add (1) search bar to the navbar menu.
 
-        $event->menu->add(['text' => 'searchLT', 'search' => true, 'topnav' => true]);
+        $event->menu->add(['text' => 'searchLT', 'type' => 'navbar-search', 'topnav' => true]);
 
         // Add (1) submenu to the sidebar menu.
 
@@ -50,12 +50,17 @@ class AdminLteTest extends TestCase
         // Add (1) invalid item.
 
         $event->menu->add(['text' => 'invalid']);
+
+        // Add (1) search bar to the sidebar menu.
+
+        $event->menu->add(['text' => 'search', 'search' => true]);
     }
 
     public function testMenuWithoutFilters()
     {
         $menu = $this->makeAdminLte()->menu();
-        $this->assertCount(11, $menu);
+
+        $this->assertCount(12, $menu);
         $this->assertEquals('header', $menu[0]['header']);
         $this->assertEquals('sidebar', $menu[1]['text']);
         $this->assertEquals('topnavLF', $menu[2]['text']);
@@ -67,12 +72,14 @@ class AdminLteTest extends TestCase
         $this->assertEquals('searchLT', $menu[8]['text']);
         $this->assertEquals('submenu', $menu[9]['text']);
         $this->assertEquals('invalid', $menu[10]['text']);
+        $this->assertEquals('search', $menu[11]['text']);
     }
 
     public function testMenuSidebarFilter()
     {
         $menu = $this->makeAdminLte()->menu('sidebar');
-        $this->assertCount(6, $menu);
+
+        $this->assertCount(7, $menu);
         $this->assertArrayNotHasKey(5, $menu);
         $this->assertArrayNotHasKey(6, $menu);
         $this->assertArrayNotHasKey(7, $menu);
@@ -84,6 +91,7 @@ class AdminLteTest extends TestCase
         $this->assertEquals('topnavRF', $menu[3]['text']);
         $this->assertEquals('topnavUF', $menu[4]['text']);
         $this->assertEquals('submenu', $menu[9]['text']);
+        $this->assertEquals('search', $menu[11]['text']);
     }
 
     public function testMenuNavbarLeftFilter()
@@ -91,8 +99,8 @@ class AdminLteTest extends TestCase
         // Test with config 'adminlte.layout_topnav' => null.
 
         config(['adminlte.layout_topnav' => null]);
-
         $menu = $this->makeAdminLte()->menu('navbar-left');
+
         $this->assertCount(2, $menu);
         $this->assertArrayNotHasKey(0, $menu);
         $this->assertArrayNotHasKey(1, $menu);
@@ -103,19 +111,21 @@ class AdminLteTest extends TestCase
         $this->assertArrayNotHasKey(7, $menu);
         $this->assertArrayNotHasKey(9, $menu);
         $this->assertArrayNotHasKey(10, $menu);
+        $this->assertArrayNotHasKey(11, $menu);
         $this->assertEquals('topnavLT', $menu[5]['text']);
         $this->assertEquals('searchLT', $menu[8]['text']);
 
-        // Set with config 'adminlte.layout_topnav' => true.
+        // Test with config 'adminlte.layout_topnav' => true.
 
         config(['adminlte.layout_topnav' => true]);
-
         $menu = $this->makeAdminLte()->menu('navbar-left');
+
         $this->assertCount(7, $menu);
         $this->assertArrayNotHasKey(0, $menu);
         $this->assertArrayNotHasKey(6, $menu);
         $this->assertArrayNotHasKey(7, $menu);
         $this->assertArrayNotHasKey(10, $menu);
+        $this->assertArrayNotHasKey(11, $menu);
         $this->assertEquals('sidebar', $menu[1]['text']);
         $this->assertEquals('topnavLF', $menu[2]['text']);
         $this->assertEquals('topnavRF', $menu[3]['text']);
@@ -128,6 +138,7 @@ class AdminLteTest extends TestCase
     public function testMenuNavbarRightFilter()
     {
         $menu = $this->makeAdminLte()->menu('navbar-right');
+
         $this->assertCount(1, $menu);
         $this->assertArrayNotHasKey(0, $menu);
         $this->assertArrayNotHasKey(1, $menu);
@@ -139,12 +150,14 @@ class AdminLteTest extends TestCase
         $this->assertArrayNotHasKey(8, $menu);
         $this->assertArrayNotHasKey(9, $menu);
         $this->assertArrayNotHasKey(10, $menu);
+        $this->assertArrayNotHasKey(11, $menu);
         $this->assertEquals('topnavRT', $menu[6]['text']);
     }
 
     public function testMenuNavbarUserFilter()
     {
         $menu = $this->makeAdminLte()->menu('navbar-user');
+
         $this->assertCount(1, $menu);
         $this->assertArrayNotHasKey(0, $menu);
         $this->assertArrayNotHasKey(1, $menu);
@@ -156,6 +169,7 @@ class AdminLteTest extends TestCase
         $this->assertArrayNotHasKey(8, $menu);
         $this->assertArrayNotHasKey(9, $menu);
         $this->assertArrayNotHasKey(10, $menu);
+        $this->assertArrayNotHasKey(11, $menu);
         $this->assertEquals('topnavUT', $menu[7]['text']);
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the new **navbar search** menu item to use a new `type` property. The `type` property will help to easy distinguish the menu items. On the future we expect to use this property on all the menu items in order to simplify recognition logic.

**IMPORTANT:**

This will introduce a minor breaking change, since the menu configuration for the navbar search should be changed to use the new `type => 'navbar-search'` property instead of the old `search => true` property.

#### Checklist

- [x] I tested these changes.
