### PR TITLE
Fix visual style on invalid state for Bootstrap Select component

### DIFF
--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -29,3 +29,19 @@
 
 </script>
 @endpush
+
+{{-- Set of CSS workarounds for the plugin --}}
+{{-- NOTE: this may change with newer plugin versions --}}
+
+@once
+@push('css')
+<style type="text/css">
+
+    {{-- Fix the invalid visual style --}}
+    .bootstrap-select.is-invalid {
+        padding-right: 0px !important;
+    }
+
+</style>
+@endpush
+@endonce


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix invalid state visual style for the **Booststrap Select** component.

#### Without the fix:
![Screenshot 2022-05-07 at 13-40-23 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167264494-de69a11a-e738-489d-b74a-f02e828b520d.png)

#### With the fix:
![Screenshot 2022-05-07 at 13-42-05 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167264493-66b29f1d-65cd-4461-8572-7559bf8302aa.png)

#### Checklist

- [x] I tested these changes.