### PR TITLE
Improve base logic for old support

### DIFF
--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -4,7 +4,6 @@
 
     {{-- Input Date --}}
     <input id="{{ $id }}" name="{{ $name }}" data-target="#{{ $id }}" data-toggle="datetimepicker"
-        value="{{ $makeItemValue($errorKey, $attributes->get('value')) }}"
         {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite
@@ -17,6 +16,11 @@
     $(() => {
         let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
         $('#{{ $id }}').datetimepicker(usrCfg);
+
+        {{-- Add support to auto display the old submitted value or values --}}
+
+        let value = "{{ $getOldValue($errorKey, $attributes->get('value')) }}";
+        $('#{{ $id }}').val(value);
     })
 
 </script>

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Input --}}
     <input id="{{ $id }}" name="{{ $name }}"
-        value="{{ $makeItemValue($errorKey, $attributes->get('value')) }}"
+        value="{{ $getOldValue($errorKey, $attributes->get('value')) }}"
         {{ $attributes->merge(['class' => $makeItemClass()]) }}>
 
 @overwrite

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -10,24 +10,20 @@
 
 @overwrite
 
-{{-- Support to auto select old submitted values --}}
+{{-- Support to auto select the old submitted values --}}
 
-@if($errors->any())
+@if($errors->any() && $enableOldSupport)
 @push('js')
 <script>
 
     $(() => {
 
-        let oldOptions = @json(collect($makeItemValue($errorKey)));
+        let oldOptions = @json(collect($getOldValue($errorKey)));
 
         $('#{{ $id }} option').each(function()
         {
             let value = $(this).val() || $(this).text();
-
-            if (oldOptions.includes(value))
-            {
-                $(this).prop('selected', true);
-            }
+            $(this).prop('selected', oldOptions.includes(value));
         });
     });
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -20,18 +20,14 @@
 
         {{-- Add support to auto select old submitted values --}}
 
-        @if($errors->any())
+        @if($errors->any() && $enableOldSupport)
 
-            let oldOptions = @json(collect($makeItemValue($errorKey)));
+            let oldOptions = @json(collect($getOldValue($errorKey)));
 
             $('#{{ $id }} option').each(function()
             {
                 let value = $(this).val() || $(this).text();
-
-                if (oldOptions.includes(value))
-                {
-                    $(this).prop('selected', true);
-                }
+                $(this).prop('selected', oldOptions.includes(value));
             });
 
             $('#{{ $id }}').trigger('change');

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -5,6 +5,6 @@
     {{-- Textarea --}}
     <textarea id="{{ $id }}" name="{{ $name }}"
         {{ $attributes->merge(['class' => $makeItemClass()]) }}
-    >{{ $makeItemValue($errorKey, $slot) }}</textarea>
+    >{{ $getOldValue($errorKey, $slot) }}</textarea>
 
 @overwrite

--- a/src/View/Components/Form/Traits/OldValueSupportTrait.php
+++ b/src/View/Components/Form/Traits/OldValueSupportTrait.php
@@ -5,23 +5,24 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form\Traits;
 trait OldValueSupportTrait
 {
     /**
-     * Enable the retrievement of the submitted value in case of validation
-     * errors. This submitted value may be automatically shown when there is a
-     * validation error.
+     * Whether to enable the retrievement of the submitted value in case of
+     * validation errors. If enabled, the submitted value will be automatically
+     * shown when there is a validation error.
      *
      * @var bool
      */
-    protected $enableOldSupport;
+    public $enableOldSupport;
 
     /**
-     * Make the value attribute for an input item, with auto lookup for a
-     * submitted value in case of validation errors.
+     * Gets the previous submitted value for an input item. When the old value
+     * support is disabled or the old value can't be found, the specified
+     * default value is returned.
      *
-     * @param  string  $errorKey  The key name to lookup for validation errors
-     * @param  mixed  $default  The default value for the input element
+     * @param  string  $errorKey  The key to use for look up the old value
+     * @param  mixed  $default  Default value to use when there isn't old value
      * @return mixed
      */
-    public function makeItemValue($errorKey, $default = null)
+    public function getOldValue($errorKey, $default = null)
     {
         return $this->enableOldSupport ? old($errorKey, $default) : $default;
     }

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -112,9 +112,9 @@ class FormComponentsTest extends TestCase
         // Test component with old support disabled.
 
         $component = new Components\Form\InputDate('name');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('default', $iVal);
+        $this->assertEquals('default', $oVal);
 
         // Test component with old support enabled.
 
@@ -123,9 +123,9 @@ class FormComponentsTest extends TestCase
         );
 
         $this->addInputOnCurrentRequest('name', 'foo');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('foo', $iVal);
+        $this->assertEquals('foo', $oVal);
     }
 
     public function testInputFileComponent()
@@ -250,9 +250,9 @@ class FormComponentsTest extends TestCase
         // Test component with old support disabled.
 
         $component = new Components\Form\Select('name');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('default', $iVal);
+        $this->assertEquals('default', $oVal);
 
         // Test component with old support enabled.
 
@@ -261,9 +261,9 @@ class FormComponentsTest extends TestCase
         );
 
         $this->addInputOnCurrentRequest('name', 'foo');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('foo', $iVal);
+        $this->assertEquals('foo', $oVal);
     }
 
     public function testSelect2Component()
@@ -283,9 +283,9 @@ class FormComponentsTest extends TestCase
         // Test component with old support disabled.
 
         $component = new Components\Form\Select2('name');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('default', $iVal);
+        $this->assertEquals('default', $oVal);
 
         // Test component with old support enabled.
 
@@ -294,9 +294,9 @@ class FormComponentsTest extends TestCase
         );
 
         $this->addInputOnCurrentRequest('name', 'foo');
-        $iVal = $component->makeItemValue('name', 'default');
+        $oVal = $component->getOldValue('name', 'default');
 
-        $this->assertEquals('foo', $iVal);
+        $this->assertEquals('foo', $oVal);
     }
 
     public function testSelectBsComponent()


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Improve the base old logic for the old support on the form components:
- Review the `OldValueSupportTrait`.
- Improve old support on select components.
- Fix old support on `input-date` component to work when `allowMultidate=true` for the undelying plugin config.

#### Checklist

- [x] I tested these changes.