### PR TITLE
Add readonly support on select2 component.

### DIFF
--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -39,7 +39,7 @@
 </script>
 @endpush
 
-{{-- Setup the height and font size of the plugin when using sm/lg sizes --}}
+{{-- CSS workarounds for the Select2 plugin --}}
 {{-- NOTE: this may change with newer plugin versions --}}
 
 @once
@@ -78,6 +78,21 @@
     .input-group-lg .select2-selection--multiple .select2-selection__rendered {
         font-size: 1.25rem !important;
         line-height: 1.7;
+    }
+
+    {{-- Enhance the plugin to support readonly attribute --}}
+    select[readonly].select2-hidden-accessible + .select2-container {
+        pointer-events: none;
+        touch-action: none;
+    }
+
+    select[readonly].select2-hidden-accessible + .select2-container .select2-selection {
+        background: #e9ecef;
+        box-shadow: none;
+    }
+
+    select[readonly].select2-hidden-accessible + .select2-container .select2-search__field {
+        display: none;
     }
 
 </style>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add `readonly` support on **Select2 component**.

#### Before this PR:

The next markup do not prohibit to select an option when using `readonly` attribute.

```blade
<x-adminlte-select2 name="sel2Readonly" readonly>
    <option>Option 1</option>
    <option selected>Option 2</option>
</x-adminlte-select2>
```
![Screenshot 2022-05-11 at 19-58-43 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167961470-6e581911-5441-4dcd-a645-0e8445785dde.png)

#### After this PR:

Selection is prohibited to the user. However, the value is still submitted within the form, as expected...

![Screenshot 2022-05-11 at 19-56-48 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/167961478-df252c33-34e5-49a9-93c3-25f8ca677603.png)

#### Checklist

- [x] I tested these changes.