### PR TITLE
Improve error lookup on the session's errors bag for the components

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Date Range Input --}}
     <input id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
 

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Input Color --}}
     <input id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
 

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Input Date --}}
     <input id="{{ $id }}" name="{{ $name }}" data-target="#{{ $id }}" data-toggle="datetimepicker"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
 

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -6,7 +6,7 @@
 
         {{-- Custom file input --}}
         <input type="file" id="{{ $id }}" name="{{ $name }}"
-            {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+            {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
         {{-- Custom file label --}}
         <label class="custom-file-label text-truncate" for="{{ $id }}"

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -26,10 +26,12 @@
     </div>
 
     {{-- Error feedback --}}
-    @if($isInvalid() && ! isset($disableFeedback))
-        <span class="invalid-feedback d-block" role="alert">
-            <strong>{{ $message }}</strong>
-        </span>
+    @if(! isset($disableFeedback))
+        @error($errorKey)
+            <span class="invalid-feedback d-block" role="alert">
+                <strong>{{ $message }}</strong>
+            </span>
+        @enderror
     @endif
 
 </div>

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -26,12 +26,10 @@
     </div>
 
     {{-- Error feedback --}}
-    @if(! isset($disableFeedback))
-        @error($errorKey)
-            <span class="invalid-feedback d-block" role="alert">
-                <strong>{{ $message }}</strong>
-            </span>
-        @enderror
+    @if($isInvalid() && ! isset($disableFeedback))
+        <span class="invalid-feedback d-block" role="alert">
+            <strong>{{ $errors->first($errorKey) }}</strong>
+        </span>
     @endif
 
 </div>

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -8,7 +8,7 @@
     @endisset
 
     {{-- Input group --}}
-    <div class="{{ $makeInputGroupClass($errors->first($errorKey)) }}">
+    <div class="{{ $makeInputGroupClass() }}">
 
         {{-- Input prepend slot --}}
         @isset($prependSlot)

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -26,12 +26,10 @@
     </div>
 
     {{-- Error feedback --}}
-    @if(! isset($disableFeedback))
-        @error($errorKey)
-            <span class="invalid-feedback d-block" role="alert">
-                <strong>{{ $message }}</strong>
-            </span>
-        @enderror
+    @if($isInvalid() && ! isset($disableFeedback))
+        <span class="invalid-feedback d-block" role="alert">
+            <strong>{{ $message }}</strong>
+        </span>
     @endif
 
 </div>

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Input Slider --}}
     <input id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Input Switch --}}
     <input type="checkbox" id="{{ $id }}" name="{{ $name }}" value="true"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
 

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -4,6 +4,6 @@
 
     {{-- Input --}}
     <input id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Select --}}
     <select id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
         {{ $slot }}
     </select>
 

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Select --}}
     <select id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
         {{ $slot }}
     </select>
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Select --}}
     <select id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}>
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
         {{ $slot }}
     </select>
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Summernote Textarea --}}
     <textarea id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}
     >{{ $slot }}</textarea>
 
 @overwrite

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Textarea --}}
     <textarea id="{{ $id }}" name="{{ $name }}"
-        {{ $attributes->merge(['class' => $makeItemClass($errors->first($errorKey))]) }}
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}
     >{{ $slot }}</textarea>
 
 @overwrite

