### PR TITLE
master.blade.php: favicons/manifest.json use-credentials

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -66,7 +66,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
         <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
         <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
-        <link rel="manifest" href="{{ asset('favicons/manifest.json') }}">
+        <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
     @endif


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Small change to favicon/manifest.json to avoid the 401 status code that results from failing to use credentials when accessing the manifest.json file when credentials are required:
<img width="786" alt="401 Manifest Error" src="https://user-images.githubusercontent.com/3285539/149394796-03e9efa1-82db-49cb-a6db-83997a1c5ddf.png">

Further information can be found here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin

#### Checklist

- ✅ I tested these changes.