### PR TITLE
Add suport for a new navbar notification menu item.

### DIFF
--- a/resources/views/components/layout/navbar-notification-link.blade.php
+++ b/resources/views/components/layout/navbar-notification-link.blade.php
@@ -1,0 +1,123 @@
+{{-- Navbar notification link --}}
+
+<li class="nav-item" id="{{ $id }}">
+
+    {{-- Link --}}
+    <a {{ $attributes->merge(['class' => 'nav-link']) }}>
+
+        {{-- Icon --}}
+        <i class="{{ $makeIconClass() }}"></i>
+
+        {{-- Badge --}}
+        <span class="{{ $makeBadgeClass() }}">{{ $badgeLabel }}</span>
+
+    </a>
+
+</li>
+
+{{-- If required, update the notification periodically --}}
+
+@if (isset($updateUrl, $updateTime) && $updateTime > 0)
+@push('js')
+<script>
+
+    $(() => {
+
+        // Method to get new notification data from the configured url.
+
+        let updateNotification = (nLink) =>
+        {
+            // Make an ajax call to the configured url. The response should be
+            // an object with the new data. The supported properties are:
+            // 'label', 'label_color' and 'icon_color'.
+
+            $.ajax({
+                url: "{{ url($updateUrl) }}"
+            })
+            .done((data) => {
+                nLink.update(data);
+            })
+            .fail(function(jqXHR, textStatus, errorThrown) {
+                console.log(jqXHR, textStatus, errorThrown);
+            });
+        };
+
+        // First load of the notification data.
+
+        let nLink = new _AdminLTE_NavbarNotificationLink("{{ $id }}");
+        updateNotification(nLink);
+
+        // Periodically update the notification.
+
+        setInterval(updateNotification, {{ $updateTime * 1000 }}, nLink);
+    })
+
+</script>
+@endpush
+@endif
+
+{{-- Register Javascript utility class for this component --}}
+
+@once
+@push('js')
+<script>
+
+    class _AdminLTE_NavbarNotificationLink {
+
+        /**
+         * Constructor.
+         *
+         * target: The id of the target notification link.
+         */
+        constructor(target)
+        {
+            this.target = target;
+        }
+
+        /**
+         * Update the notification link.
+         *
+         * data: An object with the new data.
+         */
+        update(data)
+        {
+            // Check if target and data exists.
+
+            let t = $(`li#${this.target}`);
+
+            if (t.length <= 0 || ! data) {
+                return;
+            }
+
+            let badge = t.find(".navbar-badge");
+            let icon = t.find(".nav-link > i");
+
+            // Update the badge label.
+
+            if (data.label && data.label > 0) {
+                badge.html(data.label);
+            } else {
+                badge.empty();
+            }
+
+            // Update the badge color.
+
+            if (data.label_color) {
+                badge.removeClass((idx, classes) => {
+                    return (classes.match(/(^|\s)badge-\S+/g) || []).join(' ');
+                }).addClass(`badge-${data.label_color} badge-pill`);
+            }
+
+            // Update the icon color.
+
+            if (data.icon_color) {
+                icon.removeClass((idx, classes) => {
+                    return (classes.match(/(^|\s)text-\S+/g) || []).join(' ');
+                }).addClass(`text-${data.icon_color}`);
+            }
+        }
+    }
+
+</script>
+@endpush
+@endonce

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -17,6 +17,15 @@ use JeroenNoten\LaravelAdminLte\Http\ViewComposers\AdminLteComposer;
 class AdminLteServiceProvider extends BaseServiceProvider
 {
     /**
+     * Array with the available layout components.
+     *
+     * @var array
+     */
+    protected $layoutComponents = [
+        Components\Layout\NavbarNotificationLink::class,
+    ];
+
+    /**
      * Array with the available form components.
      *
      * @var array
@@ -210,6 +219,7 @@ class AdminLteServiceProvider extends BaseServiceProvider
         // Load all the blade-x components.
 
         $components = array_merge(
+            $this->layoutComponents,
             $this->formComponents,
             $this->toolComponents,
             $this->widgetComponents

--- a/src/Components/Layout/NavbarNotificationLink.php
+++ b/src/Components/Layout/NavbarNotificationLink.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Components\Layout;
+
+use Illuminate\View\Component;
+
+class NavbarNotificationLink extends Component
+{
+    /**
+     * The id attribute for the underlying <li> wrapper.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The notification icon (a Font Awesome icon).
+     *
+     * @var string
+     */
+    public $icon;
+
+    /**
+     * The notification icon color (an AdminLTE color).
+     *
+     * @var string
+     */
+    public $iconColor;
+
+    /**
+     * The label for the notification badge.
+     *
+     * @var string
+     */
+    public $badgeLabel;
+
+    /**
+     * The background color for the notification badge (an AdminLTE color).
+     *
+     * @var string
+     */
+    public $badgeColor;
+
+    /**
+     * The url to query for new data in order to update the notification.
+     *
+     * @var string
+     */
+    public $updateUrl;
+
+    /**
+     * The time interval (in seconds) for query the update url.
+     *
+     * @var integer
+     */
+    public $updateTime;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        $id, $icon, $iconColor = null, $badgeLabel = null, $badgeColor = null,
+        $updateUrl = null, $updateTime = null
+    ) {
+        $this->id = $id;
+        $this->icon = $icon;
+        $this->iconColor = $iconColor;
+        $this->badgeLabel = $badgeLabel;
+        $this->badgeColor = $badgeColor;
+        $this->updateUrl = $updateUrl;
+        $this->updateTime = isset($updateTime) ? intval($updateTime) : 0;
+    }
+
+    /**
+     * Make the class attribute for the notification icon.
+     *
+     * @return string
+     */
+    public function makeIconClass()
+    {
+        $classes = [$this->icon];
+
+        if (! empty($this->iconColor)) {
+            $classes[] = "text-{$this->iconColor}";
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Make the class attribute for the notification badge.
+     *
+     * @return string
+     */
+    public function makeBadgeClass()
+    {
+        $classes = ['badge navbar-badge text-bold text-xs badge-pill'];
+
+        if (! empty($this->badgeColor)) {
+            $classes[] = "badge-{$this->badgeColor}";
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('adminlte::components.layout.navbar-notification-link');
+    }
+}

--- a/src/Helpers/MenuItemHelper.php
+++ b/src/Helpers/MenuItemHelper.php
@@ -105,6 +105,19 @@ class MenuItemHelper
     }
 
     /**
+     * Check if a menu item is a notification link.
+     *
+     * @param mixed $item
+     * @return bool
+     */
+    public static function isNotificationLink($item)
+    {
+        return isset($item['id'], $item['icon'], $item['type']) &&
+               (isset($item['url']) || isset($item['route'])) &&
+               $item['type'] === 'notification-link';
+    }
+
+    /**
      * Check if a menu item is a navbar search item (legacy or new).
      *
      * @param mixed $item
@@ -165,6 +178,7 @@ class MenuItemHelper
     public static function isValidNavbarItem($item)
     {
         return self::isNavbarSearch($item) ||
+               self::isNotificationLink($item) ||
                self::isFullscreen($item) ||
                self::isSubmenu($item) ||
                self::isLink($item);

--- a/tests/Components/LayoutComponentsTest.php
+++ b/tests/Components/LayoutComponentsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use JeroenNoten\LaravelAdminLte\Components;
+
+class LayoutComponentsTest extends TestCase
+{
+    /**
+     * Get package providers.
+     */
+    protected function getPackageProviders($app)
+    {
+        // Register our service provider into the Laravel's application.
+
+        return ['JeroenNoten\LaravelAdminLte\AdminLteServiceProvider'];
+    }
+
+    /**
+     * Return array with the available blade components.
+     */
+    protected function getComponents()
+    {
+        $base = 'adminlte::components.layout';
+
+        return [
+            "{$base}.navbar-notification-link" => new Components\Layout\NavbarNotificationLink('id', 'icon'),
+        ];
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | General components tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testAllComponentsRender()
+    {
+        foreach ($this->getComponents() as $viewName => $component) {
+            $view = $component->render();
+            $this->assertEquals($view->getName(), $viewName);
+        }
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Individual layout components tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testNavbarNotificationLinkComponent()
+    {
+        // Test basic component.
+        $component = new Components\Layout\NavbarNotificationLink('id', 'icon');
+
+        $iClass = $component->makeIconClass();
+        $bClass = $component->makeBadgeClass();
+
+        $this->assertStringContainsString('icon', $iClass);
+        $this->assertStringContainsString('badge', $bClass);
+        $this->assertStringContainsString('navbar-badge', $bClass);
+
+        // Test advanced component.
+        // $id, $icon, $iconColor, $badgeLabel, $badgeColor, $updateUrl,
+        // $updateTime
+        $component = new Components\Layout\NavbarNotificationLink(
+            'id', 'icon', 'danger', null, 'primary', null, null
+        );
+
+        $iClass = $component->makeIconClass();
+        $bClass = $component->makeBadgeClass();
+
+        $this->assertStringContainsString('text-danger', $iClass);
+        $this->assertStringContainsString('badge-primary', $bClass);
+    }
+}


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue|Enhancement
| License                 | MIT

#### What's in this PR?

Add support to a new menu item that represents a **navbar notification link** in relation to issue #713 . The menu item is implemented with an underlying blade component, so will only work for **Laravel >= 7.x**. This item will be rendered as an icon with a notification badge. When clicking on the icon, you will be redirected to the configured `url` or `route`. The icon support periodically updates of the badge, the badge color and the icon color using an **ajax** request to another configurable `url`. The summary of the configuration options are:

```php
[
    'type'         => 'notification-link', // The menu item type => REQUIRED
    'id'           => 'my-notification', // An ID attribute => REQUIRED
    'icon'         => 'fas fa-bell', // A font awesome icon => REQUIRED
    'icon_color'   => 'warning', // The initial icon color => OPTIONAL
    'label'        => 0, // The initial label for the badge => OPTIONAL
    'label_color'  => 'danger', // The initial badge color => OPTIONAL
    'url'          => 'notifications/show', // Url for the click event => REQUIRED
    'topnav_right' => true, // Or "'topnav' => true" to place on the left => REQUIRED
    'update_url'   => 'notifications/get', // Url to use for fetch new data => OPTIONAL
    'update_time'  => 30, // The query frequency for new data (in seconds) => OPTIONAL
],
```

You can also use the `route` attribute of a menu item in replacement of the `url` attribute to specify the url for the click event. The `update_url` and `update_time` are optional, so you can implement your own update procedure for the link if you don't like the internal one (both are required for use the internal one). When querying the `update_url` it should a response with a `json` containing the properties:

- label
- label_color
- icon_color

Example:

```php
// On routes...

Route::get('notifications/get', 'NotificationsController@getNotificationsData');

// On the NotificationsController...

/**
 * Get random notification data for a notification link item.
 *
 * @param Request $request
 * @return Array
 */
public function getNotificationsData(Request $request)
{
    $colors = [
        'light', 'dark','primary', 'secondary',
        'info', 'success', 'warning', 'danger'
    ];

    return [
        'label'        => rand(0, 20),
        'label_color'  => $colors[rand(0, 7)],
        'icon_color'   => $colors[rand(0, 7)],
    ];
}
```

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.