### PR TITLE
Improves and fix issues on the input-group-component

### DIFF
--- a/resources/views/components/date-range.blade.php
+++ b/resources/views/components/date-range.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Date Range Input --}}
-    <input id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite
 
@@ -28,7 +28,7 @@
             }
         @endisset
 
-        $('#{{ $name }}').daterangepicker(usrCfg);
+        $('#{{ $id }}').daterangepicker(usrCfg);
     })
 
 </script>

--- a/resources/views/components/input-color.blade.php
+++ b/resources/views/components/input-color.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Input Color --}}
-    <input id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite
 
@@ -19,16 +19,16 @@
 
         let setAddonColor = function()
         {
-            let color = $('#{{ $name }}').data('colorpicker').getValue();
+            let color = $('#{{ $id }}').data('colorpicker').getValue();
 
-            $('#{{ $name }}').closest('.input-group')
+            $('#{{ $id }}').closest('.input-group')
                 .find('.input-group-text > i')
                 .css('color', color);
         }
 
         // Init the plugin and register the change event listener.
 
-        $('#{{ $name }}').colorpicker( @json($config) )
+        $('#{{ $id }}').colorpicker( @json($config) )
             .on('change', setAddonColor);
 
         // Set the initial color for the addon.

--- a/resources/views/components/input-date.blade.php
+++ b/resources/views/components/input-date.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Input Date --}}
-    <input id="{{ $name }}" name="{{ $name }}" data-target="#{{ $name }}" data-toggle="datetimepicker"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input id="{{ $id }}" name="{{ $name }}" data-target="#{{ $id }}" data-toggle="datetimepicker"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite
 
@@ -15,7 +15,7 @@
 
     $(() => {
         let usrCfg = _adminlte_idUtils.parseCfg( @json($config) );
-        $('#{{ $name }}').datetimepicker(usrCfg);
+        $('#{{ $id }}').datetimepicker(usrCfg);
     })
 
 </script>

--- a/resources/views/components/input-file.blade.php
+++ b/resources/views/components/input-file.blade.php
@@ -5,11 +5,11 @@
     <div class="custom-file">
 
         {{-- Custom file input --}}
-        <input type="file" id="{{ $name }}" name="{{ $name }}"
-            {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+        <input type="file" id="{{ $id }}" name="{{ $name }}"
+            {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
         {{-- Custom file label --}}
-        <label class="custom-file-label text-truncate" for="{{ $name }}"
+        <label class="custom-file-label text-truncate" for="{{ $id }}"
             @isset($legend) data-browse="{{ $legend }}" @endisset>
             {{ $placeholder }}
         </label>

--- a/resources/views/components/input-group-component.blade.php
+++ b/resources/views/components/input-group-component.blade.php
@@ -2,13 +2,13 @@
 
     {{-- Input label --}}
     @isset($label)
-        <label for="{{ $name }}" @isset($labelClass) class="{{ $labelClass }}" @endisset>
+        <label for="{{ $id }}" @isset($labelClass) class="{{ $labelClass }}" @endisset>
             {{ $label }}
         </label>
     @endisset
 
     {{-- Input group --}}
-    <div class="{{ $makeInputGroupClass($errors->first($name)) }}">
+    <div class="{{ $makeInputGroupClass($errors->first($errorKey)) }}">
 
         {{-- Input prepend slot --}}
         @isset($prependSlot)
@@ -27,7 +27,7 @@
 
     {{-- Error feedback --}}
     @if(! isset($disableFeedback))
-        @error($name)
+        @error($errorKey)
             <span class="invalid-feedback d-block" role="alert">
                 <strong>{{ $message }}</strong>
             </span>
@@ -58,4 +58,3 @@
 </style>
 @endpush
 @endonce
-

--- a/resources/views/components/input-slider.blade.php
+++ b/resources/views/components/input-slider.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Input Slider --}}
-    <input id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite
 
@@ -45,7 +45,7 @@
 
         // Initialize the plugin.
 
