### PR TITLE
Add Options component

### DIFF
--- a/resources/views/components/form/options.blade.php
+++ b/resources/views/components/form/options.blade.php
@@ -1,3 +1,9 @@
 @foreach($options as $key => $value)
-    <option value="{{ $key }}" @if(in_array($key, $selected, $strict)) selected @endif>{{ $value }}</option>
+
+    <option value="{{ $key }}"
+        @if($isSelected($key)) selected @endif
+        @if($isDisabled($key)) disabled @endif>
+        {{ $value }}
+    </option>
+
 @endforeach

--- a/resources/views/components/form/options.blade.php
+++ b/resources/views/components/form/options.blade.php
@@ -1,11 +1,18 @@
 {{-- Empty option --}}
-@isset($emptyOption)
+@if(isset($emptyOption))
 
-    <option class="d-none">
+    <option value>
         {{ is_string($emptyOption) ? $emptyOption : '' }}
     </option>
 
-@endisset
+{{-- Placeholder option --}}
+@elseif(isset($placeholder))
+
+    <option class="d-none" value>
+        {{ is_string($placeholder) ? $placeholder : '' }}
+    </option>
+
+@endif
 
 {{-- Other options --}}
 @foreach($options as $key => $value)

--- a/resources/views/components/form/options.blade.php
+++ b/resources/views/components/form/options.blade.php
@@ -1,0 +1,3 @@
+@foreach($options as $key => $value)
+    <option value="{{ $key }}" @if(in_array($key, $selected, $strict)) selected @endif>{{ $value }}</option>
+@endforeach

--- a/resources/views/components/form/options.blade.php
+++ b/resources/views/components/form/options.blade.php
@@ -1,3 +1,13 @@
+{{-- Empty option --}}
+@isset($emptyOption)
+
+    <option class="d-none">
+        {{ is_string($emptyOption) ? $emptyOption : '' }}
+    </option>
+
+@endisset
+
+{{-- Other options --}}
 @foreach($options as $key => $value)
 
     <option value="{{ $key }}"

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -41,6 +41,7 @@ class AdminLteServiceProvider extends BaseServiceProvider
         Components\Form\InputFile::class,
         Components\Form\InputSlider::class,
         Components\Form\InputSwitch::class,
+        Components\Form\Options::class,
         Components\Form\Select::class,
         Components\Form\Select2::class,
         Components\Form\SelectBs::class,

--- a/src/Components/Form/Options.php
+++ b/src/Components/Form/Options.php
@@ -22,6 +22,13 @@ class Options extends Component
     public $selected;
 
     /**
+     * The list of disabled option keys.
+     *
+     * @var array
+     */
+    public $disabled;
+
+    /**
      * Whether to use strict comparison between key and selections.
      *
      * @var bool
@@ -31,11 +38,35 @@ class Options extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct($options = null, $selected = null, $strict = null)
-    {
+    public function __construct(
+        $options, $selected = null, $disabled = null, $strict = null
+    ) {
         $this->options = Arr::wrap($options);
         $this->selected = Arr::wrap($selected);
+        $this->disabled = Arr::wrap($disabled);
         $this->strict = isset($strict);
+    }
+
+    /**
+     * Determines if an option's key is on selected state.
+     *
+     * @param string $key The option's key.
+     * @return bool
+     */
+    public function isSelected($key)
+    {
+        return in_array($key, $this->selected, $this->strict);
+    }
+
+    /**
+     * Determines if an option's key is on disabled state.
+     *
+     * @param string $key The option's key.
+     * @return bool
+     */
+    public function isDisabled($key)
+    {
+        return in_array($key, $this->disabled, $this->strict);
     }
 
     /**

--- a/src/Components/Form/Options.php
+++ b/src/Components/Form/Options.php
@@ -36,15 +36,26 @@ class Options extends Component
     public $strict;
 
     /**
+     * Whether to add an empty option to the list of options. If the value is
+     * a string, it will be used as the option label, otherwise no label will
+     * be available for the empty option.
+     *
+     * @var bool|string
+     */
+    public $emptyOption;
+
+    /**
      * Create a new component instance.
      */
     public function __construct(
-        $options, $selected = null, $disabled = null, $strict = null
+        $options, $selected = null, $disabled = null,
+        $strict = null, $emptyOption = null
     ) {
         $this->options = Arr::wrap($options);
         $this->selected = Arr::wrap($selected);
         $this->disabled = Arr::wrap($disabled);
         $this->strict = isset($strict);
+        $this->emptyOption = $emptyOption;
     }
 
     /**

--- a/src/Components/Form/Options.php
+++ b/src/Components/Form/Options.php
@@ -8,21 +8,21 @@ use Illuminate\View\Component;
 class Options extends Component
 {
     /**
-     * The list of options as key value pairs
+     * The list of options as key value pairs.
      *
      * @var array
      */
     public $options;
 
     /**
-     * The list of selected option keys
+     * The list of selected option keys.
      *
      * @var array
      */
     public $selected;
 
     /**
-     * Whether to use strict comparison between key and selections
+     * Whether to use strict comparison between key and selections.
      *
      * @var bool
      */

