### PR TITLE
Fix sidebar menu item search

### DIFF
--- a/resources/views/partials/sidebar/menu-item-search-menu.blade.php
+++ b/resources/views/partials/sidebar/menu-item-search-menu.blade.php
@@ -6,7 +6,6 @@
             {{-- Search input --}}
             <input class="form-control form-control-sidebar" type="search"
                 @isset($item['id']) id="{{ $item['id'] }}" @endisset
-                name="{{ $item['input_name'] }}"
                 placeholder="{{ $item['text'] }}"
                 aria-label="{{ $item['text'] }}">
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

The new sidebar search over the menu items do not need a `name` attribute.

#### Checklist

- [x] I tested these changes.