-        let slider = $('#{{ $name }}').bootstrapSlider(usrCfg);
+        let slider = $('#{{ $id }}').bootstrapSlider(usrCfg);
 
         // Fix height conflict when orientation is vertical.
 

--- a/resources/views/components/input-switch.blade.php
+++ b/resources/views/components/input-switch.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Input Switch --}}
-    <input type="checkbox" id="{{ $name }}" name="{{ $name }}" value="true"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input type="checkbox" id="{{ $id }}" name="{{ $name }}" value="true"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite
 
@@ -14,7 +14,7 @@
 <script>
 
     $(() => {
-        $('#{{ $name }}').bootstrapSwitch( @json($config) );
+        $('#{{ $id }}').bootstrapSwitch( @json($config) );
     })
 
 </script>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -3,7 +3,7 @@
 @section('input_group_item')
 
     {{-- Input --}}
-    <input id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <input id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
 
 @overwrite

--- a/resources/views/components/select-bs.blade.php
+++ b/resources/views/components/select-bs.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Select --}}
-    <select id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <select id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
         {{ $slot }}
     </select>
 
@@ -16,7 +16,7 @@
 <script>
 
     $(() => {
-        $('#{{ $name }}').selectpicker( @json($config) );
+        $('#{{ $id }}').selectpicker( @json($config) );
     })
 
 </script>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Select --}}
-    <select id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <select id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
         {{ $slot }}
     </select>
 

--- a/resources/views/components/select2.blade.php
+++ b/resources/views/components/select2.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Select --}}
-    <select id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}>
+    <select id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
         {{ $slot }}
     </select>
 
@@ -16,7 +16,7 @@
 <script>
 
     $(() => {
-        $('#{{ $name }}').select2( @json($config) );
+        $('#{{ $id }}').select2( @json($config) );
     })
 
 </script>

--- a/resources/views/components/text-editor.blade.php
+++ b/resources/views/components/text-editor.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Summernote Textarea --}}
-    <textarea id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}
+    <textarea id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}
     >{{ $slot }}</textarea>
 
 @overwrite
@@ -25,12 +25,12 @@
 
         // Initialize the plugin.
 
-        $('#{{ $name }}').summernote(usrCfg);
+        $('#{{ $id }}').summernote(usrCfg);
 
         // Check for disabled attribute.
 
         @isset($attributes['disabled'])
-            $('#{{ $name }}').summernote('disable');
+            $('#{{ $id }}').summernote('disable');
         @endisset
     })
 

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -3,8 +3,8 @@
 @section('input_group_item')
 
     {{-- Textarea --}}
-    <textarea id="{{ $name }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($name))]) }}
+    <textarea id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}
     >{{ $slot }}</textarea>
 
 @overwrite

--- a/src/Components/DateRange.php
+++ b/src/Components/DateRange.php
@@ -29,13 +29,13 @@ class DateRange extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = [], $enableDefaultRanges = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = [], $enableDefaultRanges = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/Input.php
+++ b/src/Components/Input.php
@@ -10,12 +10,13 @@ class Input extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
     }
 

--- a/src/Components/InputColor.php
+++ b/src/Components/InputColor.php
@@ -20,13 +20,13 @@ class InputColor extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/InputDate.php
+++ b/src/Components/InputDate.php
@@ -46,13 +46,13 @@ class InputDate extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/InputFile.php
+++ b/src/Components/InputFile.php
@@ -25,13 +25,13 @@ class InputFile extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $placeholder = '', $legend = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $placeholder = '', $legend = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->legend = $legend;

--- a/src/Components/InputGroupComponent.php
+++ b/src/Components/InputGroupComponent.php
@@ -163,14 +163,15 @@ class InputGroupComponent extends Component
      * Make the error key that will be used to search for validation errors.
      * The error key is generated from the 'name' property.
      * Examples:
