### PR TITLE
Fix single date range picker component with placeholder

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -28,7 +28,12 @@
             {
                 let startDate = picker.startDate.format(picker.locale.format);
                 let endDate = picker.endDate.format(picker.locale.format);
-                $(this).val(startDate + picker.locale.separator + endDate);
+
+                let value = picker.singleDatePicker
+                    ? startDate
+                    : startDate + picker.locale.separator + endDate;
+
+                $(this).val(value);
             });
 
             $('#{{ $id }}').on('cancel.daterangepicker', function(ev, picker)


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix date range picker component when using single date mode and the placeholder option.

#### Start point:
Date range picker is presented with a placeholder...
![Screenshot 2022-05-07 at 13-31-48 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167264077-3dc0b84c-3261-4fc2-b317-47d2d6fbbd31.png)

#### Without the fix:
There is an issue when picking a single date, instead a date range is displayed on the input...
![Screenshot 2022-05-07 at 13-33-33 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167264059-8b9c12f9-8288-408b-88c5-384727bd13ec.png)

#### With the fix:
Now a single datetime is displayed on the input...
![Screenshot 2022-05-07 at 13-32-30 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167264074-5116cf42-8978-4e9b-876a-0a510a5f8644.png)

#### Checklist

- [x] I tested these changes.