### PR TITLE
Improve datatables component layout

### DIFF
--- a/src/Components/Tool/Datatable.php
+++ b/src/Components/Tool/Datatable.php
@@ -2,6 +2,7 @@
 
 namespace JeroenNoten\LaravelAdminLte\Components\Tool;
 
+use Illuminate\Support\Arr;
 use Illuminate\View\Component;
 
 class Datatable extends Component
@@ -261,12 +262,35 @@ class Datatable extends Component
             'exportOptions' => ['columns' => $colSelector],
         ];
 
-        // Return the set of configured buttons.
+        // The length change button should not be added if the configuration of
+        // datatables explicitly disable it.
+
+        $buttons = [$printBtn, $csvBtn, $excelBtn, $pdfBtn];
+
+        if ($this->isLengthButtonEnabled()) {
+            $buttons = Arr::prepend($buttons, $lengthBtn);
+        }
+
+        // Return the set of configured buttons.        
 
         return [
             'dom' => ['button' => ['className' => 'btn']],
-            'buttons' => [$lengthBtn, $printBtn, $csvBtn, $excelBtn, $pdfBtn],
+            'buttons' => $buttons,
         ];
+    }
+
+    /**
+     * Check if length button should be available on the set of tool buttons.
+     *
+     * @return bool
+     */
+    protected function isLengthButtonEnabled()
+    {
+        if (! isset($this->config['lengthChange'])) {
+            return true;
+        }
+
+        return (bool)$this->config['lengthChange'];
     }
 
     /**

--- a/src/Components/Tool/Datatable.php
+++ b/src/Components/Tool/Datatable.php
@@ -196,9 +196,9 @@ class Datatable extends Component
         // r - Processing display element.
         // B - buttons extension.
 
-        return '<"row" <"col-sm-6" B> <"col-sm-6" f> >
+        return '<"row" <"col-md-8" B> <"col-md-4" f> >
                 <"row" <"col-12" tr> >
-                <"row" <"col-sm-5" i> <"col-sm-7" p> >';
+                <"row" <"col-md-5" i> <"col-md-7" p> >';
     }
 
     /**

--- a/src/Components/Tool/Datatable.php
+++ b/src/Components/Tool/Datatable.php
@@ -271,7 +271,7 @@ class Datatable extends Component
             $buttons = Arr::prepend($buttons, $lengthBtn);
         }
 
-        // Return the set of configured buttons.        
+        // Return the set of configured buttons.
 
         return [
             'dom' => ['button' => ['className' => 'btn']],
@@ -290,7 +290,7 @@ class Datatable extends Component
             return true;
         }
 
-        return (bool)$this->config['lengthChange'];
+        return (bool) $this->config['lengthChange'];
     }
 
     /**

--- a/tests/Components/ToolComponentsTest.php
+++ b/tests/Components/ToolComponentsTest.php
@@ -40,6 +40,7 @@ class ToolComponentsTest extends TestCase
     public function testDatatableComponent()
     {
         // Test basic component.
+
         $component = new Components\Tool\Datatable('id', []);
 
         $tClass = $component->makeTableClass();
@@ -49,6 +50,7 @@ class ToolComponentsTest extends TestCase
         // $id, $heads, $theme, $headTheme, $bordered, $hoverable, $striped,
         // $compressed, $withFooter, $footerTheme, $beautify, $withButtons,
         // $config
+
         $component = new Components\Tool\Datatable(
             'id', [], 'primary', null, true, true, true, true, null, null,
             null, true, null
@@ -60,6 +62,26 @@ class ToolComponentsTest extends TestCase
         $this->assertStringContainsString('table-striped', $tClass);
         $this->assertStringContainsString('table-sm', $tClass);
         $this->assertStringContainsString('table-primary', $tClass);
+
+        $this->assertContains(
+            ['extend' => 'pageLength', 'className' => 'btn-default'],
+            $component->config['buttons']['buttons']
+        );
+
+        // Test advanced component with length change button disabled.
+        // $id, $heads, $theme, $headTheme, $bordered, $hoverable, $striped,
+        // $compressed, $withFooter, $footerTheme, $beautify, $withButtons,
+        // $config
+
+        $component = new Components\Tool\Datatable(
+            'id', [], 'primary', null, true, true, true, true, null, null,
+            null, true, ['lengthChange' => false]
+        );
+
+        $this->assertNotContains(
+            ['extend' => 'pageLength', 'className' => 'btn-default'],
+            $component->config['buttons']['buttons']
+        );
     }
 
     public function testModalComponent()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

 - Minor change to improve the underlying **Datatables** component layout to look nicely on multiple screen sizes.
 - The length change tool button will not be available when `lengthChange` property of datatables is explicitly set to `false`.

#### Checklist

- [x] I tested these changes.