### PR TITLE
Add base support to iframe mode feature

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -429,6 +429,48 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | IFrame
+    |--------------------------------------------------------------------------
+    |
+    | Here we change the IFrame mode configuration. Note these changes will
+    | only apply to the view that extends and enable the IFrame mode.
+    | TODO: Reorganize and review these options.
+    |
+    | For detailed instructions you can look the <TODO> section here:
+    | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/...
+    |
+    */
+
+    'layout_iframe' => [
+        'url-default' => [
+            'url' => '',
+            'title' => 'Home',
+        ],
+        'buttons' => [
+            'close'=> [
+                'active' => true,
+                'caption' => 'Close',
+            ],
+            'close-all'=> [
+                'active' => true,
+                'caption' => 'Close All',
+            ],
+            'close-all-other'=> [
+                'active' => true,
+                'caption' => 'Close All Other',
+            ],
+            'scroll-left'=> true,
+            'scroll-right'=> true,
+            'fullscreen'=> true,
+        ],
+        'captions' => [
+            'no-tab' => 'No tab selected!',
+            'loading' => 'Tab is loading',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Livewire
     |--------------------------------------------------------------------------
     |
@@ -436,6 +478,7 @@ return [
     |
     | For detailed instructions you can look the livewire here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Other-Configuration
+    |
     */
 
     'livewire' => false,

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -33,25 +33,11 @@
         @endif
 
         {{-- Content Wrapper --}}
-        <div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
-
-            {{-- Content Header --}}
-            @hasSection('content_header')
-                <div class="content-header">
-                    <div class="{{ config('adminlte.classes_content_header') ?: $def_container_class }}">
-                        @yield('content_header')
-                    </div>
-                </div>
-            @endif
-
-            {{-- Main Content --}}
-            <div class="content">
-                <div class="{{ config('adminlte.classes_content') ?: $def_container_class }}">
-                    @yield('content')
-                </div>
-            </div>
-
-        </div>
+        @empty($iframeEnabled)
+            @include('adminlte::partials.cwrapper.cwrapper-default')
+        @else
+            @include('adminlte::partials.cwrapper.cwrapper-iframe')
+        @endempty
 
         {{-- Footer --}}
         @hasSection('footer')

--- a/resources/views/partials/cwrapper/cwrapper-default.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-default.blade.php
@@ -1,0 +1,21 @@
+{{-- Content Wrapper --}}
+
+<div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
+
+    {{-- Content Header --}}
+    @hasSection('content_header')
+        <div class="content-header">
+            <div class="{{ config('adminlte.classes_content_header') ?: $def_container_class }}">
+                @yield('content_header')
+            </div>
+        </div>
+    @endif
+
+    {{-- Main Content --}}
+    <div class="content">
+        <div class="{{ config('adminlte.classes_content') ?: $def_container_class }}">
+            @yield('content')
+        </div>
+    </div>
+
+</div>

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -1,0 +1,66 @@
+{{-- Content wrapper for IFrame mode --}}
+
+<div class="content-wrapper iframe-mode" data-widget="iframe" data-loading-screen="750">
+    <div class="nav navbar navbar-expand navbar-white navbar-light border-bottom p-0">
+        <div class="nav-item dropdown">
+            @if(config('adminlte.layout_iframe.buttons.close.active'))
+                @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                    <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ config('adminlte.layout_iframe.buttons.close.caption') }}</a>
+                @else
+                    <a class="nav-link bg-danger" href="#" data-widget="iframe-close">Close</a>
+                @endif
+            @endif
+            @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                <div class="dropdown-menu mt-0">
+                    @if(config('adminlte.layout_iframe.buttons.close-all.active'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">{{ config('adminlte.layout_iframe.buttons.close-all.caption') }}</a>
+                    @endif
+                    @if(config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">{{ config('adminlte.layout_iframe.buttons.close-all-other.caption') }}</a>
+                    @endif
+                </div>
+            @endif
+        </div>
+
+        {{-- Render button left --}}
+        @if(config('adminlte.layout_iframe.buttons.scroll-left'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft"><i class="fas fa-angle-double-left"></i></a>
+        @endif
+
+        <ul class="navbar-nav" role="tablist">
+            {{-- Starting a page by default --}}
+            @if(!empty(config('adminlte.layout_iframe.url-default.url')))
+                <li class="nav-item active" role="presentation">
+                    <a class="nav-link active" data-toggle="row" id="tab-index" href="#panel-index" role="tab" aria-controls="panel-index" aria-selected="true">
+                        {{ config('adminlte.layout_iframe.url-default.title') ?: 'Dashboard' }}
+                    </a>
+                </li>
+            @endif
+        </ul>
+
+        {{-- Render button Right --}}
+        @if(config('adminlte.layout_iframe.buttons.scroll-right'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright"><i class="fas fa-angle-double-right"></i></a>
+        @endif
+
+        {{-- Render button Fullscreen --}}
+        @if(config('adminlte.layout_iframe.buttons.fullscreen'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen"><i class="fas fa-expand"></i></a>
+        @endif
+    </div>
+    <div class="tab-content">
+        @if(!empty(config('adminlte.layout_iframe.url-default.url')))
+            <div class="tab-pane fade active show" id="panel-index" role="tabpanel" aria-labelledby="tab-index">
+                <iframe src=" {{ config('adminlte.layout_iframe.url-default.url') }}" style="height: 671px;"></iframe>
+            </div>
+        @endif
+        <div class="tab-empty">
+            <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.no-tab') ?: 'No tab selected!' }}</h2>
+        </div>
+        <div class="tab-loading">
+            <div>
+                <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.loading') ?: 'Tab is loading' }} <i class="fa fa-sync fa-spin"></i></h2>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add base logic to support `IFrame` mode feature. To use the `IFrame` mode, the user should define his main/root view as just:

```blade
@extends('adminlte::page', ['iframeEnabled' => true])
```

All other views will be defines as before ([see usage](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Usage)):

```blade
@extends('adminlte::page')
...
...
...
```

#### Checklist

- [ ] I tested these changes.
- [x] I have linked the related issues.