### PR TITLE
Add old() support to x-adminlte-input-date component

### DIFF
--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -4,6 +4,7 @@
 
     {{-- Input Date --}}
     <input id="{{ $id }}" name="{{ $name }}" data-target="#{{ $id }}" data-toggle="datetimepicker"
+        value="{{ $makeItemValue($errorKey, $attributes->get('value')) }}"
         {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite

--- a/src/View/Components/Form/InputDate.php
+++ b/src/View/Components/Form/InputDate.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class InputDate extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The default set of icons for the Tempus Dominus plugin configuration.
      *
@@ -48,13 +50,14 @@ class InputDate extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = []
+        $errorKey = null, $config = [], $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
             $igroupClass, $disableFeedback, $errorKey
         );
 
+        $this->enableOldSupport = isset($enableOldSupport);
         $this->config = is_array($config) ? $config : [];
 
         // Setup the default plugin icons option.

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -107,6 +107,27 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 
+    public function testInputDateComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\InputDate('name');
+        $iVal = $component->makeItemValue('name', 'default');
+
+        $this->assertEquals('default', $iVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\InputDate(
+            'name', null, null, null, null, null, null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $iVal = $component->makeItemValue('name', 'default');
+
+        $this->assertEquals('foo', $iVal);
+    }
+
     public function testInputFileComponent()
     {
         $component = new Components\Form\InputFile('name', null, null, 'sm');


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add internal `old()` support to `x-adminlte-input-date` component.

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [x] Add documentation on the wiki pages.
