### PR TITLE
Improve the x-adminlte-card component

### DIFF
--- a/resources/views/components/widget/card.blade.php
+++ b/resources/views/components/widget/card.blade.php
@@ -1,39 +1,56 @@
 <div {{ $attributes->merge(['class' => $makeCardClass()]) }}>
 
     {{-- Card header --}}
-    <div class="{{ $makeCardHeaderClass() }}">
+    @if(! $isCardHeaderEmpty(isset($toolsSlot)))
+        <div class="{{ $makeCardHeaderClass() }}">
 
-        {{-- Title --}}
-        <h3 class="{{ $makeCardTitleClass() }}">
-            @isset($icon)<i class="{{ $icon }} mr-2"></i>@endisset
-            @isset($title){{ $title }}@endisset
-        </h3>
+            {{-- Title --}}
+            <h3 class="{{ $makeCardTitleClass() }}">
+                @isset($icon)<i class="{{ $icon }} mr-1"></i>@endisset
+                @isset($title){{ $title }}@endisset
+            </h3>
 
-        {{-- Tools --}}
-        <div class="card-tools">
-            @isset($maximizable)
-                <x-adminlte-button theme="tool" data-card-widget="maximize" icon="fas fa-lg fa-expand"/>
-            @endisset
+            {{-- Tools --}}
+            <div class="card-tools">
 
-            @if($collapsible === 'collapsed')
-                <x-adminlte-button theme="tool" data-card-widget="collapse" icon="fas fa-lg fa-plus"/>
-            @elseif (isset($collapsible))
-                <x-adminlte-button theme="tool" data-card-widget="collapse" icon="fas fa-lg fa-minus"/>
-            @endif
+                {{-- Extra tools slot --}}
+                @isset($toolsSlot)
+                    {{ $toolsSlot }}
+                @endisset
 
-            @isset($removable)
-                <x-adminlte-button theme="tool" data-card-widget="remove" icon="fas fa-lg fa-times"/>
-            @endisset
+                {{-- Default tools --}}
+                @isset($maximizable)
+                    <x-adminlte-button theme="tool" data-card-widget="maximize" icon="fas fa-lg fa-expand"/>
+                @endisset
+
+                @if($collapsible === 'collapsed')
+                    <x-adminlte-button theme="tool" data-card-widget="collapse" icon="fas fa-lg fa-plus"/>
+                @elseif(isset($collapsible))
+                    <x-adminlte-button theme="tool" data-card-widget="collapse" icon="fas fa-lg fa-minus"/>
+                @endif
+
+                @isset($removable)
+                    <x-adminlte-button theme="tool" data-card-widget="remove" icon="fas fa-lg fa-times"/>
+                @endisset
+
+            </div>
+
         </div>
-
-    </div>
+    @endif
 
     {{-- Card body --}}
     @if(! $slot->isEmpty())
-        <div {{ $attributes->merge(['class' => $makeCardBodyClass()]) }}>
+        <div class="{{ $makeCardBodyClass() }}">
             {{ $slot }}
         </div>
     @endif
+
+    {{-- Card footer --}}
+    @isset($footerSlot)
+        <div class="{{ $makeCardFooterClass() }}">
+            {{ $footerSlot }}
+        </div>
+    @endisset
 
     {{-- Card overlay --}}
     @if($disabled)

--- a/src/View/Components/Widget/Card.php
+++ b/src/View/Components/Widget/Card.php
@@ -208,7 +208,7 @@ class Card extends Component
     /**
      * Check if the card header is empty (no items defined for the header).
      *
-     * @param  bool $hasSlot Whether the card header slot is defined
+     * @param  bool  $hasSlot Whether the card header slot is defined
      * @return bool
      */
     public function isCardHeaderEmpty($hasSlot = false)

--- a/src/View/Components/Widget/Card.php
+++ b/src/View/Components/Widget/Card.php
@@ -36,12 +36,28 @@ class Card extends Component
     public $themeMode;
 
     /**
+     * Extra classes for the "card-header" element. This provides a way to
+     * customize the card header container style.
+     *
+     * @var string
+     */
+    public $headerClass;
+
+    /**
      * Extra classes for the "card-body" element. This provides a way to
      * customize the card body container style.
      *
      * @var string
      */
     public $bodyClass;
