### PR TITLE
Add feature to change the logo for authentication pages

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -72,6 +72,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Authenticated Logo
+    |--------------------------------------------------------------------------
+    |
+    | Here you can change the logo for login screens.
+    |
+    | For detailed instructions you can look the logo section here:
+    | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Basic-Configuration
+    |
+    */
+
+    'auth_logo' => false,
+    'auth_logo_img' => 'vendor/adminlte/dist/img/AdminLTELogo.png',
+    'auth_logo_img_class' => '',
+    'auth_logo_img_alt' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Preloader Animation
     |--------------------------------------------------------------------------
     |

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -53,7 +53,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Logo
+    | Admin Panel Logo
     |--------------------------------------------------------------------------
     |
     | Here you can change the logo of your admin panel.
@@ -68,24 +68,31 @@ return [
     'logo_img_class' => 'brand-image img-circle elevation-3',
     'logo_img_xl' => null,
     'logo_img_xl_class' => 'brand-image-xs',
-    'logo_img_alt' => 'AdminLTE',
+    'logo_img_alt' => 'Admin Logo',
 
     /*
     |--------------------------------------------------------------------------
-    | Authenticated Logo
+    | Authentication Logo
     |--------------------------------------------------------------------------
     |
-    | Here you can change the logo for login screens.
+    | Here you can setup an alternative logo to use on your login and register
+    | screens. When disabled, the admin panel logo will be used instead.
     |
-    | For detailed instructions you can look the logo section here:
+    | For detailed instructions you can look the auth logo section here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Basic-Configuration
     |
     */
 
-    'auth_logo' => false,
-    'auth_logo_img' => 'vendor/adminlte/dist/img/AdminLTELogo.png',
-    'auth_logo_img_class' => '',
-    'auth_logo_img_alt' => '',
+    'auth_logo' => [
+        'enabled' => false,
+        'img' => [
+            'path' => 'vendor/adminlte/dist/img/AdminLTELogo.png',
+            'alt' => 'Auth Logo',
+            'class' => '',
+            'width' => 50,
+            'height' => 50,
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/auth/auth-page.blade.php
+++ b/resources/views/auth/auth-page.blade.php
@@ -1,11 +1,11 @@
 @extends('adminlte::master')
 
-@php($dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home'))
+@php( $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home') )
 
 @if (config('adminlte.use_route_url', false))
-    @php($dashboard_url = $dashboard_url ? route($dashboard_url) : '')
+    @php( $dashboard_url = $dashboard_url ? route($dashboard_url) : '' )
 @else
-    @php($dashboard_url = $dashboard_url ? url($dashboard_url) : '')
+    @php( $dashboard_url = $dashboard_url ? url($dashboard_url) : '' )
 @endif
 
 @section('adminlte_css')
@@ -21,13 +21,28 @@
         {{-- Logo --}}
         <div class="{{ $auth_type ?? 'login' }}-logo">
             <a href="{{ $dashboard_url }}">
-                @if (config('adminlte.auth_logo'))
-                    <img src="{{ asset(config('adminlte.auth_logo_img')) }}"
-                        class="{{ config('adminlte.auth_logo_img_class') }}" alt="{{ config('adminlte.auth_logo_img_alt') }}">
+
+                {{-- Logo Image --}}
+                @if (config('adminlte.auth_logo.enabled', false))
+                    <img src="{{ asset(config('adminlte.auth_logo.img.path')) }}"
+                         alt="{{ config('adminlte.auth_logo.img.alt') }}"
+                         @if (config('adminlte.auth_logo.img.class', null))
+                            class="{{ config('adminlte.auth_logo.img.class') }}"
+                         @endif
+                         @if (config('adminlte.auth_logo.img.width', null))
+                            width="{{ config('adminlte.auth_logo.img.width') }}"
+                         @endif
+                         @if (config('adminlte.auth_logo.img.height', null))
+                            height="{{ config('adminlte.auth_logo.img.height') }}"
+                         @endif>
                 @else
-                    <img src="{{ asset(config('adminlte.logo_img')) }}" height="50">
+                    <img src="{{ asset(config('adminlte.logo_img')) }}"
+                         alt="{{ config('adminlte.logo_img_alt') }}" height="50">
                 @endif
+
+                {{-- Logo Label --}}
                 {!! config('adminlte.logo', '<b>Admin</b>LTE') !!}
+
             </a>
         </div>
 

--- a/resources/views/auth/auth-page.blade.php
+++ b/resources/views/auth/auth-page.blade.php
@@ -1,11 +1,11 @@
 @extends('adminlte::master')
 
-@php( $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home') )
+@php($dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home'))
 
 @if (config('adminlte.use_route_url', false))
-    @php( $dashboard_url = $dashboard_url ? route($dashboard_url) : '' )
+    @php($dashboard_url = $dashboard_url ? route($dashboard_url) : '')
 @else
-    @php( $dashboard_url = $dashboard_url ? url($dashboard_url) : '' )
+    @php($dashboard_url = $dashboard_url ? url($dashboard_url) : '')
 @endif
 
 @section('adminlte_css')
@@ -21,7 +21,12 @@
         {{-- Logo --}}
         <div class="{{ $auth_type ?? 'login' }}-logo">
             <a href="{{ $dashboard_url }}">
-                <img src="{{ asset(config('adminlte.logo_img')) }}" height="50">
+                @if (config('adminlte.auth_logo'))
+                    <img src="{{ asset(config('adminlte.auth_logo_img')) }}"
+                        class="{{ config('adminlte.auth_logo_img_class') }}" alt="{{ config('adminlte.auth_logo_img_alt') }}">
+                @else
+                    <img src="{{ asset(config('adminlte.logo_img')) }}" height="50">
+                @endif
                 {!! config('adminlte.logo', '<b>Admin</b>LTE') !!}
             </a>
         </div>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

Good evening, I liked the project and wanted to contribute with a small adjustment. I'm sorry! for my english, because i'm brazilian i'm still practicing.

### What's in this PR?


#### Introduction
Possibility to change the logo of the authentication pages in the configuration.

#### Description
Although the framework includes a logo on the screens (login and administrative),  but for the login screen it usually appears an icon or small image representing the logo. In a situation where the developer wants to include a different logo on the login screen (example, logo adapted for screen with background dark or a larger image representing the emblem).  Also, the logo setup is more geared towards the admin screen and sidebar than the login screen.

So I created this pull request that allows the developer to customize a logo image for authentication screens for their customers. If you don't need it, the system will work normally as it was before, without any changes.

#### How does it work?

In the **'auth_logo'** parameter, the developer will choose whether to customize the logo of the authentication screens yes (true) or no (false). In case 'false' the framework will not change the logo and will work as it was before.

- **auth_logo**: render the custom (true) or (false) logo that comes by default. (boolean)
- **auth_logo_img_class**: Add class from css file. (string)
- **auth_logo_img**: image path. (string)
- **auth_logo_img_alt**: alt image. (string)

### Wiki - https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Basic-Configuration

How would it look in the framework Wiki with new implementation. 

After the **title** right on the configuration screen. https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Basic-Configuration#logo

Title: Authenticated Logo

If you want to change the logo of the authentication pages, with Login, Register, Reset Password, etc. You can enable in the `auth_img` parameter set to `true`. 

- **auth_img**: Customize a logo (true) or keep it as default (false)
- **auth_logo_img**:  The path to the logo image.
- **auth_logo_img_class**: Extra classes for the logo image.
- **auth_logo_img_alt**:  The alternate text for the logo images.


### Checklist

- [x] I tested these changes.
- [ ] Add Wiki docs
