### PR TITLE
Improve input group component errors bag treatment

### DIFF
--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -1,3 +1,11 @@
+{{-- Setup the internal errors bag for the component --}}
+
+@php
+    $setErrorsBag($errors);
+@endphp
+
+{{-- Setup the input group component structure --}}
+
 <div class="{{ $makeFormGroupClass() }}">
 
     {{-- Input label --}}

--- a/src/View/Components/Form/InputGroupComponent.php
+++ b/src/View/Components/Form/InputGroupComponent.php
@@ -7,6 +7,14 @@ use Illuminate\View\Component;
 class InputGroupComponent extends Component
 {
     /**
+     * Holds an instance of the Laravel errors bag. This will be mainly used to
+     * detect when the input group has associated errors.
+     *
+     * @var \Illuminate\Support\MessageBag;
+     */
+    protected $errorsBag;
+
+    /**
      * The id attribute for the underlying input group item. The input group
      * item may be an "input", a "select", a "textarea", etc.
      *
@@ -99,6 +107,10 @@ class InputGroupComponent extends Component
         // Setup the lookup key for validation errors.
 
         $this->errorKey = $errorKey ?? $this->makeErrorKey();
+
+        // Initialize the internal errors bag holder variable.
+
+        $this->errorsBag = null;
     }
 
     /**
@@ -166,13 +178,26 @@ class InputGroupComponent extends Component
     public function isInvalid()
     {
         // Get the errors bag from session. The errors bag will be an instance
-        // of the Illuminate\Support\MessageBag class.
+        // of the Illuminate\Support\MessageBag class. First we will check if
+        // the errors bag is available within this instance, otherwise we will
+        // try to get it from the session.
 
-        $errors = session()->get('errors');
+        $errors = $this->errorsBag ?? session()->get('errors');
 
         // Check if exists any error related to the configured error key.
 
-        return ! empty($errors) && ! empty($errors->first($this->errorKey));
+        return ! empty($errors) && $errors->has($this->errorKey);
+    }
+
+    /**
+     * Setup the internal errors bag.
+     *
+     * @param  \Illuminate\Support\MessageBag  $errorsBag
+     * @return void
+     */
+    public function setErrorsBag($errorsBag)
+    {
+        $this->errorsBag = $errorsBag;
     }
 
     /**

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -73,7 +73,7 @@ class FormComponentsTest extends TestCase
     |--------------------------------------------------------------------------
     */
 
-    public function testInputGroupComponent()
+    public function testInvalidInputGroupComponentBySessionErrorsBag()
     {
         $component = new Components\Form\InputGroupComponent(
             'name', null, null, 'lg', null, 'fgroup-class', 'igroup-class'
@@ -87,6 +87,37 @@ class FormComponentsTest extends TestCase
 
         $this->assertStringContainsString('input-group', $iGroupClass);
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
+        $this->assertStringContainsString('igroup-class', $iGroupClass);
+        $this->assertStringContainsString('adminlte-invalid-igroup', $iGroupClass);
+        $this->assertStringContainsString('form-group', $fGroupClass);
+        $this->assertStringContainsString('fgroup-class', $fGroupClass);
+        $this->assertStringContainsString('form-control', $iClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testInvalidInputGroupComponentByErrorsBagSetup()
+    {
+        // Note we configure a specific error key called 'nameErrorKey'.
+
+        $component = new Components\Form\InputGroupComponent(
+            'name', null, null, 'sm', null, 'fgroup-class',
+            'igroup-class', null, 'nameErrorKey'
+        );
+
+        // Setup an internal errors bag for the component.
+
+        $msgBag = new MessageBag();
+        $msgBag->add('nameErrorKey', 'error');
+        $component->setErrorsBag($msgBag);
+
+        // Test the component.
+
+        $iGroupClass = $component->makeInputGroupClass();
+        $fGroupClass = $component->makeFormGroupClass();
+        $iClass = $component->makeItemClass();
+
+        $this->assertStringContainsString('input-group', $iGroupClass);
+        $this->assertStringContainsString('input-group-sm', $iGroupClass);
         $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-igroup', $iGroupClass);
         $this->assertStringContainsString('form-group', $fGroupClass);

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -128,6 +128,7 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('adminlte-invalid-igroup', $iGroupClass);
         $this->assertStringContainsString('form-group', $fGroupClass);
         $this->assertStringContainsString('fgroup-class', $fGroupClass);
+    }
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Now the errors bag can be set from the component's blade file, this enhances support for the **Livewire** package, in where the errors bag is not flashed to the session.

Fixes #972 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.