--- a/src/Components/Form/InputDate.php
+++ b/src/Components/Form/InputDate.php
@@ -69,14 +69,13 @@ class InputDate extends InputGroupComponent
     /**
      * Make the class attribute for the input group item.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid = null)
+    public function makeItemClass()
     {
         $classes = ['form-control', 'datetimepicker'];
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/Components/Form/InputFile.php
+++ b/src/Components/Form/InputFile.php
@@ -41,14 +41,13 @@ class InputFile extends InputGroupComponent
     /**
      * Make the class attribute for the input group item.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid = null)
+    public function makeItemClass()
     {
         $classes = ['custom-file-input'];
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/Components/Form/InputGroupComponent.php
+++ b/src/Components/Form/InputGroupComponent.php
@@ -158,24 +158,6 @@ class InputGroupComponent extends Component
     }
 
     /**
-     * Check if there exists validation errors on the session related to the
-     * configured error key.
-     *
-     * @return bool
-     */
-    public function isInvalid()
-    {
-        // Get the errors bag from session. The errors bag will be an instance
-        // of the Illuminate\Support\MessageBag class.
-
-        $errors = session()->get('errors');
-
-        // Check if exists any error related to the configured error key.
-
-        return ! empty($errors) && ! empty($errors->first($this->errorKey));
-    }
-
-    /**
      * Make the error key that will be used to search for validation errors.
      * The error key is generated from the 'name' property.
      * Examples:
@@ -189,6 +171,24 @@ class InputGroupComponent extends Component
         $errKey = preg_replace('@\[\]$@', '', $this->name);
 
         return preg_replace('@\[([^]]+)\]@', '.$1', $errKey);
+    }
+
+    /**
+     * Check if there exists validation errors on the session related to the
+     * configured error key.
+     *
+     * @return bool
+     */
+    protected function isInvalid()
+    {
+        // Get the errors bag from session. The errors bag will be an instance
+        // of the Illuminate\Support\MessageBag class.
+
+        $errors = session()->get('errors');
+
+        // Check if exists any error related to the configured error key.
+
+        return ! empty($errors) && ! empty($errors->first($this->errorKey));
     }
 
     /**

--- a/src/Components/Form/InputGroupComponent.php
+++ b/src/Components/Form/InputGroupComponent.php
@@ -158,6 +158,24 @@ class InputGroupComponent extends Component
     }
 
     /**
+     * Check if there exists validation errors on the session related to the
+     * configured error key.
+     *
+     * @return bool
+     */
+    public function isInvalid()
+    {
+        // Get the errors bag from session. The errors bag will be an instance
+        // of the Illuminate\Support\MessageBag class.
+
+        $errors = session()->get('errors');
+
+        // Check if exists any error related to the configured error key.
+
+        return ! empty($errors) && ! empty($errors->first($this->errorKey));
+    }
+
+    /**
      * Make the error key that will be used to search for validation errors.
      * The error key is generated from the 'name' property.
      * Examples:
@@ -171,24 +189,6 @@ class InputGroupComponent extends Component
         $errKey = preg_replace('@\[\]$@', '', $this->name);
 
         return preg_replace('@\[([^]]+)\]@', '.$1', $errKey);
-    }
-
-    /**
-     * Check if there exists validation errors on the session related to the
-     * configured error key.
-     *
-     * @return bool
-     */
-    protected function isInvalid()
-    {
-        // Get the errors bag from session. The errors bag will be an instance
-        // of the Illuminate\Support\MessageBag class.
-
-        $errors = session()->get('errors');
-
-        // Check if exists any error related to the configured error key.
-
-        return ! empty($errors) && ! empty($errors->first($this->errorKey));
     }
 
     /**

--- a/src/Components/Form/InputGroupComponent.php
+++ b/src/Components/Form/InputGroupComponent.php
@@ -120,10 +120,9 @@ class InputGroupComponent extends Component
     /**
      * Make the class attribute for the "input-group" element.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeInputGroupClass($invalid = null)
+    public function makeInputGroupClass()
     {
         $classes = ['input-group'];
 
@@ -131,7 +130,7 @@ class InputGroupComponent extends Component
             $classes[] = "input-group-{$this->size}";
         }
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'adminlte-invalid-igroup';
         }
 
@@ -145,14 +144,13 @@ class InputGroupComponent extends Component
     /**
      * Make the class attribute for the input group item.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid = null)
+    public function makeItemClass()
     {
         $classes = ['form-control'];
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';
         }
 
@@ -173,6 +171,24 @@ class InputGroupComponent extends Component
         $errKey = preg_replace('@\[\]$@', '', $this->name);
 
         return preg_replace('@\[([^]]+)\]@', '.$1', $errKey);
+    }
+
+    /**
+     * Check if there exists validation errors on the session related to the
+     * configured error key.
+     *
+     * @return bool
+     */
+    protected function isInvalid()
+    {
+        // Get the errors bag from session. The errors bag will be an instance
+        // of the Illuminate\Support\MessageBag class.
+
+        $errors = session()->get('errors');
+
+        // Check if exists any error related to the configured error key.
+
+        return ! empty($errors) && ! empty($errors->first($this->errorKey));
     }
 
     /**

--- a/src/Components/Form/InputSlider.php
+++ b/src/Components/Form/InputSlider.php
@@ -48,10 +48,9 @@ class InputSlider extends InputGroupComponent
      * Make the class attribute for the "input-group" element. Note we overwrite
      * the method of the parent class.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeInputGroupClass($invalid = null)
+    public function makeInputGroupClass()
     {
         $classes = ['input-group'];
 
@@ -59,7 +58,7 @@ class InputSlider extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'adminlte-invalid-islgroup';
         }
 

--- a/src/Components/Form/InputSwitch.php
+++ b/src/Components/Form/InputSwitch.php
@@ -36,10 +36,9 @@ class InputSwitch extends InputGroupComponent
      * Make the class attribute for the "input-group" element. Note we overwrite
      * the method of the parent class.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeInputGroupClass($invalid = null)
+    public function makeInputGroupClass()
     {
         $classes = ['input-group'];
 
@@ -47,7 +46,7 @@ class InputSwitch extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'adminlte-invalid-iswgroup';
         }
 
@@ -61,14 +60,13 @@ class InputSwitch extends InputGroupComponent
     /**
      * Make the class attribute for the input group item.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid = null)
+    public function makeItemClass()
     {
         $classes = [];
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/Components/Form/SelectBs.php
+++ b/src/Components/Form/SelectBs.php
@@ -35,14 +35,13 @@ class SelectBs extends inputGroupComponent
     /**
      * Make the class attribute for the input group item.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeItemClass($invalid = null)
+    public function makeItemClass()
     {
         $classes = ['form-control'];
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/Components/Form/TextEditor.php
+++ b/src/Components/Form/TextEditor.php
@@ -41,10 +41,9 @@ class TextEditor extends InputGroupComponent
      * Make the class attribute for the "input-group" element. Note we overwrite
      * the method of the parent class.
      *
-     * @param string $invalid
      * @return string
      */
