### PR TITLE
Old support for advanced form components

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -28,6 +28,15 @@
             }
         @endisset
 
+        {{-- Add support to auto select the previous submitted value --}}
+
+        @if($errors->any() && $enableOldSupport)
+            let oldRange = @json($getOldValue($errorKey));
+            oldRange = oldRange.split(" - ");
+            usrCfg.startDate = oldRange.length > 0 ? oldRange[0] : null;
+            usrCfg.endDate = oldRange.length > 1 ? oldRange[1] : null;
+        @endif
+
         $('#{{ $id }}').daterangepicker(usrCfg);
     })
 

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -31,6 +31,12 @@
         $('#{{ $id }}').colorpicker( @json($config) )
             .on('change', setAddonColor);
 
+        {{-- Add support to auto select the previous submitted value --}}
+
+        @if($errors->any() && $enableOldSupport)
+            $('#{{ $id }}').val( @json($getOldValue($errorKey)) ).change();
+        @endif
+
         // Set the initial color for the addon.
 
         setAddonColor();

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -18,30 +18,33 @@
 
         // Check for disabled attribute (alternative to data-slider-enable).
 
-        @isset($attributes['disabled'])
+        @if($attributes->has('disabled'))
             usrCfg.enabled = false;
-        @endisset
+        @endif
 
         // Check for min, max and step attributes (alternatives to
         // data-slider-min, data-slider-max and data-slider-step).
 
-        @isset($attributes['min'])
-            usrCfg.min = {{ $attributes['min'] }};
-        @endisset
+        @if($attributes->has('min'))
+            usrCfg.min = Number( @json($attributes['min']) );
+        @endif
 
-        @isset($attributes['max'])
-            usrCfg.max = {{ $attributes['max'] }};
-        @endisset
+        @if($attributes->has('max'))
+            usrCfg.max = Number( @json($attributes['max']) );
+        @endif
 
-        @isset($attributes['step'])
-            usrCfg.step = {{ $attributes['step'] }};
-        @endisset
+        @if($attributes->has('step'))
+            usrCfg.step = Number( @json($attributes['step']) );
+        @endif
 
         // Check for value attribute (alternative to data-slider-value).
+        // Also, add support to auto select the previous submitted value.
 
-        @isset($attributes['value'])
-            usrCfg.value = {{ $attributes['value'] }};
-        @endisset
+        @if($attributes->has('value') || ($errors->any() && $enableOldSupport))
+            let value = @json($getOldValue($errorKey, $attributes['value']));
+            value = value.split(",").map(Number);
+            usrCfg.value = value.length > 1 ? value : value[0];
+        @endif
 
         // Initialize the plugin.
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -15,6 +15,13 @@
 
     $(() => {
         $('#{{ $id }}').bootstrapSwitch( @json($config) );
+
+        {{-- Add support to auto select the previous submitted value --}}
+
+        @if($errors->any() && $enableOldSupport)
+            let oldState = @json((bool)$getOldValue($errorKey));
+            $('#{{ $id }}').bootstrapSwitch('state', oldState);
+        @endif
     })
 
 </script>

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -21,10 +21,8 @@
         {{-- Add support to auto select old submitted values --}}
 
         @if($errors->any() && $enableOldSupport)
-
             let oldOptions = @json(collect($getOldValue($errorKey)));
             $('#{{ $id }}').selectpicker('val', oldOptions);
-
         @endif
     })
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -17,6 +17,15 @@
 
     $(() => {
         $('#{{ $id }}').selectpicker( @json($config) );
+
+        {{-- Add support to auto select old submitted values --}}
+
+        @if($errors->any() && $enableOldSupport)
+
+            let oldOptions = @json(collect($getOldValue($errorKey)));
+            $('#{{ $id }}').selectpicker('val', oldOptions);
+
+        @endif
     })
 
 </script>

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -5,7 +5,7 @@
     {{-- Summernote Textarea --}}
     <textarea id="{{ $id }}" name="{{ $name }}"
         {{ $attributes->merge(['class' => $makeItemClass()]) }}
-    >{{ $slot }}</textarea>
+    >{{ $getOldValue($errorKey, $slot) }}</textarea>
 
 @overwrite
 

--- a/src/View/Components/Form/DateRange.php
+++ b/src/View/Components/Form/DateRange.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class DateRange extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The DateRangePicker plugin configuration parameters. Array with
      * key => value pairs, where the key should be an existing configuration
