### PR TITLE
Replace components javascript utility methods by classes

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -14,12 +14,12 @@
 <script>
 
     $(() => {
-        let usrCfg = _adminlte_drUtils.parseCfg( @json($config) );
+        let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
 
         // Check if default set of ranges should be enabled.
 
         @isset($enableDefaultRanges)
-            usrCfg.ranges = usrCfg.ranges || _adminlte_drUtils.defRanges();
+            usrCfg.ranges = usrCfg.ranges || _AdminLTE_DateRange.defaultRanges;
             let range = usrCfg.ranges['{{ $enableDefaultRanges }}'];
 
             if (Array.isArray(range)) {
@@ -34,70 +34,64 @@
 </script>
 @endpush
 
-{{-- Add utility methods for the plugin --}}
+{{-- Register Javascript utility class for this component --}}
 
 @once
 @push('js')
 <script>
 
-    function DR_Utils() {
+    class _AdminLTE_DateRange {
 
         /**
-         * Parse the php plugin configuration to eval javascript code.
+         * A default set of ranges options.
          */
-        this.parseCfg = function(cfg)
+        static defaultRanges = {
+            'Today': [
+                moment(),
+                moment()
+            ],
+            'Yesterday': [
+                moment().subtract(1, 'days'),
+                moment().subtract(1, 'days')
+            ],
+            'Last 7 Days': [
+                moment().subtract(6, 'days'),
+                moment()
+            ],
+            'Last 30 Days': [
+                moment().subtract(29, 'days'),
+                moment()
+            ],
+            'This Month': [
+                moment().startOf('month'),
+                moment().endOf('month')
+            ],
+            'Last Month': [
+                moment().subtract(1, 'month').startOf('month'),
+                moment().subtract(1, 'month').endOf('month')
+            ]
+        }
+
+        /**
+         * Parse the php plugin configuration and eval the javascript code.
+         *
+         * cfg: A json with the php side configuration.
+         */
+        static parseCfg(cfg)
         {
             for (const prop in cfg) {
                 let v = cfg[prop];
 
                 if (typeof v === 'string' && v.startsWith('js:')) {
                     cfg[prop] = eval(v.slice(3));
-                }
-                else if (typeof v === 'object') {
-                    cfg[prop] = this.parseCfg(v);
+                } else if (typeof v === 'object') {
+                    cfg[prop] = _AdminLTE_DateRange.parseCfg(v);
                 }
             }
 
             return cfg;
         }
-
-        /**
-         * Creates a default set of ranges option for the plugin.
-         */
-        this.defRanges = function()
-        {
-            return {
-                'Today': [
-                    moment(),
-                    moment()
-                ],
-                'Yesterday': [
-                    moment().subtract(1, 'days'),
-                    moment().subtract(1, 'days')
-                ],
-                'Last 7 Days': [
-                    moment().subtract(6, 'days'),
-                    moment()
-                ],
-                'Last 30 Days': [
-                    moment().subtract(29, 'days'),
-                    moment()
-                ],
-                'This Month': [
-                    moment().startOf('month'),
-                    moment().endOf('month')
-                ],
-                'Last Month': [
-                    moment().subtract(1, 'month').startOf('month'),
-                    moment().subtract(1, 'month').endOf('month')
-                ]
-            };
-        }
     }
-
-    // Create the plugin utilities object.
-
-    var _adminlte_drUtils = new DR_Utils();
 
 </script>
 @endpush

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -14,25 +14,27 @@
 <script>
 
     $(() => {
-        let usrCfg = _adminlte_idUtils.parseCfg( @json($config) );
+        let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
         $('#{{ $id }}').datetimepicker(usrCfg);
     })
 
 </script>
 @endpush
 
-{{-- Add utility methods for the plugin --}}
+{{-- Register Javascript utility class for this component --}}
 
 @once
 @push('js')
 <script>
 
-    function ID_Utils() {
+    class _AdminLTE_InputDate {
 
         /**
-         * Parse the php plugin configuration to eval javascript code.
+         * Parse the php plugin configuration and eval the javascript code.
+         *
+         * cfg: A json with the php side configuration.
          */
-        this.parseCfg = function(cfg)
+        static parseCfg(cfg)
         {
             for (const prop in cfg) {
                 let v = cfg[prop];
@@ -40,17 +42,13 @@
                 if (typeof v === 'string' && v.startsWith('js:')) {
                     cfg[prop] = eval(v.slice(3));
                 } else if (typeof v === 'object') {
-                    cfg[prop] = this.parseCfg(v);
+                    cfg[prop] = _AdminLTE_InputDate.parseCfg(v);
                 }
             }
 
             return cfg;
         }
     }
-
-    // Create the plugin utilities object.
-
-    var _adminlte_idUtils = new ID_Utils();
 
 </script>
 @endpush

--- a/resources/views/components/widget/info-box.blade.php
+++ b/resources/views/components/widget/info-box.blade.php
@@ -37,56 +37,65 @@
 
 </div>
 
-{{-- Add JS utility methods for this component --}}
+{{-- Register Javascript utility class for this component --}}
 
 @once
 @push('js')
 <script>
 
-    function IB_Utils() {
+    class _AdminLTE_InfoBox {
 
         /**
-         * Update the box data.
+         * Constructor.
+         *
+         * target: The id of the target info box.
          */
-        this.update = function(target, data)
+        constructor(target)
         {
-            // Check if target exists.
+            this.target = target;
+        }
 
-            let t = $('#' + target);
+        /**
+         * Update the info box.
+         *
+         * data: An object with the new data.
+         */
+        update(data)
+        {
+            // Check if target and data exists.
 
-            if (t.length <= 0) {
+            let t = $(`#${this.target}`);
+
+            if (t.length <= 0 || ! data) {
                 return;
             }
 
             // Update available data.
 
-            if (data && data.title) {
+            if (data.title) {
                 t.find('.info-box-text').html(data.title);
             }
 
-            if (data && data.text) {
+            if (data.text) {
                 t.find('.info-box-number').html(data.text);
             }
 
-            if (data && data.icon) {
+            if (data.icon) {
                 t.find('.info-box-icon i').attr('class', data.icon);
             }
 
-            if (data && data.description) {
+            if (data.description) {
                 t.find('.progress-description').html(data.description);
             }
 
             // Update progress bar.
 
-            if (data && data.progress) {
-                _adminlte_pbUtils.setValue('progress-' + target, data.progress);
+            if (data.progress) {
+                let pBar = new _AdminLTE_Progress(`progress-${this.target}`);
+                pBar.setValue(data.progress);
             }
         }
     }
-
-    // Create the plugin utilities object.
-
-    var _adminlte_ibUtils = new IB_Utils();
 
 </script>
 @endpush

--- a/resources/views/components/widget/progress.blade.php
+++ b/resources/views/components/widget/progress.blade.php
@@ -16,22 +16,32 @@
 
 </div>
 
-{{-- Add JS utility methods for this component --}}
+{{-- Register Javascript utility class for this component --}}
 
 @once
 @push('js')
 <script>
 
-    function PB_Utils() {
+    class _AdminLTE_Progress {
 
         /**
-         * Gets the target progress bar current value.
+         * Constructor.
+         *
+         * target: The id of the target progress bar.
          */
-        this.getValue = function(target)
+        constructor(target)
+        {
+            this.target = target;
+        }
+
+        /**
+         * Get the current progress bar value.
+         */
+        getValue()
         {
             // Check if target exists.
 
-            let t = $('#' + target);
+            let t = $(`#${this.target}`);
 
             if (t.length <= 0) {
                 return;
@@ -43,13 +53,13 @@
         }
 
         /**
-         * Update the target progress bar with a new value.
+         * Set the new progress bar value.
          */
-        this.setValue = function(target, value)
+        setValue(value)
         {
             // Check if target exists.
 
-            let t = $('#' + target);
+            let t = $(`#${this.target}`);
 
             if (t.length <= 0) {
                 return;
@@ -62,17 +72,13 @@
             t.find('.progress-bar').css('width', value + '%')
                 .attr('aria-valuenow', value);
 
-            if (t.find('span.sr-only').length >= 0) {
+            if (t.find('span.sr-only').length > 0) {
                 t.find('span.sr-only').text(value + '% Progress');
             } else {
                 t.find('.progress-bar').text(value + '%');
             }
         }
     }
-
-    // Create the plugin utilities object.
-
-    var _adminlte_pbUtils = new PB_Utils();
 
 </script>
 @endpush

--- a/resources/views/components/widget/small-box.blade.php
+++ b/resources/views/components/widget/small-box.blade.php
@@ -37,22 +37,66 @@
 
 </div>
 
-{{-- Add JS utility methods for this component --}}
+{{-- Register Javascript utility class for this component --}}
 
 @once
 @push('js')
 <script>
 
-    function SB_Utils() {
+    class _AdminLTE_SmallBox {
 
         /**
-         * Toggle the loading animation.
+         * Constructor.
+         *
+         * target: The id of the target small box.
          */
-        this.toggleLoading = function(target)
+        constructor(target)
+        {
+            this.target = target;
+        }
+
+        /**
+         * Update the small box.
+         *
+         * data: An object with the new data.
+         */
+        update(data)
+        {
+            // Check if target and data exists.
+
+            let t = $(`#${this.target}`);
+
+            if (t.length <= 0 || ! data) {
+                return;
+            }
+
+            // Update available data.
+
+            if (data.title) {
+                t.find('.inner h3').html(data.title);
+            }
+
+            if (data.text) {
+                t.find('.inner h5').html(data.text);
+            }
+
+            if (data.icon) {
+                t.find('.icon i').attr('class', data.icon);
+            }
+
+            if (data.url) {
+                t.find('.small-box-footer').attr('href', data.url);
+            }
+        }
+
+        /**
+         * Toggle the loading animation of the small box.
+         */
+        toggleLoading()
         {
             // Check if target exists.
 
-            let t = $('#' + target);
+            let t = $(`#${this.target}`);
 
             if (t.length <= 0) {
                 return;
@@ -62,43 +106,7 @@
 
             t.find('.overlay').toggleClass('d-none');
         }
-
-        /**
-         * Update the box data.
-         */
-        this.update = function(target, data)
-        {
-            // Check if target exists.
-
-            let t = $('#' + target);
-
-            if (t.length <= 0) {
-                return;
-            }
-
-            // Update available data.
-
-            if (data && data.title) {
-                t.find('.inner h3').html(data.title);
-            }
-
-            if (data && data.text) {
-                t.find('.inner h5').html(data.text);
-            }
-
-            if (data && data.icon) {
-                t.find('.icon i').attr('class', data.icon);
-            }
-
-            if (data && data.url) {
-                t.find('.small-box-footer').attr('href', data.url);
-            }
-        }
     }
-
-    // Create the plugin utilities object.
-
-    var _adminlte_sbUtils = new SB_Utils();
 
 </script>
 @endpush


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Currently, various **blade-x components** provides `Javascript` utilities methods to interact whit they. This PR replaces those utilities method that are registered under multiple global variables of the `window` javascript object by new utilities classes. This way, we don't need to register any global variable on `Javascript` and the user can still access the utilities using the provided new classes.

#### Example:

Previously, we use next code example to update an **info-box** component:

```js
$(document).ready(() => {
    let data = {text: 'new text', description: 'new description'};
    _adminlte_ibUtils.update('myInfoBoxID', data);
});
```

Now, we have to do:

```js
$(document).ready(() => {
    let myIBox = new _AdminLTE_InfoBox('myInfoBoxID');
    let data = {text: 'new text', description: 'new description'};
    myIBox.update(data);
});
```

#### Checklist

- [x] I tested these changes.