-     * $name = 'files[]'         => $errorKey = 'files'
-     * $name = 'person[2][name]' => $errorKey = 'person.2.name'
+     * $name = 'files[]'         => $errorKey = 'files'.
+     * $name = 'person[2][name]' => $errorKey = 'person.2.name'.
      *
      * @return string
      */
     protected function makeErrorKey()
     {
         $errKey = preg_replace('@\[\]$@', '', $this->name);
+
         return preg_replace('@\[([a-zA-Z0-9_-]+)\]@', '.$1', $errKey);
     }
 

--- a/src/Components/InputGroupComponent.php
+++ b/src/Components/InputGroupComponent.php
@@ -7,8 +7,17 @@ use Illuminate\View\Component;
 class InputGroupComponent extends Component
 {
     /**
-     * The name and id attribute for the input group item. The input group item
-     * may be an "input", a "select", a "textarea", etc.
+     * The id attribute for the underlying input group item. The input group
+     * item may be an "input", a "select", a "textarea", etc.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The name attribute for the underlying input group item. This value will
+     * be used as the default id attribute when not provided. The input group
+     * item may be an "input", a "select", a "textarea", etc.
      *
      * @var string
      */
@@ -29,6 +38,14 @@ class InputGroupComponent extends Component
     public $size;
 
     /**
+     * Additional classes for "input-group" element. This provides a way to
+     * customize the input group container style.
+     *
+     * @var string
+     */
+    public $igroupClass;
+
+    /**
      * Extra classes for the label container. This provides a way to customize
      * the label style.
      *
@@ -42,7 +59,7 @@ class InputGroupComponent extends Component
      *
      * @var string
      */
-    public $topClass;
+    public $fgroupClass;
 
     /**
      * Indicates if the invalid feedback is disabled for the input group.
@@ -52,12 +69,13 @@ class InputGroupComponent extends Component
     public $disableFeedback;
 
     /**
-     * Additional classes for "input-group" element. This provides a way to
-     * customize the input group container style.
+     * The lookup key to use when searching for validation errors. The lookup
+     * key is automatically generated from the name property. This provides a
+     * way to overwrite that value.
      *
      * @var string
      */
-    public $inputGroupClass;
+    public $errorKey;
 
     /**
      * Create a new component instance.
@@ -65,16 +83,22 @@ class InputGroupComponent extends Component
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null
     ) {
+        $this->id = $id ?? $name;
         $this->name = $name;
         $this->label = $label;
-        $this->size = $size;
-        $this->topClass = $topClass;
+        $this->size = $igroupSize;
+        $this->fgroupClass = $fgroupClass;
         $this->labelClass = $labelClass;
-        $this->inputGroupClass = $inputGroupClass;
+        $this->igroupClass = $igroupClass;
         $this->disableFeedback = $disableFeedback;
+
+        // Setup the lookup key for validation errors.
+
+        $this->errorKey = $errorKey ?? $this->makeErrorKey();
     }
 
     /**
@@ -86,8 +110,8 @@ class InputGroupComponent extends Component
     {
         $classes = ['form-group'];
 
-        if (isset($this->topClass)) {
-            $classes[] = $this->topClass;
+        if (isset($this->fgroupClass)) {
+            $classes[] = $this->fgroupClass;
         }
 
         return implode(' ', $classes);
@@ -111,8 +135,8 @@ class InputGroupComponent extends Component
             $classes[] = 'adminlte-invalid-igroup';
         }
 
-        if (isset($this->inputGroupClass)) {
-            $classes[] = $this->inputGroupClass;
+        if (isset($this->igroupClass)) {
+            $classes[] = $this->igroupClass;
         }
 
         return implode(' ', $classes);
@@ -133,6 +157,21 @@ class InputGroupComponent extends Component
         }
 
         return implode(' ', $classes);
+    }
+
+    /**
+     * Make the error key that will be used to search for validation errors.
+     * The error key is generated from the 'name' property.
+     * Examples:
+     * $name = 'files[]'         => $errorKey = 'files'
+     * $name = 'person[2][name]' => $errorKey = 'person.2.name'
+     *
+     * @return string
+     */
+    protected function makeErrorKey()
+    {
+        $errKey = preg_replace('@\[\]$@', '', $this->name);
+        return preg_replace('@\[([a-zA-Z0-9_-]+)\]@', '.$1', $errKey);
     }
 
     /**

--- a/src/Components/InputGroupComponent.php
+++ b/src/Components/InputGroupComponent.php
@@ -172,7 +172,7 @@ class InputGroupComponent extends Component
     {
         $errKey = preg_replace('@\[\]$@', '', $this->name);
 
-        return preg_replace('@\[([a-zA-Z0-9_-]+)\]@', '.$1', $errKey);
+        return preg_replace('@\[([^]]+)\]@', '.$1', $errKey);
     }
 
     /**

--- a/src/Components/InputSlider.php
+++ b/src/Components/InputSlider.php
@@ -27,13 +27,13 @@ class InputSlider extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = [], $color = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = [], $color = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];
@@ -41,7 +41,7 @@ class InputSlider extends InputGroupComponent
 
         // Set a default plugin 'id' option.
 
-        $this->config['id'] = $this->config['id'] ?? "{$name}-slider";
+        $this->config['id'] = $this->config['id'] ?? "{$this->id}-slider";
     }
 
     /**
@@ -63,8 +63,8 @@ class InputSlider extends InputGroupComponent
             $classes[] = 'adminlte-invalid-islgroup';
         }
 
-        if (isset($this->inputGroupClass)) {
-            $classes[] = $this->inputGroupClass;
+        if (isset($this->igroupClass)) {
+            $classes[] = $this->igroupClass;
         }
 
         return implode(' ', $classes);

--- a/src/Components/InputSwitch.php
+++ b/src/Components/InputSwitch.php
@@ -20,13 +20,13 @@ class InputSwitch extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];
@@ -51,8 +51,8 @@ class InputSwitch extends InputGroupComponent
             $classes[] = 'adminlte-invalid-iswgroup';
         }
 
-        if (isset($this->inputGroupClass)) {
-            $classes[] = $this->inputGroupClass;
+        if (isset($this->igroupClass)) {
+            $classes[] = $this->igroupClass;
         }
 
         return implode(' ', $classes);

--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -10,30 +10,14 @@ class Select extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
-    }
-
-    /**
-     * Make the class attribute for the input group item.
-     *
-     * @param string $invalid
-     * @return string
-     */
-    public function makeItemClass($invalid = null)
-    {
-        $classes = ['form-control'];
-
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
-            $classes[] = 'is-invalid';
-        }
-
-        return implode(' ', $classes);
     }
 
     /**

--- a/src/Components/Select2.php
+++ b/src/Components/Select2.php
@@ -21,34 +21,17 @@ class Select2 extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];
         $this->config['theme'] = 'bootstrap4';
-    }
-
-    /**
-     * Make the class attribute for the input group item.
-     *
-     * @param string $invalid
-     * @return string
-     */
-    public function makeItemClass($invalid = null)
-    {
-        $classes = ['form-control'];
-
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
-            $classes[] = 'is-invalid';
-        }
-
-        return implode(' ', $classes);
     }
 
     /**

--- a/src/Components/SelectBs.php
+++ b/src/Components/SelectBs.php
@@ -20,11 +20,13 @@ class SelectBs extends inputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $disableFeedback = null, $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];

--- a/src/Components/TextEditor.php
+++ b/src/Components/TextEditor.php
@@ -21,13 +21,13 @@ class TextEditor extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null,
-        $config = []
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = []
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
 
         $this->config = is_array($config) ? $config : [];
@@ -56,8 +56,8 @@ class TextEditor extends InputGroupComponent
             $classes[] = 'adminlte-invalid-itegroup';
         }
 
-        if (isset($this->inputGroupClass)) {
-            $classes[] = $this->inputGroupClass;
+        if (isset($this->igroupClass)) {
+            $classes[] = $this->igroupClass;
         }
 
         return implode(' ', $classes);

--- a/src/Components/Textarea.php
+++ b/src/Components/Textarea.php
@@ -10,12 +10,13 @@ class Textarea extends InputGroupComponent
      * @return void
      */
     public function __construct(
-        $name, $label = null, $size = null, $labelClass = null,
-        $topClass = null, $inputGroupClass = null, $disableFeedback = null
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null
     ) {
         parent::__construct(
-            $name, $label, $size, $labelClass, $topClass,
-            $inputGroupClass, $disableFeedback
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
         );
     }
 

