### PR TITLE
Support explicit plugin deactivation when active by default

### DIFF
--- a/resources/views/plugins.blade.php
+++ b/resources/views/plugins.blade.php
@@ -1,15 +1,29 @@
 @foreach(config('adminlte.plugins') as $pluginName => $plugin)
-    @if($plugin['active'] || View::getSection('plugins.' . ($plugin['name'] ?? $pluginName)))
+
+    {{-- Check whether the plugin is active --}}
+
+    @php
+        $plugSection = View::getSection('plugins.' . ($plugin['name'] ?? $pluginName));
+        $isPlugActive = $plugin['active']
+            ? ! isset($plugSection) || $plugSection
+            : ! empty($plugSection);
+    @endphp
+
+    {{-- When the plugin is active, include its files --}}
+
+    @if($isPlugActive)
         @foreach($plugin['files'] as $file)
 
-            {{-- Setup the file location  --}}
+            {{-- Setup the file location --}}
+
             @php
                 if (! empty($file['asset'])) {
                     $file['location'] = asset($file['location']);
                 }
             @endphp
 
-            {{-- Check requested file type --}}
+            {{-- Check the requested file type --}}
+
             @if($file['type'] == $type && $type == 'css')
                 <link rel="stylesheet" href="{{ $file['location'] }}">
             @elseif($file['type'] == $type && $type == 'js')
@@ -18,4 +32,5 @@
 
         @endforeach
     @endif
+
 @endforeach


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | IEnhancement
| License                 | MIT

#### What's in this PR?

Currently, when a **plugin** is not `active` by configuration (see [Plugins Configuration](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Plugins-Configuration)), you can include it on a specific blade view using the statement: `@section('plugins.PluginName', true)`.

However, when the **plugin** is `active` by configuration, it will be included in all the blade views that extends the **AdminLTE layout**, and there is no way to explicit deactivate it on a specific blade view (i.e, to not include its files on that blade view).

This **PR** address that situation by supporting explicit deactivation of a plugin that is `active` by configuration using the statement: `@section('plugins.PluginName', false)`

Notes: Fix #1135

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [ ] Add documentation on Wiki pages
