### PR TITLE
Add margin right to icons of some components

### DIFF
--- a/resources/views/components/callout.blade.php
+++ b/resources/views/components/callout.blade.php
@@ -3,7 +3,7 @@
     {{-- Callout title --}}
     @if(! empty($title) || ! empty($icon))
         <h5 @isset($titleClass) class="{{ $titleClass }}" @endisset>
-            @isset($icon) <i class="{{ $icon }}"></i> @endisset
+            @isset($icon) <i class="{{ $icon }} mr-2"></i> @endisset
             @isset($title) {{ $title }} @endisset
         </h5>
     @endif

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -5,7 +5,7 @@
 
         {{-- Title --}}
         <h3 class="{{ $makeCardTitleClass() }}">
-            @isset($icon)<i class="{{ $icon }}"></i>@endisset
+            @isset($icon)<i class="{{ $icon }} mr-2"></i>@endisset
             @isset($title){{ $title }}@endisset
         </h3>
 

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -7,7 +7,7 @@
         {{--Modal header --}}
         <div class="{{ $makeModalHeaderClass() }}">
             <h4 class="modal-title">
-                @isset($icon)<i class="{{ $icon }}"></i>@endisset
+                @isset($icon)<i class="{{ $icon }} mr-2"></i>@endisset
                 @isset($title){{ $title }}@endisset
             </h4>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add `mr-2` (margin right) class to icons (when available) of the next components:
- **Modal**
- **Card**
- **Callout**

#### Checklist

- [x] I tested these changes.
