### PR TITLE
Add new IFrame configuration options

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -455,6 +455,8 @@ return [
         ],
         'options' => [
             'loading_screen' => 1000,
+            'auto_show_new_tab' => true,
+            'use_navbar_items' => true,
         ],
     ],
 

--- a/resources/views/partials/cwrapper/cwrapper-default.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-default.blade.php
@@ -7,7 +7,7 @@
 @endif
 
 {{-- Default Content Wrapper --}}
-<div class="content-wrapper {{ config('adminlte.classes_content_wrapper') ?? '' }}">
+<div class="content-wrapper {{ config('adminlte.classes_content_wrapper', '') }}">
 
     {{-- Content Header --}}
     @hasSection('content_header')

--- a/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
+++ b/resources/views/partials/cwrapper/cwrapper-iframe.blade.php
@@ -1,14 +1,14 @@
 {{-- IFrame Content Wrapper --}}
-
-{{-- TODO: Add config for other properties --}}
-<div class="content-wrapper iframe-mode {{ config('adminlte.classes_content_wrapper') ?? '' }}" data-widget="iframe"
-     data-loading-screen="{{ config('adminlte.iframe.options.loading_screen') ?? false }}">
+<div class="content-wrapper iframe-mode {{ config('adminlte.classes_content_wrapper', '') }}" data-widget="iframe"
+     data-auto-show-new-tab="{{ config('adminlte.iframe.options.auto_show_new_tab', true) }}"
+     data-loading-screen="{{ config('adminlte.iframe.options.loading_screen', true) }}"
+     data-use-navbar-items="{{ config('adminlte.iframe.options.use_navbar_items', true) }}">
 
     {{-- IFrame Navbar --}}
     <div class="nav navbar navbar-expand navbar-white navbar-light border-bottom p-0">
 
         {{-- Close Buttons --}}
-        @if(config('adminlte.iframe.buttons.close_all') || config('adminlte.iframe.buttons.close_all_other'))
+        @if(config('adminlte.iframe.buttons.close_all', true) || config('adminlte.iframe.buttons.close_all_other', true))
 
             <div class="nav-item dropdown">
                 <a class="nav-link bg-danger dropdown-toggle" data-toggle="dropdown" href="#"
@@ -16,17 +16,17 @@
                     {{ __('adminlte::iframe.btn_close') }}
                 </a>
                 <div class="dropdown-menu mt-0">
-                    @if(config('adminlte.iframe.buttons.close'))
+                    @if(config('adminlte.iframe.buttons.close', false))
                         <a class="dropdown-item" href="#" data-widget="iframe-close">
                             {{ __('adminlte::iframe.btn_close_active') }}
                         </a>
                     @endif
-                    @if(config('adminlte.iframe.buttons.close_all'))
+                    @if(config('adminlte.iframe.buttons.close_all', true))
                         <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all">
                             {{ __('adminlte::iframe.btn_close_all') }}
                         </a>
                     @endif
-                    @if(config('adminlte.iframe.buttons.close_all_other'))
+                    @if(config('adminlte.iframe.buttons.close_all_other', true))
                         <a class="dropdown-item" href="#" data-widget="iframe-close" data-type="all-other">
                             {{ __('adminlte::iframe.btn_close_all_other') }}
                         </a>
@@ -34,7 +34,7 @@
                 </div>
             </div>
 
-        @elseif(config('adminlte.iframe.buttons.close'))
+        @elseif(config('adminlte.iframe.buttons.close', false))
 
             <a class="nav-link bg-danger" href="#" data-widget="iframe-close">
                  {{ __('adminlte::iframe.btn_close') }}
@@ -43,7 +43,7 @@
         @endif
 
         {{-- Scroll Left Button --}}
-        @if(config('adminlte.iframe.buttons.scroll_left'))
+        @if(config('adminlte.iframe.buttons.scroll_left', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-scrollleft">
                 <i class="fas fa-angle-double-left"></i>
             </a>
@@ -53,7 +53,7 @@
         <ul class="navbar-nav" role="tablist">
 
             {{-- Default Tab --}}
-            @if(! empty(config('adminlte.iframe.default_tab.url')))
+            @if(! empty(config('adminlte.iframe.default_tab.url', null)))
                 <li class="nav-item active" role="presentation">
                     <a id="tab-default" class="nav-link active" data-toggle="row" href="#panel-default"
                        role="tab" aria-controls="panel-default" aria-selected="true">
@@ -66,14 +66,14 @@
         </ul>
 
         {{-- Scroll Right Button --}}
-        @if(config('adminlte.iframe.buttons.scroll_right'))
+        @if(config('adminlte.iframe.buttons.scroll_right', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-scrollright">
                 <i class="fas fa-angle-double-right"></i>
             </a>
         @endif
 
         {{-- Fullscreen Button --}}
-        @if(config('adminlte.iframe.buttons.fullscreen'))
+        @if(config('adminlte.iframe.buttons.fullscreen', true))
             <a class="nav-link bg-light" href="#" data-widget="iframe-fullscreen">
                 <i class="fas fa-expand"></i>
             </a>
@@ -85,7 +85,7 @@
     <div class="tab-content">
 
         {{-- Default Tab Content --}}
-        @if(! empty(config('adminlte.iframe.default_tab.url')))
+        @if(! empty(config('adminlte.iframe.default_tab.url', null)))
             <div id="panel-default" class="tab-pane fade active show" role="tabpanel" aria-labelledby="tab-default">
                 {{-- TODO: Height can't be harcoded, because it depends on user screen size --}}
                 <iframe src="{{ config('adminlte.iframe.default_tab.url') }}" style="height: 671px;"></iframe>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Add new configuration options for the **IFrame** mode (`auto_show_new_tab` and `use_navbar_items`).
- Enable default values for all configurations of the **IFrame** mode.

#### Checklist

- [x] I tested these changes.