@@ -31,7 +33,8 @@ class DateRange extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = [], $enableDefaultRanges = null
+        $errorKey = null, $config = [], $enableDefaultRanges = null,
+        $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -40,6 +43,7 @@ class DateRange extends InputGroupComponent
 
         $this->config = is_array($config) ? $config : [];
         $this->enableDefaultRanges = $enableDefaultRanges;
+        $this->enableOldSupport = isset($enableOldSupport);
     }
 
     /**

--- a/src/View/Components/Form/InputColor.php
+++ b/src/View/Components/Form/InputColor.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class InputColor extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The Bootstrap Colorpicker plugin configuration parameters. Array with
      * key => value pairs, where the key should be an existing configuration
@@ -22,7 +24,7 @@ class InputColor extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = []
+        $errorKey = null, $config = [], $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -30,6 +32,7 @@ class InputColor extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+        $this->enableOldSupport = isset($enableOldSupport);
     }
 
     /**

--- a/src/View/Components/Form/InputSlider.php
+++ b/src/View/Components/Form/InputSlider.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class InputSlider extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The bootstrap-slider plugin configuration parameters. Array with
      * key => value pairs, where the key should be an existing configuration
@@ -29,7 +31,7 @@ class InputSlider extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = [], $color = null
+        $errorKey = null, $config = [], $color = null, $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -37,6 +39,7 @@ class InputSlider extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+        $this->enableOldSupport = isset($enableOldSupport);
         $this->color = $color;
 
         // Set a default plugin 'id' option.

--- a/src/View/Components/Form/InputSwitch.php
+++ b/src/View/Components/Form/InputSwitch.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class InputSwitch extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The Bootstrap Switch plugin configuration parameters. Array with
      * key => value pairs, where the key should be an existing configuration
@@ -22,7 +24,7 @@ class InputSwitch extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = []
+        $errorKey = null, $config = [], $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -30,6 +32,7 @@ class InputSwitch extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+        $this->enableOldSupport = isset($enableOldSupport);
     }
 
     /**

--- a/src/View/Components/Form/SelectBs.php
+++ b/src/View/Components/Form/SelectBs.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class SelectBs extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The bootstrap-select plugin configuration parameters. Array with
      * key => value pairs, where the key should be an existing configuration
@@ -22,7 +24,7 @@ class SelectBs extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = []
+        $errorKey = null, $config = [], $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -30,6 +32,7 @@ class SelectBs extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+        $this->enableOldSupport = isset($enableOldSupport);
     }
 
     /**

--- a/src/View/Components/Form/TextEditor.php
+++ b/src/View/Components/Form/TextEditor.php
@@ -4,6 +4,8 @@ namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
 
 class TextEditor extends InputGroupComponent
 {
+    use Traits\OldValueSupportTrait;
+
     /**
      * The Summernote plugin configuration parameters. Array with key => value
      * pairs, where the key should be an existing configuration property of
@@ -23,7 +25,7 @@ class TextEditor extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = []
+        $errorKey = null, $config = [], $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -31,6 +33,7 @@ class TextEditor extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+        $this->enableOldSupport = isset($enableOldSupport);
 
         // Setup the default plugin width option.
 

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -7,6 +7,8 @@ class FormComponentsTest extends TestCase
 {
     /**
      * Return array with the available blade components.
+     *
+     * @return array
      */
     protected function getComponents()
     {
@@ -33,6 +35,9 @@ class FormComponentsTest extends TestCase
 
     /**
      * Add an error on the session's error bag for the provided $key.
+     *
+     * @param  string  $key  The key for which to add an error
+     * @return void
      */
     protected function addErrorOnSessionFor($key)
     {
@@ -46,6 +51,7 @@ class FormComponentsTest extends TestCase
      *
      * @param  string  $key  The input key
      * @param  mixed  $val  The input value
+     * @return void
      */
     protected function addInputOnCurrentRequest($key, $val)
     {
@@ -69,7 +75,7 @@ class FormComponentsTest extends TestCase
 
     /*
     |--------------------------------------------------------------------------
-    | Individual form components tests.
+    | Input group component tests.
     |--------------------------------------------------------------------------
     */
 
@@ -94,6 +100,91 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('form-control', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Date range component tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testDateRangeComponent()
+    {
+        $component = new Components\Form\DateRange('name');
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
+
+        $this->assertStringContainsString('form-control', $iClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testDateRangeComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\DateRange('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\DateRange(
+            'name', null, null, null, null, null, null,
+            null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input color component tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testInputColorComponent()
+    {
+        $component = new Components\Form\InputColor('name');
+
+        $this->addErrorOnSessionFor('name');
+
+        $iClass = $component->makeItemClass();
+
+        $this->assertStringContainsString('form-control', $iClass);
+        $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    public function testInputColorComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\InputColor('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\InputColor(
+            'name', null, null, null, null, null, null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input date component tests.
+    |--------------------------------------------------------------------------
+    */
 
     public function testInputDateComponent()
     {
@@ -128,6 +219,12 @@ class FormComponentsTest extends TestCase
         $this->assertEquals('foo', $oVal);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | Input file component tests.
+    |--------------------------------------------------------------------------
+    */
+
     public function testInputFileComponent()
     {
         $component = new Components\Form\InputFile('name', null, null, 'sm');
@@ -138,6 +235,12 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('custom-file-input', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input slider component tests.
+    |--------------------------------------------------------------------------
+    */
 
     public function testInputSliderComponent()
     {
@@ -157,6 +260,34 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('is-invalid', $iClass);
     }
 
+    public function testInputSliderComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\InputSlider('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\InputSlider(
+            'name', null, null, null, null, null, null,
+            null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input switch component tests.
+    |--------------------------------------------------------------------------
+    */
+
     public function testInputSwitchComponent()
     {
         $component = new Components\Form\InputSwitch(
@@ -174,6 +305,33 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('adminlte-invalid-iswgroup', $iGroupClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
+
+    public function testInputSwitchComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\InputSwitch('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\InputSwitch(
+            'name', null, null, null, null, null, null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Options component tests.
+    |--------------------------------------------------------------------------
+    */
 
     public function testOptionsComponent()
     {
@@ -233,6 +391,12 @@ class FormComponentsTest extends TestCase
         $this->assertStringMatchesFormat($format, $html);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | Select component tests.
+    |--------------------------------------------------------------------------
+    */
+
     public function testSelectComponent()
     {
         $component = new Components\Form\Select('name');
@@ -265,6 +429,12 @@ class FormComponentsTest extends TestCase
 
         $this->assertEquals('foo', $oVal);
     }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Select2 component tests.
+    |--------------------------------------------------------------------------
+    */
 
     public function testSelect2Component()
     {
@@ -299,6 +469,12 @@ class FormComponentsTest extends TestCase
         $this->assertEquals('foo', $oVal);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | SelectBs component tests.
+    |--------------------------------------------------------------------------
+    */
+
     public function testSelectBsComponent()
     {
         $component = new Components\Form\SelectBs('name', null, null, 'lg');
@@ -311,6 +487,33 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('form-control-lg', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
     }
+
+    public function testSelectBsComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\SelectBs('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\SelectBs(
+            'name', null, null, null, null, null, null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Text editor component tests.
+    |--------------------------------------------------------------------------
+    */
 
     public function testTextEditorComponent()
     {
@@ -326,5 +529,26 @@ class FormComponentsTest extends TestCase
         $this->assertStringContainsString('input-group-lg', $iGroupClass);
         $this->assertStringContainsString('igroup-class', $iGroupClass);
         $this->assertStringContainsString('adminlte-invalid-itegroup', $iGroupClass);
+    }
+
+    public function testTextEditorComponentOldSupport()
+    {
+        // Test component with old support disabled.
+
+        $component = new Components\Form\TextEditor('name');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('default', $oVal);
+
+        // Test component with old support enabled.
+
+        $component = new Components\Form\TextEditor(
+            'name', null, null, null, null, null, null, null, null, null, true
+        );
+
+        $this->addInputOnCurrentRequest('name', 'foo');
+        $oVal = $component->getOldValue('name', 'default');
+
+        $this->assertEquals('foo', $oVal);
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add old support for advanced form components:
- `x-adminlte-date-range`
- `x-adminlte-input-color`
- `x-adminlte-input-slider`
- `x-adminlte-input-switch`
- `x-adminlte-select-bs`
- `x-adminlte-text-editor`

This will finally fix #889 


#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [x] Add documentation on the Wiki