--- a/tests/Components/ComponentsTest.php
+++ b/tests/Components/ComponentsTest.php
@@ -79,7 +79,7 @@ class ComponentsTest extends TestCase
     public function testInputGroupComponent()
     {
         $component = new Components\InputGroupComponent(
-            'name', null, 'lg', null, 'top-class', 'igroup-custom-class'
+            'name', null, null, 'lg', null, 'fgroup-class', 'igroup-class'
         );
 
         $iGroupClass = $component->makeInputGroupClass(true);
@@ -88,10 +88,10 @@ class ComponentsTest extends TestCase
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
-        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-igroup', $iGroupClass);
         $this->assertStringContainsString('form-group', $fGroupClass);
-        $this->assertStringContainsString('top-class', $fGroupClass);
+        $this->assertStringContainsString('fgroup-class', $fGroupClass);
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
@@ -113,7 +113,7 @@ class ComponentsTest extends TestCase
 
     public function testInputFileComponent()
     {
-        $component = new Components\InputFile('name', null, 'sm');
+        $component = new Components\InputFile('name', null, null, 'sm');
         $iClass = $component->makeItemClass(true);
 
         $this->assertStringContainsString('custom-file-input', $iClass);
@@ -123,7 +123,7 @@ class ComponentsTest extends TestCase
     public function testInputSliderComponent()
     {
         $component = new Components\InputSlider(
-            'name', null, 'lg', null, null, 'igroup-custom-class'
+            'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
         $iGroupClass = $component->makeInputGroupClass(true);
@@ -131,7 +131,7 @@ class ComponentsTest extends TestCase
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
-        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-islgroup', $iGroupClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
@@ -139,7 +139,7 @@ class ComponentsTest extends TestCase
     public function testInputSwitchComponent()
     {
         $component = new Components\InputSwitch(
-            'name', null, 'lg', null, null, 'igroup-custom-class'
+            'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
         $iGroupClass = $component->makeInputGroupClass(true);
@@ -147,7 +147,7 @@ class ComponentsTest extends TestCase
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
-        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-iswgroup', $iGroupClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
@@ -172,7 +172,7 @@ class ComponentsTest extends TestCase
 
     public function testSelectBsComponent()
     {
-        $component = new Components\SelectBs('name', null, 'lg');
+        $component = new Components\SelectBs('name', null, null, 'lg');
         $iClass = $component->makeItemClass(true);
 
         $this->assertStringContainsString('form-control', $iClass);
@@ -183,14 +183,14 @@ class ComponentsTest extends TestCase
     public function testTextEditorComponent()
     {
         $component = new Components\TextEditor(
-            'name', null, 'lg', null, null, 'igroup-custom-class'
+            'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
         $iGroupClass = $component->makeInputGroupClass(true);
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
-        $this->assertStringContainsString('igroup-custom-class', $iGroupClass);
+        $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-itegroup', $iGroupClass);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue and Enhancement
| License                 | MIT

#### What's in this PR?

Improve and fix some issue on the **input-group-component** and its dependant components in relation to issue #861 
- Add support to a new **id** attribute. When not provided, the **name** attribute will be used as the **id**.
- Rename some properties of the component:
  - **size** => **igroup-size** (The input group size)
  - **top-class** => **fgroup-class** (The form group extra classes)
  - **input-group-class** => **igroup-class** (The input group extra classes)
- Allow the specification of the **error key** to lookup for validation errors using a new **error-key** property. When not provided the property will be automatically generated from the **name** property.
- Other minor fixes.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
