### PR TITLE
Fixing the appearance of User Menu

### DIFF
--- a/resources/views/partials/navbar/menu-item-dropdown-user-menu.blade.php
+++ b/resources/views/partials/navbar/menu-item-dropdown-user-menu.blade.php
@@ -19,7 +19,7 @@
     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
         @if(config('adminlte.usermenu_image'))
             <img src="{{ Auth::user()->adminlte_image() }}"
-                 class="user-image img-circle elevation-2"
+                 class="user-image img-circle elevation-2 inline-block"
                  alt="{{ Auth::user()->name }}">
         @endif
         <span @if(config('adminlte.usermenu_image')) class="d-none d-md-inline" @endif>
@@ -36,7 +36,7 @@
                 @if(!config('adminlte.usermenu_image')) h-auto @endif">
                 @if(config('adminlte.usermenu_image'))
                     <img src="{{ Auth::user()->adminlte_image() }}"
-                         class="img-circle elevation-2"
+                         class="img-circle elevation-2 inline-block"
                          alt="{{ Auth::user()->name }}">
                 @endif
                 <p class="@if(!config('adminlte.usermenu_image')) mt-0 @endif">


### PR DESCRIPTION
Adding "inline-block" to User Images

| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

I have added some "inline-blocks", which will affect the correct positioning of the user's images in the User Menu.

The modified files are:
- resources\views\partials\navbar\menu-item-dropdown-user-menu.blade.php

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related enhancements.

#### Author

[Joan Salmoral Parramon - raskan](https://github.com/jsalmoralp)

#### Before

![image](https://user-images.githubusercontent.com/36802264/121783563-9ab1f000-cbaf-11eb-9319-79d8049fc400.png)
![image](https://user-images.githubusercontent.com/36802264/121783584-c339ea00-cbaf-11eb-8688-7fccc1304aaf.png)

#### After

![image](https://user-images.githubusercontent.com/36802264/121783643-1875fb80-cbb0-11eb-94d8-04efee241b56.png)
![image](https://user-images.githubusercontent.com/36802264/121783652-23c92700-cbb0-11eb-8e03-c971d99bcfa5.png)

