### PR TITLE
Integrate new sidebar search bars

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -224,7 +224,7 @@ return [
     */
 
     'menu' => [
-        // Navbar items:        
+        // Navbar items:
         [
             'type'         => 'navbar-search',
             'text'         => 'search',

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -224,10 +224,17 @@ return [
     */
 
     'menu' => [
+        // Navbar items:        
         [
-            'type'   => 'navbar-search',
-            'text'   => 'search',
-            'topnav' => true,
+            'type'         => 'navbar-search',
+            'text'         => 'search',
+            'topnav_right' => true,
+        ],
+
+        // Sidebar items:
+        [
+            'type' => 'sidebar-menu-search',
+            'text' => 'search',
         ],
         [
             'text' => 'blog',

--- a/resources/views/partials/navbar/menu-item-search-form.blade.php
+++ b/resources/views/partials/navbar/menu-item-search-form.blade.php
@@ -14,8 +14,9 @@
 
                 {{-- Search input --}}
                 <input class="form-control form-control-navbar" type="search"
-                    placeholder="{{ $item['text'] }}"
+                    @isset($item['id']) id="{{ $item['id'] }}" @endisset
                     name="{{ $item['input_name'] }}"
+                    placeholder="{{ $item['text'] }}"
                     aria-label="{{ $item['text'] }}">
 
                 {{-- Search buttons --}}

--- a/resources/views/partials/sidebar/menu-item-search-menu.blade.php
+++ b/resources/views/partials/sidebar/menu-item-search-menu.blade.php
@@ -1,9 +1,7 @@
 <li>
 
-    <form class="form-inline my-2" action="{{ $item['href'] }}" method="{{ $item['method'] }}">
-        {{ csrf_field() }}
-
-        <div class="input-group">
+    <div class="form-inline my-2">
+        <div class="input-group" data-widget="sidebar-search" data-arrow-sign="&raquo;">
 
             {{-- Search input --}}
             <input class="form-control form-control-sidebar" type="search"
@@ -14,12 +12,12 @@
 
             {{-- Search button --}}
             <div class="input-group-append">
-                <button class="btn btn-sidebar" type="submit">
+                <button class="btn btn-sidebar">
                     <i class="fas fa-fw fa-search"></i>
                 </button>
             </div>
 
         </div>
-    </form>
+    </div>
 
 </li>

--- a/resources/views/partials/sidebar/menu-item.blade.php
+++ b/resources/views/partials/sidebar/menu-item.blade.php
@@ -5,10 +5,15 @@
     {{-- Header --}}
     @include('adminlte::partials.sidebar.menu-item-header')
 
-@elseif ($menuItemHelper->isLegacySearch($item))
+@elseif ($menuItemHelper->isLegacySearch($item) || $menuItemHelper->isSidebarCustomSearch($item))
 
     {{-- Search form --}}
     @include('adminlte::partials.sidebar.menu-item-search-form')
+
+@elseif ($menuItemHelper->isSidebarMenuSearch($item))
+
+    {{-- Search menu --}}
+    @include('adminlte::partials.sidebar.menu-item-search-menu')
 
 @elseif ($menuItemHelper->isSubmenu($item))
 

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -33,6 +33,19 @@ class MenuItemHelper
     }
 
     /**
+     * Check if a menu item is a submenu.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isSubmenu($item)
+    {
+        return isset($item['text']) &&
+               isset($item['submenu']) &&
+               is_array($item['submenu']);
+    }
+
+    /**
      * Check if a menu item is a legacy search bar.
      *
      * @param mixed $item
@@ -59,6 +72,32 @@ class MenuItemHelper
     }
 
     /**
+     * Check if a menu item is a sidebar custom search bar.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isSidebarCustomSearch($item)
+    {
+        return isset($item['text']) &&
+               isset($item['type']) &&
+               $item['type'] === 'sidebar-custom-search';
+    }
+
+    /**
+     * Check if a menu item is a sidebar menu search bar.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isSidebarMenuSearch($item)
+    {
+        return isset($item['text']) &&
+               isset($item['type']) &&
+               $item['type'] === 'sidebar-menu-search';
+    }
+
+    /**
      * Check if a menu item is a navbar search item (legacy or new).
      *
      * @param mixed $item
@@ -71,16 +110,28 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a submenu.
+     * Check if a menu item is a sidebar search item (legacy or new).
      *
      * @param mixed $item
      * @return bool
      */
-    public static function isSubmenu($item)
+    public static function isSidebarSearch($item)
     {
-        return isset($item['text']) &&
-               isset($item['submenu']) &&
-               is_array($item['submenu']);
+        return self::isLegacySearch($item) ||
+               self::isSidebarMenuSearch($item) ||
+               self::isSidebarCustomSearch($item);
+    }
+
+    /**
+     * Check if a menu item is a search item (for sidebar or navbar).
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isSearchItem($item)
+    {
+        return self::isNavbarSearch($item) ||
+               self::isSidebarSearch($item);
     }
 
     /**
@@ -97,18 +148,6 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a search item (for sidebar or navbar).
-     *
-     * @param mixed $item
-     * @return bool
-     */
-    public static function isSearchItem($item)
-    {
-        return self::isLegacySearch($item) ||
-               self::isNavbarSearch($item);
-    }
-
-    /**
      * Check if a menu item is valid for the sidebar section.
      *
      * @param mixed $item
@@ -117,7 +156,7 @@ class MenuItemHelper
     public static function isValidSidebarItem($item)
     {
         return self::isHeader($item) ||
-               self::isLegacySearch($item) ||
+               self::isSidebarSearch($item) ||
                self::isSubmenu($item) ||
                self::isLink($item);
     }

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -123,18 +123,6 @@ class MenuItemHelper
     }
 
     /**
-     * Check if a menu item is a search item (for sidebar or navbar).
-     *
-     * @param mixed $item
-     * @return bool
-     */
-    public static function isSearchItem($item)
-    {
-        return self::isNavbarSearch($item) ||
-               self::isSidebarSearch($item);
-    }
-
-    /**
      * Check if a menu item is allowed to be shown.
      *
      * @param mixed $item

--- a/src/Menu/Filters/SearchFilter.php
+++ b/src/Menu/Filters/SearchFilter.php
@@ -21,7 +21,10 @@ class SearchFilter implements FilterInterface
      */
     public function transform($item)
     {
-        if (! MenuItemHelper::isSearchItem($item)) {
+        $isSearch = MenuItemHelper::isNavbarSearch($item) ||
+                    MenuItemHelper::isSidebarSearch($item);
+
+        if (! $isSearch) {
             return $item;
         }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -87,7 +87,7 @@ class ServiceProviderTest extends TestCase
         $adminlte = $this->app->make(AdminLte::class);
         $menu = $adminlte->menu();
 
-        $this->assertCount(10, $menu);
+        $this->assertCount(11, $menu);
         $this->assertEquals('search', $menu[0]['text']);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Integration of the new sidebar search bars available in **AdminLTE v3.1.0**
- Add support to a new `'type' => 'sidebar-menu-search' ` that will automatically search on the available sidebar menu items. The required configuration example is:
  ```php
  [
      'type' => 'sidebar-menu-search',
      'text' => 'Menu search',
  ]
  ```
  ![Screenshot_2021-04-16 AdminLTE 3 Widgets](https://user-images.githubusercontent.com/63609705/115074620-52889100-9ed0-11eb-9c88-569653190023.png)

- The legacy sidebar search is still supported with old configuration or a new one using `'type' => 'sidebar-custom-search' `. This search will submit data to the configured `url` and you need to create a **CUSTOM** controller and response to handle it. This was the previous logic for search bar (navbar or sidebar). The configuration example is:
  **Legacy**
  ```php
  [
      'text' => 'Custom search',
      'search' => true,
      'url' => 'sidebar/search',
      'method' => 'get' /*or 'post'*/,
  ]
  ```
  **New**
  ```php
  [
      'type' => 'sidebar-custom-search',
      'text' => 'Custom search',
      'url' => 'sidebar/search',
      'method' => 'get' /*or 'post'*/,
  ]
  ```

- All the new sidebar search bars solve the responsive issue mentioned in #674 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