-    public function makeInputGroupClass($invalid = null)
+    public function makeInputGroupClass()
     {
         $classes = ['input-group'];
 
@@ -52,7 +51,7 @@ class TextEditor extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if (! empty($invalid) && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
             $classes[] = 'adminlte-invalid-itegroup';
         }
 

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use JeroenNoten\LaravelAdminLte\Components;
+use Illuminate\Support\MessageBag;
 
 class FormComponentsTest extends TestCase
 {
@@ -39,6 +40,16 @@ class FormComponentsTest extends TestCase
         ];
     }
 
+    /**
+     * Add an error on the session's error bag for the provided $key.
+     */
+    protected function addErrorOnSessionFor($key)
+    {
+        $msgBag = new MessageBag();
+        $msgBag->add($key, 'error');
+        session()->put('errors', $msgBag);
+    }
+
     /*
     |--------------------------------------------------------------------------
     | General components tests.
@@ -65,9 +76,11 @@ class FormComponentsTest extends TestCase
             'name', null, null, 'lg', null, 'fgroup-class', 'igroup-class'
         );
 
-        $iGroupClass = $component->makeInputGroupClass(true);
+        $this->addErrorOnSessionFor('name');
+
+        $iGroupClass = $component->makeInputGroupClass();
         $fGroupClass = $component->makeFormGroupClass();
-        $iClass = $component->makeItemClass(true);
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
@@ -82,7 +95,10 @@ class FormComponentsTest extends TestCase
     public function testInputDateComponent()
     {
         $component = new Components\Form\InputDate('name');
-        $iClass = $component->makeItemClass(true);
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('datetimepicker', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
@@ -91,7 +107,9 @@ class FormComponentsTest extends TestCase
     public function testInputFileComponent()
     {
         $component = new Components\Form\InputFile('name', null, null, 'sm');
-        $iClass = $component->makeItemClass(true);
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('custom-file-input', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
@@ -103,8 +121,10 @@ class FormComponentsTest extends TestCase
             'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
-        $iGroupClass = $component->makeInputGroupClass(true);
-        $iClass = $component->makeItemClass(true);
+        $this->addErrorOnSessionFor('name');
+
+        $iGroupClass = $component->makeInputGroupClass();
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
@@ -119,8 +139,10 @@ class FormComponentsTest extends TestCase
             'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
-        $iGroupClass = $component->makeInputGroupClass(true);
-        $iClass = $component->makeItemClass(true);
+        $this->addErrorOnSessionFor('name');
+
+        $iGroupClass = $component->makeInputGroupClass();
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
@@ -132,7 +154,10 @@ class FormComponentsTest extends TestCase
     public function testSelectComponent()
     {
         $component = new Components\Form\Select('name');
-        $iClass = $component->makeItemClass(true);
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
@@ -141,7 +166,10 @@ class FormComponentsTest extends TestCase
     public function testSelect2Component()
     {
         $component = new Components\Form\Select2('name');
-        $iClass = $component->makeItemClass(true);
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
@@ -150,7 +178,10 @@ class FormComponentsTest extends TestCase
     public function testSelectBsComponent()
     {
         $component = new Components\Form\SelectBs('name', null, null, 'lg');
-        $iClass = $component->makeItemClass(true);
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
 
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('form-control-lg', $iClass);
@@ -163,7 +194,9 @@ class FormComponentsTest extends TestCase
             'name', null, null, 'lg', null, null, 'igroup-class'
         );
 
-        $iGroupClass = $component->makeInputGroupClass(true);
+        $this->addErrorOnSessionFor('name');
+
+        $iGroupClass = $component->makeInputGroupClass();
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use JeroenNoten\LaravelAdminLte\Components;
 use Illuminate\Support\MessageBag;
+use JeroenNoten\LaravelAdminLte\Components;
 
 class FormComponentsTest extends TestCase
 {


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue & Enhancement
| License                 | MIT

#### What's in this PR?

Make improvements on the lookup for validation errors using the session errors bag:
- The lookup logic was moved to the `InputGroupClass`, there is no need to check the errors bag on each blade template.
- Now, existence of the errors bag is checked before trying to access it.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