--- a/src/Components/Form/Options.php
+++ b/src/Components/Form/Options.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Components\Form;
+
+use Illuminate\Support\Arr;
+use Illuminate\View\Component;
+
+class Options extends Component
+{
+    /**
+     * The list of options as key value pairs
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
+     * The list of selected option keys
+     *
+     * @var array
+     */
+    public $selected;
+
+    /**
+     * Whether to use strict comparison between key and selections
+     *
+     * @var bool
+     */
+    public $strict;
+
+    /**
+     * Create a new component instance.
+     */
+    public function __construct($options = null, $selected = null, $strict = null)
+    {
+        $this->options = Arr::wrap($options);
+        $this->selected = Arr::wrap($selected);
+        $this->strict = isset($strict);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('adminlte::components.form.options');
+    }
+}

--- a/src/Components/Form/Options.php
+++ b/src/Components/Form/Options.php
@@ -29,33 +29,44 @@ class Options extends Component
     public $disabled;
 
     /**
-     * Whether to use strict comparison between key and selections.
+     * Whether to use strict comparison between the option keys and the keys of
+     * the selected/disabled options.
      *
      * @var bool
      */
     public $strict;
 
     /**
-     * Whether to add an empty option to the list of options. If the value is
-     * a string, it will be used as the option label, otherwise no label will
-     * be available for the empty option.
+     * Whether to add a selectable empty option to the list of options. If the
+     * value is a string, it will be used as the option label, otherwise no
+     * label will be available for the empty option.
      *
      * @var bool|string
      */
     public $emptyOption;
 
     /**
+     * Whether to add a placeholder (non-selectable option) to the list of
+     * options. If the value is a string, it will be used as the placeholder
+     * label, otherwise no label will be available for the placeholder.
+     *
+     * @var bool|string
+     */
+    public $placeholder;
+
+    /**
      * Create a new component instance.
      */
     public function __construct(
         $options, $selected = null, $disabled = null,
-        $strict = null, $emptyOption = null
+        $strict = null, $emptyOption = null, $placeholder = null
     ) {
         $this->options = Arr::wrap($options);
         $this->selected = Arr::wrap($selected);
         $this->disabled = Arr::wrap($disabled);
         $this->strict = isset($strict);
         $this->emptyOption = $emptyOption;
+        $this->placeholder = $placeholder;
     }
 
     /**

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -27,7 +27,7 @@ class FormComponentsTest extends TestCase
             "{$base}.select-bs"    => new Components\Form\SelectBs('name'),
             "{$base}.textarea"     => new Components\Form\Textarea('name'),
             "{$base}.text-editor"  => new Components\Form\TextEditor('name'),
-            "{$base}.options"      => new Components\Form\Options(),
+            "{$base}.options"      => new Components\Form\Options(['o1, o2']),
         ];
     }
 
@@ -142,6 +142,28 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 
+    public function testOptionsComponent()
+    {
+        $options = ['m' => 'Male', 'f' => 'Female', 'o' => 'Other'];
+        $component = new Components\Form\Options($options, 'f', 'o');
+
+        // Test selected / disabled options.
+
+        $this->assertFalse($component->isSelected('m'));
+        $this->assertTrue($component->isSelected('f'));
+        $this->assertFalse($component->isDisabled('m'));
+        $this->assertTrue($component->isDisabled('o'));
+
+        // Test rendered HTML.
+
+        $html = $component->resolveView()->with($component->data());
+        $format = '%A<option%avalue="m"%A>%AMale%A</option>%A';
+        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
+        $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
+
+        $this->assertStringMatchesFormat($format, $html);
+    }
+
     public function testSelectComponent()
     {
         $component = new Components\Form\Select('name');
@@ -152,17 +174,6 @@ class FormComponentsTest extends TestCase
 
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
-    }
-
-    public function testOptionsComponent()
-    {
-        $options = ['m' => 'Male', 'f' => 'Female', 'o' => 'Other'];
-        $component = new Components\Form\Options($options, 'f');
-        $html = $component->resolveView()->with($component->data());
-        $format = '%A<option%avalue="m"%A>%AMale%A</option>%A';
-        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
-        $format .= '<option%avalue="o"%A>%AOther%A</option>%A';
-        $this->assertStringMatchesFormat($format, $html);
     }
 
     public function testSelect2Component()

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\MessageBag;
+use Illuminate\Testing\TestView;
+use Illuminate\View\View;
 use JeroenNoten\LaravelAdminLte\Components;
 
 class FormComponentsTest extends TestCase
@@ -14,19 +16,20 @@ class FormComponentsTest extends TestCase
 
         return [
             "{$base}.input-group-component" => new Components\Form\InputGroupComponent('name'),
-            "{$base}.button"       => new Components\Form\Button(),
-            "{$base}.date-range"   => new Components\Form\DateRange('name'),
-            "{$base}.input"        => new Components\Form\Input('name'),
-            "{$base}.input-color"  => new Components\Form\InputColor('name'),
-            "{$base}.input-date"   => new Components\Form\InputDate('name'),
-            "{$base}.input-file"   => new Components\Form\InputFile('name'),
+            "{$base}.button" => new Components\Form\Button(),
+            "{$base}.date-range" => new Components\Form\DateRange('name'),
+            "{$base}.input" => new Components\Form\Input('name'),
+            "{$base}.input-color" => new Components\Form\InputColor('name'),
+            "{$base}.input-date" => new Components\Form\InputDate('name'),
+            "{$base}.input-file" => new Components\Form\InputFile('name'),
             "{$base}.input-slider" => new Components\Form\InputSlider('name'),
             "{$base}.input-switch" => new Components\Form\InputSwitch('name'),
-            "{$base}.select"       => new Components\Form\Select('name'),
-            "{$base}.select2"      => new Components\Form\Select2('name'),
-            "{$base}.select-bs"    => new Components\Form\SelectBs('name'),
-            "{$base}.textarea"     => new Components\Form\Textarea('name'),
-            "{$base}.text-editor"  => new Components\Form\TextEditor('name'),
+            "{$base}.select" => new Components\Form\Select('name'),
+            "{$base}.select2" => new Components\Form\Select2('name'),
+            "{$base}.select-bs" => new Components\Form\SelectBs('name'),
+            "{$base}.textarea" => new Components\Form\Textarea('name'),
+            "{$base}.text-editor" => new Components\Form\TextEditor('name'),
+            "{$base}.options" => new Components\Form\Options(),
         ];
     }
 
@@ -151,6 +154,18 @@ class FormComponentsTest extends TestCase
 
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testOptionsComponent()
+    {
+        $options = ['m' => 'Male', 'f' => 'Female', 'o' => 'Other'];
+        $component = new Components\Form\Options($options, 'f');
+        $view = $component->resolveView();
+        $view = $view instanceof View
+            ? new TestView($view->with($component->data()))
+            : new TestView(view($view, $component->data()));
+        $view->assertSeeInOrder(array_values($options));
+        $view->assertSeeInOrder(['value="m"', 'Male', 'value="f"', 'selected', 'Female', 'value="o"', 'Other'], false);
     }
 
     public function testSelect2Component()

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -168,7 +168,7 @@ class FormComponentsTest extends TestCase
         $component = new Components\Form\Options($options, 'f', 'o', null, true);
 
         $html = $component->resolveView()->with($component->data());
-        $format = '%A<option%Aclass="d-none"%A>%A</option>%A';
+        $format = '%A<option%Avalue%A>%A</option>%A';
         $format .= '%A<option%avalue="m"%A>%AMale%A</option>%A';
         $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
         $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
@@ -180,7 +180,19 @@ class FormComponentsTest extends TestCase
         $component = new Components\Form\Options($options, 'f', 'o', null, 'Label');
 
         $html = $component->resolveView()->with($component->data());
-        $format = '%A<option%Aclass="d-none"%A>%ALabel%A</option>%A';
+        $format = '%A<option%Avalue%A>%ALabel%A</option>%A';
+        $format .= '%A<option%avalue="m"%A>%AMale%A</option>%A';
+        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
+        $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
+
+        $this->assertStringMatchesFormat($format, $html);
+
+        // Test rendered HTML with placeholder.
+
+        $component = new Components\Form\Options($options, 'f', 'o', null, null, 'Placeholder');
+
+        $html = $component->resolveView()->with($component->data());
+        $format = '%A<option%Aclass="d-none"%Avalue%A>%APlaceholder%A</option>%A';
         $format .= '%A<option%avalue="m"%A>%AMale%A</option>%A';
         $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
         $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Support\MessageBag;
-use Illuminate\Testing\TestView;
-use Illuminate\View\View;
 use JeroenNoten\LaravelAdminLte\Components;
 
 class FormComponentsTest extends TestCase
@@ -16,20 +14,20 @@ class FormComponentsTest extends TestCase
 
         return [
             "{$base}.input-group-component" => new Components\Form\InputGroupComponent('name'),
-            "{$base}.button" => new Components\Form\Button(),
-            "{$base}.date-range" => new Components\Form\DateRange('name'),
-            "{$base}.input" => new Components\Form\Input('name'),
-            "{$base}.input-color" => new Components\Form\InputColor('name'),
-            "{$base}.input-date" => new Components\Form\InputDate('name'),
-            "{$base}.input-file" => new Components\Form\InputFile('name'),
+            "{$base}.button"       => new Components\Form\Button(),
+            "{$base}.date-range"   => new Components\Form\DateRange('name'),
+            "{$base}.input"        => new Components\Form\Input('name'),
+            "{$base}.input-color"  => new Components\Form\InputColor('name'),
+            "{$base}.input-date"   => new Components\Form\InputDate('name'),
+            "{$base}.input-file"   => new Components\Form\InputFile('name'),
             "{$base}.input-slider" => new Components\Form\InputSlider('name'),
             "{$base}.input-switch" => new Components\Form\InputSwitch('name'),
-            "{$base}.select" => new Components\Form\Select('name'),
-            "{$base}.select2" => new Components\Form\Select2('name'),
-            "{$base}.select-bs" => new Components\Form\SelectBs('name'),
-            "{$base}.textarea" => new Components\Form\Textarea('name'),
-            "{$base}.text-editor" => new Components\Form\TextEditor('name'),
-            "{$base}.options" => new Components\Form\Options(),
+            "{$base}.select"       => new Components\Form\Select('name'),
+            "{$base}.select2"      => new Components\Form\Select2('name'),
+            "{$base}.select-bs"    => new Components\Form\SelectBs('name'),
+            "{$base}.textarea"     => new Components\Form\Textarea('name'),
+            "{$base}.text-editor"  => new Components\Form\TextEditor('name'),
+            "{$base}.options"      => new Components\Form\Options(),
         ];
     }
 
@@ -160,12 +158,11 @@ class FormComponentsTest extends TestCase
     {
         $options = ['m' => 'Male', 'f' => 'Female', 'o' => 'Other'];
         $component = new Components\Form\Options($options, 'f');
-        $view = $component->resolveView();
-        $view = $view instanceof View
-            ? new TestView($view->with($component->data()))
-            : new TestView(view($view, $component->data()));
-        $view->assertSeeInOrder(array_values($options));
-        $view->assertSeeInOrder(['value="m"', 'Male', 'value="f"', 'selected', 'Female', 'value="o"', 'Other'], false);
+        $html = $component->resolveView()->with($component->data());
+        $format = '%A<option%avalue="m"%A>%AMale%A</option>%A';
+        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
+        $format .= '<option%avalue="o"%A>%AOther%A</option>%A';
+        $this->assertStringMatchesFormat($format, $html);
     }
 
     public function testSelect2Component()

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -162,6 +162,30 @@ class FormComponentsTest extends TestCase
         $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
 
         $this->assertStringMatchesFormat($format, $html);
+
+        // Test rendered HTML with empty option (no label).
+
+        $component = new Components\Form\Options($options, 'f', 'o', null, true);
+
+        $html = $component->resolveView()->with($component->data());
+        $format = '%A<option%Aclass="d-none"%A>%A</option>%A';
+        $format .= '%A<option%avalue="m"%A>%AMale%A</option>%A';
+        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
+        $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
+
+        $this->assertStringMatchesFormat($format, $html);
+
+        // Test rendered HTML with empty option (and label).
+
+        $component = new Components\Form\Options($options, 'f', 'o', null, 'Label');
+
+        $html = $component->resolveView()->with($component->data());
+        $format = '%A<option%Aclass="d-none"%A>%ALabel%A</option>%A';
+        $format .= '%A<option%avalue="m"%A>%AMale%A</option>%A';
+        $format .= '<option%avalue="f"%Aselected%A>%AFemale%A</option>%A';
+        $format .= '<option%avalue="o"%Adisabled%A>%AOther%A</option>%A';
+
+        $this->assertStringMatchesFormat($format, $html);
     }
 
     public function testSelectComponent()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

The PR adds option blade component. Fixes #890

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [x] Create documentation on Wiki.

#### Usage
```html
<x-adminlte-select name="myoption">
    <option value="">Select option...</option>
    <x-adminlte-options :options="$options" selected="$selectedOption"/>
</x-adminlte-select>

<x-adminlte-select name="color">
    <option value="">Select color...</option>
    <x-adminlte-options :options="['r'=>'Red','b'=>'Blue','g'=>'Green']" :selected="'g'"/>
</x-adminlte-select>

<x-adminlte-select name="enabled">
    <option value="">Select option...</option>
    <x-adminlte-options :options="['Disabled','Enabled']" :selected="0" strict/>
</x-adminlte-select>

<x-adminlte-select name="user">
    <option value="">Select user...</option>
    <x-adminlte-options :options="\App\Models\User::pluck('name','id')->all()" :selected="$model->user_id"/>
</x-adminlte-select>
```