### PR TITLE
Review the sidebar mini configuration options

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -145,7 +145,7 @@ return [
     |
     */
 
-    'sidebar_mini' => true,
+    'sidebar_mini' => 'lg',
     'sidebar_collapse' => false,
     'sidebar_collapse_auto_size' => false,
     'sidebar_collapse_remember' => false,

--- a/src/Helpers/LayoutHelper.php
+++ b/src/Helpers/LayoutHelper.php
@@ -187,10 +187,10 @@ class LayoutHelper
 
         // Add classes related to the "sidebar_mini" configuration.
 
-        if (config('adminlte.sidebar_mini', true) === true) {
+        if (config('adminlte.sidebar_mini', 'lg') === 'lg') {
             $classes[] = 'sidebar-mini';
-        } elseif (config('adminlte.sidebar_mini', true) == 'md') {
-            $classes[] = 'sidebar-mini sidebar-mini-md';
+        } elseif (config('adminlte.sidebar_mini', 'lg') === 'md') {
+            $classes[] = 'sidebar-mini-md';
         }
 
         // Add classes related to the "sidebar_collapse" configuration.

--- a/src/Helpers/LayoutHelper.php
+++ b/src/Helpers/LayoutHelper.php
@@ -184,7 +184,7 @@ class LayoutHelper
     }
 
     /**
-     * Make the set of classes related to the left sidebar configuration.
+     * Make the set of classes related to the main left sidebar configuration.
      *
      * @return array
      */

--- a/src/Helpers/LayoutHelper.php
+++ b/src/Helpers/LayoutHelper.php
@@ -14,6 +14,13 @@ class LayoutHelper
     protected static $screenBreakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 
     /**
+     * Set of tokens related to sidebar mini config values.
+     *
+     * @var array
+     */
+    protected static $sidebarMiniValues = ['xs', 'md', 'lg'];
+
+    /**
      * Check if layout topnav is enabled.
      *
      * @return bool
@@ -187,10 +194,11 @@ class LayoutHelper
 
         // Add classes related to the "sidebar_mini" configuration.
 
-        if (config('adminlte.sidebar_mini', 'lg') === 'lg') {
-            $classes[] = 'sidebar-mini';
-        } elseif (config('adminlte.sidebar_mini', 'lg') === 'md') {
-            $classes[] = 'sidebar-mini-md';
+        $sidebarMiniCfg = config('adminlte.sidebar_mini', 'lg');
+
+        if (in_array($sidebarMiniCfg, self::$sidebarMiniValues)) {
+            $suffix = $sidebarMiniCfg === 'lg' ? '' : "-{$sidebarMiniCfg}";
+            $classes[] = "sidebar-mini${suffix}";
         }
 
         // Add classes related to the "sidebar_collapse" configuration.

--- a/tests/Helpers/LayoutHelperTest.php
+++ b/tests/Helpers/LayoutHelperTest.php
@@ -69,6 +69,7 @@ class LayoutHelperTest extends TestCase
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringNotContainsString('sidebar-mini', $data);
         $this->assertStringNotContainsString('sidebar-mini-md', $data);
+        $this->assertStringNotContainsString('sidebar-mini-xs', $data);
 
         // Test config 'sidebar_mini' => 'lg'.
 
@@ -76,12 +77,22 @@ class LayoutHelperTest extends TestCase
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringContainsString('sidebar-mini', $data);
         $this->assertStringNotContainsString('sidebar-mini-md', $data);
+        $this->assertStringNotContainsString('sidebar-mini-xs', $data);
 
         // Test config 'sidebar_mini' => 'md'.
 
         config(['adminlte.sidebar_mini' => 'md']);
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringContainsString('sidebar-mini-md', $data);
+        $this->assertStringNotContainsString('sidebar-mini-xs', $data);
+        $this->assertNotRegExp('/sidebar-mini[^-]/', $data);
+
+        // Test config 'sidebar_mini' => 'xs'.
+
+        config(['adminlte.sidebar_mini' => 'xs']);
+        $data = LayoutHelper::makeBodyClasses();
+        $this->assertStringContainsString('sidebar-mini-xs', $data);
+        $this->assertStringNotContainsString('sidebar-mini-md', $data);
         $this->assertNotRegExp('/sidebar-mini[^-]/', $data);
     }
 

--- a/tests/Helpers/LayoutHelperTest.php
+++ b/tests/Helpers/LayoutHelperTest.php
@@ -63,23 +63,26 @@ class LayoutHelperTest extends TestCase
 
     public function testMakeBodyClassesWithSidebarMiniConfig()
     {
-        // Test config 'sidebar_mini' => false.
+        // Test config 'sidebar_mini' => null.
 
-        config(['adminlte.sidebar_mini' => false]);
+        config(['adminlte.sidebar_mini' => null]);
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringNotContainsString('sidebar-mini', $data);
+        $this->assertStringNotContainsString('sidebar-mini-md', $data);
 
-        // Test config 'sidebar_mini' => true.
+        // Test config 'sidebar_mini' => 'lg'.
 
-        config(['adminlte.sidebar_mini' => true]);
+        config(['adminlte.sidebar_mini' => 'lg']);
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringContainsString('sidebar-mini', $data);
+        $this->assertStringNotContainsString('sidebar-mini-md', $data);
 
         // Test config 'sidebar_mini' => 'md'.
 
         config(['adminlte.sidebar_mini' => 'md']);
         $data = LayoutHelper::makeBodyClasses();
-        $this->assertStringContainsString('sidebar-mini sidebar-mini-md', $data);
+        $this->assertStringContainsString('sidebar-mini-md', $data);
+        $this->assertNotRegExp('/sidebar-mini[^-]/', $data);
     }
 
     public function testMakeBodyClassesWithSidebarCollapseConfig()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Review the sidebar mini configuration options. The new supported options will be:
- `lg` to enable sidebar mini mode for desktop and bigger screens (>= 992px). Previously: `true`.
- `md` to enable sidebar mini mode for small tablet and bigger screens (>= 768px). Previously: `md`.
- `xs` to enable sidebar mini mode for extra small and bigger screens (>= 0px).
- `null` to disable the sidebar mini mode. Previously: `false`.

Also, fix a small bug that includes both `sidebar-mini` and `sidebar-mini-md` into the body classes when using the `md` option.

#### Checklist

- [x] I tested these changes.