### PR TITLE
Add support to iframe mode feature

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -429,6 +429,48 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | IFrame
+    |--------------------------------------------------------------------------
+    |
+    | Here we change the IFrame mode configuration. Note these changes will
+    | only apply to the view that extends and enable the IFrame mode.
+    | TODO: Reorganize and review these options.
+    |
+    | For detailed instructions you can look the <TODO> section here:
+    | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/...
+    |
+    */
+
+    'layout_iframe' => [
+        'url-default' => [
+            'url' => '',
+            'title' => 'Home',
+        ],
+        'buttons' => [
+            'close'=> [
+                'active' => true,
+                'caption' => 'Close',
+            ],
+            'close-all'=> [
+                'active' => true,
+                'caption' => 'Close All',
+            ],
+            'close-all-other'=> [
+                'active' => true,
+                'caption' => 'Close All Other',
+            ],
+            'scroll-left'=> true,
+            'scroll-right'=> true,
+            'fullscreen'=> true,
+        ],
+        'captions' => [
+            'no-tab' => 'No tab selected!',
+            'loading' => 'Tab is loading',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Livewire
     |--------------------------------------------------------------------------
     |
@@ -436,6 +478,7 @@ return [
     |
     | For detailed instructions you can look the livewire here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Other-Configuration
+    |
     */
 
     'livewire' => false,

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -434,38 +434,27 @@ return [
     |
     | Here we change the IFrame mode configuration. Note these changes will
     | only apply to the view that extends and enable the IFrame mode.
-    | TODO: Reorganize and review these options.
     |
     | For detailed instructions you can look the <TODO> section here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/...
     |
     */
 
-    'layout_iframe' => [
-        'url-default' => [
-            'url' => '',
-            'title' => 'Home',
+    'iframe' => [
+        'default_tab' => [
+            'url' => null,
+            'title' => null,
         ],
         'buttons' => [
-            'close'=> [
-                'active' => true,
-                'caption' => 'Close',
-            ],
-            'close-all'=> [
-                'active' => true,
-                'caption' => 'Close All',
-            ],
-            'close-all-other'=> [
-                'active' => true,
-                'caption' => 'Close All Other',
-            ],
-            'scroll-left'=> true,
-            'scroll-right'=> true,
-            'fullscreen'=> true,
+            'close' => true,
+            'close_all' => true,
+            'close_all_other' => true,
+            'scroll_left' => true,
+            'scroll_right' => true,
+            'fullscreen' => true,
         ],
-        'captions' => [
-            'no-tab' => 'No tab selected!',
-            'loading' => 'Tab is loading',
+        'options' => [
+            'loading_screen' => 1000,
         ],
     ],
 

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -455,6 +455,8 @@ return [
         ],
         'options' => [
             'loading_screen' => 1000,
+            'auto_show_new_tab' => true,
+            'use_navbar_items' => true,
         ],
     ],
 

--- a/resources/lang/en/iframe.php
+++ b/resources/lang/en/iframe.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | IFrame Mode Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the AdminLTE IFrame mode blade
+    | layout. You are free to modify these language lines according to your
+    | application's requirements.
+    |
+    */
+
+    'btn_close' => 'Close',
+    'btn_close_active' => 'Close Active',
+    'btn_close_all' => 'Close All',
+    'btn_close_all_other' => 'Close Everything Else',
+    'tab_empty' => 'No tab selected!',
+    'tab_home' => 'Home',
+    'tab_loading' => 'Tab is loading',
+
+];

--- a/resources/lang/es/iframe.php
+++ b/resources/lang/es/iframe.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | IFrame Mode Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the AdminLTE IFrame mode blade
+    | layout. You are free to modify these language lines according to your
+    | application's requirements.
+    |
+    */
+
+    'btn_close' => 'Cerrar',
+    'btn_close_active' => 'Cerrar Activa',
+    'btn_close_all' => 'Cerrar Todas',
+    'btn_close_all_other' => 'Cerrar Las Demás',
+    'tab_empty' => 'Ninguna pestaña seleccionada!',
+    'tab_home' => 'Inicio',
+    'tab_loading' => 'Cargando pestaña',
+
+];

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -33,25 +33,11 @@
         @endif
 
         {{-- Content Wrapper --}}
-        <div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
-
-            {{-- Content Header --}}
-            @hasSection('content_header')
-                <div class="content-header">
-                    <div class="{{ config('adminlte.classes_content_header') ?: $def_container_class }}">
-                        @yield('content_header')
-                    </div>
-                </div>
-            @endif
-
-            {{-- Main Content --}}
-            <div class="content">
-                <div class="{{ config('adminlte.classes_content') ?: $def_container_class }}">
-                    @yield('content')
-                </div>
-            </div>
-
-        </div>
+        @empty($iframeEnabled)
+            @include('adminlte::partials.cwrapper.cwrapper-default')
+        @else
+            @include('adminlte::partials.cwrapper.cwrapper-iframe')
+        @endempty
 
         {{-- Footer --}}
         @hasSection('footer')

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -2,12 +2,6 @@
 
 @inject('layoutHelper', 'JeroenNoten\LaravelAdminLte\Helpers\LayoutHelper')
 
-@if($layoutHelper->isLayoutTopnavEnabled())
-    @php( $def_container_class = 'container' )
-@else
-    @php( $def_container_class = 'container-fluid' )
-@endif
-
 @section('adminlte_css')
     @stack('css')
     @yield('css')
@@ -33,7 +27,7 @@
         @endif
 
         {{-- Content Wrapper --}}
-        @empty($iframeEnabled)
+        @empty($iFrameEnabled)
             @include('adminlte::partials.cwrapper.cwrapper-default')
         @else
             @include('adminlte::partials.cwrapper.cwrapper-iframe')

--- a/resources/views/partials/cwrapper/cwrapper-default.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-default.blade.php
@@ -1,0 +1,21 @@
+{{-- Content Wrapper --}}
+
+<div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
+
+    {{-- Content Header --}}
+    @hasSection('content_header')
+        <div class="content-header">
+            <div class="{{ config('adminlte.classes_content_header') ?: $def_container_class }}">
+                @yield('content_header')
+            </div>
+        </div>
+    @endif
+
+    {{-- Main Content --}}
+    <div class="content">
+        <div class="{{ config('adminlte.classes_content') ?: $def_container_class }}">
+            @yield('content')
+        </div>
+    </div>
+
+</div>

--- a/resources/views/partials/cwrapper/cwrapper-default.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-default.blade.php
@@ -7,7 +7,7 @@
 @endif
 
 {{-- Default Content Wrapper --}}
-<div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
+<div class="content-wrapper {{ config('adminlte.classes_content_wrapper', '') }}">
 
     {{-- Content Header --}}
     @hasSection('content_header')

--- a/resources/views/partials/cwrapper/cwrapper-default.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-default.blade.php
@@ -1,5 +1,12 @@
-{{-- Content Wrapper --}}
+@inject('layoutHelper', 'JeroenNoten\LaravelAdminLte\Helpers\LayoutHelper')
 
+@if($layoutHelper->isLayoutTopnavEnabled())
+    @php( $def_container_class = 'container' )
+@else
+    @php( $def_container_class = 'container-fluid' )
+@endif
+
+{{-- Default Content Wrapper --}}
 <div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
 
     {{-- Content Header --}}

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -1,0 +1,66 @@
+{{-- Content wrapper for IFrame mode --}}
+
+<div class="content-wrapper iframe-mode" data-widget="iframe" data-loading-screen="750">
+    <div class="nav navbar navbar-expand navbar-white navbar-light border-bottom p-0">
+        <div class="nav-item dropdown">
+            @if(config('adminlte.layout_iframe.buttons.close.active'))
+                @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                    <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ config('adminlte.layout_iframe.buttons.close.caption') }}</a>
+                @else
+                    <a class="nav-link bg-danger" href="#" data-widget="iframe-close">Close</a>
+                @endif
+            @endif
+            @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                <div class="dropdown-menu mt-0">
+                    @if(config('adminlte.layout_iframe.buttons.close-all.active'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">{{ config('adminlte.layout_iframe.buttons.close-all.caption') }}</a>
+                    @endif
+                    @if(config('adminlte.layout_iframe.buttons.close-all-other.active'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">{{ config('adminlte.layout_iframe.buttons.close-all-other.caption') }}</a>
+                    @endif
+                </div>
+            @endif
+        </div>
+
+        {{-- Render button left --}}
+        @if(config('adminlte.layout_iframe.buttons.scroll-left'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft"><i class="fas fa-angle-double-left"></i></a>
+        @endif
+
+        <ul class="navbar-nav" role="tablist">
+            {{-- Starting a page by default --}}
+            @if(!empty(config('adminlte.layout_iframe.url-default.url')))
+                <li class="nav-item active" role="presentation">
+                    <a class="nav-link active" data-toggle="row" id="tab-index" href="#panel-index" role="tab" aria-controls="panel-index" aria-selected="true">
+                        {{ config('adminlte.layout_iframe.url-default.title') ?: 'Dashboard' }}
+                    </a>
+                </li>
+            @endif
+        </ul>
+
+        {{-- Render button Right --}}
+        @if(config('adminlte.layout_iframe.buttons.scroll-right'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright"><i class="fas fa-angle-double-right"></i></a>
+        @endif
+
+        {{-- Render button Fullscreen --}}
+        @if(config('adminlte.layout_iframe.buttons.fullscreen'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen"><i class="fas fa-expand"></i></a>
+        @endif
+    </div>
+    <div class="tab-content">
+        @if(!empty(config('adminlte.layout_iframe.url-default.url')))
+            <div class="tab-pane fade active show" id="panel-index" role="tabpanel" aria-labelledby="tab-index">
+                <iframe src=" {{ config('adminlte.layout_iframe.url-default.url') }}" style="height: 671px;"></iframe>
+            </div>
+        @endif
+        <div class="tab-empty">
+            <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.no-tab') ?: 'No tab selected!' }}</h2>
+        </div>
+        <div class="tab-loading">
+            <div>
+                <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.loading') ?: 'Tab is loading' }} <i class="fa fa-sync fa-spin"></i></h2>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -53,7 +53,7 @@
         <ul class="navbar-nav" role="tablist">
 
             {{-- Default Tab --}}
-            @if(! empty(config('adminlte.iframe.default_tab.url', null)))
+            @if(! empty(config('adminlte.iframe.default_tab.url')))
                 <li class="nav-item active" role="presentation">
                     <a id="tab-default" class="nav-link active" data-toggle="row" href="#panel-default"
                        role="tab" aria-controls="panel-default" aria-selected="true">
@@ -85,9 +85,10 @@
     <div class="tab-content">
 
         {{-- Default Tab Content --}}
-        @if(! empty(config('adminlte.iframe.default_tab.url', null)))
+        @if(! empty(config('adminlte.iframe.default_tab.url')))
             <div id="panel-default" class="tab-pane fade active show" role="tabpanel" aria-labelledby="tab-default">
                 {{-- TODO: Height can't be harcoded, because it depends on user screen size --}}
+                {{-- TODO: This should be fixed on the underlying AdminLTE package --}}
                 <iframe src="{{ config('adminlte.iframe.default_tab.url') }}" style="height: 671px;"></iframe>
             </div>
         @endif

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -1,66 +1,115 @@
-{{-- Content wrapper for IFrame mode --}}
+{{-- IFrame Content Wrapper --}}
 
-<div class="content-wrapper iframe-mode" data-widget="iframe" data-loading-screen="750">
+{{-- TODO: Add config for other properties --}}
+<div class="content-wrapper iframe-mode {{ config('adminlte.classes_content_wrapper') ?? '' }}" data-widget="iframe"
+     data-loading-screen="{{ config('adminlte.iframe.options.loading_screen') ?? false }}">
+
+    {{-- IFrame Navbar --}}
     <div class="nav navbar navbar-expand navbar-white navbar-light border-bottom p-0">
-        <div class="nav-item dropdown">
-            @if(config('adminlte.layout_iframe.buttons.close.active'))
-                @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
-                    <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ config('adminlte.layout_iframe.buttons.close.caption') }}</a>
-                @else
-                    <a class="nav-link bg-danger" href="#" data-widget="iframe-close">Close</a>
-                @endif
-            @endif
-            @if(config('adminlte.layout_iframe.buttons.close-all.active') || config('adminlte.layout_iframe.buttons.close-all-other.active'))
+
+        {{-- Close Buttons --}}
+        @if(config('adminlte.iframe.buttons.close_all') || config('adminlte.iframe.buttons.close_all_other'))
+
+            <div class="nav-item dropdown">
+                <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#"
+                   role="button" aria-haspopup="true" aria-expanded="false">
+                    {{ __('adminlte::iframe.btn_close') }}
+                </a>
                 <div class="dropdown-menu mt-0">
-                    @if(config('adminlte.layout_iframe.buttons.close-all.active'))
-                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">{{ config('adminlte.layout_iframe.buttons.close-all.caption') }}</a>
+                    @if(config('adminlte.iframe.buttons.close'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close">
+                            {{ __('adminlte::iframe.btn_close_active') }}
+                        </a>
                     @endif
-                    @if(config('adminlte.layout_iframe.buttons.close-all-other.active'))
-                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">{{ config('adminlte.layout_iframe.buttons.close-all-other.caption') }}</a>
+                    @if(config('adminlte.iframe.buttons.close_all'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">
+                            {{ __('adminlte::iframe.btn_close_all') }}
+                        </a>
+                    @endif
+                    @if(config('adminlte.iframe.buttons.close_all_other'))
+                        <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">
+                            {{ __('adminlte::iframe.btn_close_all_other') }}
+                        </a>
                     @endif
                 </div>
-            @endif
-        </div>
+            </div>
 
-        {{-- Render button left --}}
-        @if(config('adminlte.layout_iframe.buttons.scroll-left'))
-            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft"><i class="fas fa-angle-double-left"></i></a>
+        @elseif(config('adminlte.iframe.buttons.close'))
+
+            <a class="nav-link bg-danger" href="#" data-widget="iframe-close">
+                 {{ __('adminlte::iframe.btn_close') }}
+            </a>
+
         @endif
 
+        {{-- Scroll Left Button --}}
+        @if(config('adminlte.iframe.buttons.scroll_left'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft">
+                <i class="fas fa-angle-double-left"></i>
+            </a>
+        @endif
+
+        {{-- Tab List --}}
         <ul class="navbar-nav" role="tablist">
-            {{-- Starting a page by default --}}
-            @if(!empty(config('adminlte.layout_iframe.url-default.url')))
+
+            {{-- Default Tab --}}
+            @if(! empty(config('adminlte.iframe.default_tab.url')))
                 <li class="nav-item active" role="presentation">
-                    <a class="nav-link active" data-toggle="row" id="tab-index" href="#panel-index" role="tab" aria-controls="panel-index" aria-selected="true">
-                        {{ config('adminlte.layout_iframe.url-default.title') ?: 'Dashboard' }}
+                    <a id="tab-default" class="nav-link active" data-toggle="row" href="#panel-default"
+                       role="tab" aria-controls="panel-default" aria-selected="true">
+                        {{-- TODO: How to translate the configured title? --}}
+                        {{ config('adminlte.iframe.default_tab.title') ?: __('adminlte::iframe.tab_home') }}
                     </a>
                 </li>
             @endif
+
         </ul>
 
-        {{-- Render button Right --}}
-        @if(config('adminlte.layout_iframe.buttons.scroll-right'))
-            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright"><i class="fas fa-angle-double-right"></i></a>
+        {{-- Scroll Right Button --}}
+        @if(config('adminlte.iframe.buttons.scroll_right'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright">
+                <i class="fas fa-angle-double-right"></i>
+            </a>
         @endif
 
-        {{-- Render button Fullscreen --}}
-        @if(config('adminlte.layout_iframe.buttons.fullscreen'))
-            <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen"><i class="fas fa-expand"></i></a>
+        {{-- Fullscreen Button --}}
+        @if(config('adminlte.iframe.buttons.fullscreen'))
+            <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen">
+                <i class="fas fa-expand"></i>
+            </a>
         @endif
+
     </div>
+
+    {{-- IFrame Tab Content --}}
     <div class="tab-content">
-        @if(!empty(config('adminlte.layout_iframe.url-default.url')))
-            <div class="tab-pane fade active show" id="panel-index" role="tabpanel" aria-labelledby="tab-index">
-                <iframe src=" {{ config('adminlte.layout_iframe.url-default.url') }}" style="height: 671px;"></iframe>
+
+        {{-- Default Tab Content --}}
+        @if(! empty(config('adminlte.iframe.default_tab.url')))
+            <div id="panel-default" class="tab-pane fade active show" role="tabpanel" aria-labelledby="tab-default">
+                {{-- TODO: Height can't be harcoded, because it depends on user screen size --}}
+                <iframe src="{{ config('adminlte.iframe.default_tab.url') }}" style="height: 671px;"></iframe>
             </div>
         @endif
+
+        {{-- Empty Tab --}}
         <div class="tab-empty">
-            <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.no-tab') ?: 'No tab selected!' }}</h2>
+            <h2 class="display-4 text-center">
+                {{ __('adminlte::iframe.tab_empty') }}
+            </h2>
         </div>
+
+        {{-- Loading Overlay --}}
         <div class="tab-loading">
-            <div>
-                <h2 class="display-4">{{ config('adminlte.layout_iframe.captions.loading') ?: 'Tab is loading' }} <i class="fa fa-sync fa-spin"></i></h2>
-            </div>
+        <div>
+            <h2 class="display-4 text-center">
+                <i class="fa fa-sync fa-spin text-secondary"></i>
+                <br/>
+                {{ __('adminlte::iframe.tab_loading') }}
+            </h2>
         </div>
+        </div>
+
     </div>
+
 </div>

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -1,14 +1,14 @@
 {{-- IFrame Content Wrapper --}}
-
-{{-- TODO: Add config for other properties --}}
-<div class="content-wrapper iframe-mode {{ config('adminlte.classes_content_wrapper') ?? '' }}" data-widget="iframe"
-     data-loading-screen="{{ config('adminlte.iframe.options.loading_screen') ?? false }}">
+<div class="content-wrapper iframe-mode {{ config('adminlte.classes_content_wrapper', '') }}" data-widget="iframe"
+     data-auto-show-new-tab="{{ config('adminlte.iframe.options.auto_show_new_tab', true) }}"
+     data-loading-screen="{{ config('adminlte.iframe.options.loading_screen', true) }}"
+     data-use-navbar-items="{{ config('adminlte.iframe.options.use_navbar_items', true) }}">
 
     {{-- IFrame Navbar --}}
     <div class="nav navbar navbar-expand navbar-white navbar-light border-bottom p-0">
 
         {{-- Close Buttons --}}
-        @if(config('adminlte.iframe.buttons.close_all') || config('adminlte.iframe.buttons.close_all_other'))
+        @if(config('adminlte.iframe.buttons.close_all', true) || config('adminlte.iframe.buttons.close_all_other', true))
 
             <div class="nav-item dropdown">
                 <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#"
@@ -16,17 +16,17 @@
                     {{ __('adminlte::iframe.btn_close') }}
                 </a>
                 <div class="dropdown-menu mt-0">
-                    @if(config('adminlte.iframe.buttons.close'))
+                    @if(config('adminlte.iframe.buttons.close', false))
                         <a class="dropdown-item" href="#" data-widget="iframe-close">
                             {{ __('adminlte::iframe.btn_close_active') }}
                         </a>
                     @endif
-                    @if(config('adminlte.iframe.buttons.close_all'))
+                    @if(config('adminlte.iframe.buttons.close_all', true))
                         <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">
                             {{ __('adminlte::iframe.btn_close_all') }}
                         </a>
                     @endif
-                    @if(config('adminlte.iframe.buttons.close_all_other'))
+                    @if(config('adminlte.iframe.buttons.close_all_other', true))
                         <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">
                             {{ __('adminlte::iframe.btn_close_all_other') }}
                         </a>
@@ -34,7 +34,7 @@
                 </div>
             </div>
 
-        @elseif(config('adminlte.iframe.buttons.close'))
+        @elseif(config('adminlte.iframe.buttons.close', false))
 
             <a class="nav-link bg-danger" href="#" data-widget="iframe-close">
                  {{ __('adminlte::iframe.btn_close') }}
@@ -43,7 +43,7 @@
         @endif
 
         {{-- Scroll Left Button --}}
-        @if(config('adminlte.iframe.buttons.scroll_left'))
+        @if(config('adminlte.iframe.buttons.scroll_left', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft">
                 <i class="fas fa-angle-double-left"></i>
             </a>
@@ -53,7 +53,7 @@
         <ul class="navbar-nav" role="tablist">
 
             {{-- Default Tab --}}
-            @if(! empty(config('adminlte.iframe.default_tab.url')))
+            @if(! empty(config('adminlte.iframe.default_tab.url', null)))
                 <li class="nav-item active" role="presentation">
                     <a id="tab-default" class="nav-link active" data-toggle="row" href="#panel-default"
                        role="tab" aria-controls="panel-default" aria-selected="true">
@@ -66,14 +66,14 @@
         </ul>
 
         {{-- Scroll Right Button --}}
-        @if(config('adminlte.iframe.buttons.scroll_right'))
+        @if(config('adminlte.iframe.buttons.scroll_right', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright">
                 <i class="fas fa-angle-double-right"></i>
             </a>
         @endif
 
         {{-- Fullscreen Button --}}
-        @if(config('adminlte.iframe.buttons.fullscreen'))
+        @if(config('adminlte.iframe.buttons.fullscreen', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen">
                 <i class="fas fa-expand"></i>
             </a>
@@ -85,7 +85,7 @@
     <div class="tab-content">
 
         {{-- Default Tab Content --}}
-        @if(! empty(config('adminlte.iframe.default_tab.url')))
+        @if(! empty(config('adminlte.iframe.default_tab.url', null)))
             <div id="panel-default" class="tab-pane fade active show" role="tabpanel" aria-labelledby="tab-default">
                 {{-- TODO: Height can't be harcoded, because it depends on user screen size --}}
                 <iframe src="{{ config('adminlte.iframe.default_tab.url') }}" style="height: 671px;"></iframe>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add base logic to support `IFrame` mode feature. To use the `IFrame` mode, the user should define his main/root view as just:

```blade
@extends('adminlte::page', ['iFrameEnabled' => true])
```

All other views will be defined as before ([see usage](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Usage)):

```blade
@extends('adminlte::page')
...
...
...
```

Also, there is a new section on the configuration file to setup the `IFrame` mode:

```php
'iframe' => [
    'default_tab' => [
        'url' => null,
        'title' => null,
    ],
    'buttons' => [
        'close' => true,
        'close_all' => true,
        'close_all_other' => true,
        'scroll_left' => true,
        'scroll_right' => true,
        'fullscreen' => true,
    ],
    'options' => [
        'loading_screen' => 1000,
        'auto_show_new_tab' => true,
        'use_navbar_items' => true,
    ],
],
```

Option | Type | Default | Description
----------|--------|------------|---------------
default_tab.url | string / null | `null` | An `url` for the default tab. If defined, it will enable a default tab on initialization
default_tab.title | string / null | `null` | The title for the default tab. When `null`, the translation of `Home` will be displayed
buttons.close | bool | `false` | Whether to enable a button to close the currently active tab
buttons.close_all | bool | `true` | Whether to enable a button to close all tabs
buttons.close_all_other | bool | `true` | Whether to enable a button to close all tabs except the active one
buttons.scroll_left | bool | `true` | Whether to enable the scroll left button
buttons.scroll_right | bool | `true` | Whether to enable the scroll right button
buttons.fullscreen | bool | `true` | Whether to enable the full screen button
options.loading_screen | bool / number | `true` | Use a `bool` to enable/disable a loading screen. Use a positive `number` to setup the loading screen hide delay (this implicitly enables the loading screen)
options.auto_show_new_tab | bool | `true` | Whether to automatically display a new opened tab
options.use_navbar_items | bool | `true` | Whether to also open the top navbar menu items in tabs, instead of open only sidebar menu items

> **Note**: Default values are used when the configuration option do not exists on the configuration file.

#### Checklist

- [ ] I tested these changes.
- [x] I have linked the related issues.
- [x] Make reorganization on the configuration.
- [x] Review the IFrame content wrapper blade view.
- [x] Add support to underlying plugin configuration.
- [ ] Create documentation on the wiki