### PR TITLE
Fix top navbar items to use the compiled active classes

### DIFF
--- a/resources/views/partials/navbar/dropdown-item-link.blade.php
+++ b/resources/views/partials/navbar/dropdown-item-link.blade.php
@@ -1,6 +1,6 @@
 <li @isset($item['id']) id="{{ $item['id'] }}" @endisset>
 
-    <a class="dropdown-item" href="{{ $item['href'] }}"
+    <a class="dropdown-item {{ $item['class'] }}" href="{{ $item['href'] }}"
        @isset($item['target']) target="{{ $item['target'] }}" @endisset
        {!! $item['data-compiled'] ?? '' !!}>
 

--- a/resources/views/partials/navbar/dropdown-item-submenu.blade.php
+++ b/resources/views/partials/navbar/dropdown-item-submenu.blade.php
@@ -1,8 +1,8 @@
 <li @isset($item['id']) id="{{ $item['id'] }}" @endisset class="dropdown-submenu dropdown-hover">
 
     {{-- Menu toggler --}}
-    <a class="dropdown-item dropdown-toggle" href="" data-toggle="dropdown"
-       {!! $item['data-compiled'] ?? '' !!}>
+    <a class="dropdown-item dropdown-toggle {{ $item['class'] }}" href=""
+       data-toggle="dropdown" {!! $item['data-compiled'] ?? '' !!}>
 
         {{-- Icon (optional) --}}
         @isset($item['icon'])

--- a/resources/views/partials/navbar/menu-item-dropdown-menu.blade.php
+++ b/resources/views/partials/navbar/menu-item-dropdown-menu.blade.php
@@ -1,7 +1,7 @@
 <li @isset($item['id']) id="{{ $item['id'] }}" @endisset class="nav-item dropdown">
 
     {{-- Menu toggler --}}
-    <a class="nav-link dropdown-toggle" href=""
+    <a class="nav-link dropdown-toggle {{ $item['class'] }}" href=""
        data-toggle="dropdown" {!! $item['data-compiled'] ?? '' !!}>
 
         {{-- Icon (optional) --}}


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Fix the blade layout definition of the top navbar items to use the compiled `active` classes. This way, top navbar items will be shown with a different style when they are currently actives.

Fixs #1113 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