+
+    /**
+     * Extra classes for the "card-footer" element. This provides a way to
+     * customize the card footer container style.
+     *
+     * @var string
+     */
+    public $footerClass;
 
     /**
      * Indicates if the card is disabled. When enabled, an overay will show
@@ -83,14 +99,17 @@ class Card extends Component
      */
     public function __construct(
         $title = null, $icon = null, $theme = null, $themeMode = null,
-        $bodyClass = null, $disabled = null, $collapsible = null,
-        $removable = null, $maximizable = null
+        $headerClass = null, $bodyClass = null, $footerClass = null,
+        $disabled = null, $collapsible = null, $removable = null,
+        $maximizable = null
     ) {
         $this->title = $title;
         $this->icon = $icon;
         $this->theme = $theme;
         $this->themeMode = $themeMode;
+        $this->headerClass = $headerClass;
         $this->bodyClass = $bodyClass;
+        $this->footerClass = $footerClass;
         $this->disabled = $disabled;
         $this->removable = $removable;
         $this->collapsible = $collapsible;
@@ -123,6 +142,22 @@ class Card extends Component
     }
 
     /**
+     * Make the class attribute for the card header.
+     *
+     * @return string
+     */
+    public function makeCardHeaderClass()
+    {
+        $classes = ['card-header'];
+
+        if (isset($this->headerClass)) {
+            $classes[] = $this->headerClass;
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Make the class attribute for the card body.
      *
      * @return string
@@ -139,16 +174,16 @@ class Card extends Component
     }
 
     /**
-     * Make the class attribute for the card header.
+     * Make the class attribute for the card footer.
      *
      * @return string
      */
-    public function makeCardHeaderClass()
+    public function makeCardFooterClass()
     {
-        $classes = ['card-header'];
+        $classes = ['card-footer'];
 
-        if ($this->isCardHeaderEmpty()) {
-            $classes[] = 'd-none';
+        if (isset($this->footerClass)) {
+            $classes[] = $this->footerClass;
         }
 
         return implode(' ', $classes);
@@ -173,13 +208,15 @@ class Card extends Component
     /**
      * Check if the card header is empty (no items defined for the header).
      *
+     * @param  bool $hasSlot Whether the card header slot is defined
      * @return bool
      */
-    protected function isCardHeaderEmpty()
+    public function isCardHeaderEmpty($hasSlot = false)
     {
         $hasTools = isset($this->collapsible) ||
                     isset($this->maximizable) ||
-                    isset($this->removable);
+                    isset($this->removable) ||
+                    $hasSlot;
 
         return empty($this->title) && empty($this->icon) && ! $hasTools;
     }

--- a/src/View/Components/Widget/Card.php
+++ b/src/View/Components/Widget/Card.php
@@ -208,7 +208,7 @@ class Card extends Component
     /**
      * Check if the card header is empty (no items defined for the header).
      *
-     * @param  bool  $hasSlot Whether the card header slot is defined
+     * @param  bool  $hasSlot  Whether the card header slot is defined
      * @return bool
      */
     public function isCardHeaderEmpty($hasSlot = false)

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -86,12 +86,14 @@ class WidgetComponentsTest extends TestCase
         $this->assertStringContainsString('card', $cClass);
         $this->assertStringContainsString('card-info', $cClass);
 
+        $hClass = $component->makeCardHeaderClass();
+        $this->assertStringContainsString('card-header', $hClass);
+
         $cbClass = $component->makeCardBodyClass();
         $this->assertStringContainsString('card-body', $cbClass);
 
-        $hClass = $component->makeCardHeaderClass();
-        $this->assertStringContainsString('card-header', $hClass);
-        $this->assertStringNotContainsString('d-none', $hClass);
+        $fClass = $component->makeCardFooterClass();
+        $this->assertStringContainsString('card-footer', $fClass);
 
         $ctClass = $component->makeCardTitleClass();
         $this->assertStringContainsString('card-title', $ctClass);
@@ -103,30 +105,38 @@ class WidgetComponentsTest extends TestCase
         $cClass = $component->makeCardClass();
         $this->assertStringContainsString('card', $cClass);
         $this->assertStringContainsString('card-danger', $cClass);
+        $this->assertTrue($component->isCardHeaderEmpty());
+        $this->assertFalse($component->isCardHeaderEmpty(true));
 
-        $hClass = $component->makeCardHeaderClass();
-        $this->assertStringContainsString('card-header', $hClass);
-        $this->assertStringContainsString('d-none', $hClass);
-
-        // Test collapsed with full theme and extra body class:
-        // $title, $icon, $theme, $themeMode, $bodyClass, $disabled,
-        // $collapsible, $removable, $maximizable.
+        // Test collapsed mode with full theme and extra body, footer and
+        // header classed:
+        // $title, $icon, $theme, $themeMode, $headerClass, $bodyClass,
+        // $footerClass, $disabled, $collapsible, $removable, $maximizable.
 
         $component = new Components\Widget\Card(
-            'title', null, 'success', 'full', 'body-class', null, 'collapsed'
+            'title', null, 'success', 'full', 'header-class', 'body-class',
+            'footer-class', null, 'collapsed'
         );
 
         $cClass = $component->makeCardClass();
         $this->assertStringContainsString('bg-gradient-success', $cClass);
         $this->assertStringContainsString('collapsed-card', $cClass);
 
+        $hClass = $component->makeCardHeaderClass();
+        $this->assertStringContainsString('card-header', $hClass);
+        $this->assertStringContainsString('header-class', $hClass);
+
         $cbClass = $component->makeCardBodyClass();
         $this->assertStringContainsString('card-body', $cbClass);
         $this->assertStringContainsString('body-class', $cbClass);
 
+        $fClass = $component->makeCardFooterClass();
+        $this->assertStringContainsString('card-footer', $fClass);
+        $this->assertStringContainsString('footer-class', $fClass);
+
         // Test outline theme:
-        // $title, $icon, $theme, $themeMode, $bodyClass, $disabled,
-        // $collapsible, $removable, $maximizable.
+        // $title, $icon, $theme, $themeMode, $headerClass, $bodyClass,
+        // $footerClass, $disabled, $collapsible, $removable, $maximizable.
 
         $component = new Components\Widget\Card(
             'title', null, 'teal', 'outline'


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add multiple improvements on the `x-adminlte-card` component:

- Fix merging attributes both on the `.card` and `.card-body` elements.
- Add a new `toolsSlot` to allow adding extra tools on the card header.
- Add a new `footerSlot` to allow adding a card footer.
- Add `header-class` property to allow adding custom classes on the card header.
- Add `footer-class` property to allow adding custom classes on the card footer.
- Fixs #1052 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
