### PR TITLE
Drop support for Laravel 6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,5 +59,5 @@ jobs:
             -   name: Upload coverage to scrutinizer-ci
                 if: matrix.php == '8.1' && matrix.laravel == '9.*' && matrix.dependency-version == 'prefer-stable'
                 run: |
-                    vendor/bin/phpunit --testsuite Laravel7+ --coverage-clover=coverage.clover
+                    vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
                     vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,14 +10,18 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1]
-                laravel: [8.*, 9.*]
+                laravel: [7.*, 8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 9.*
                         testbench: 7.*
                     -   laravel: 8.*
                         testbench: 6.22.*
+                    -   laravel: 7.*
+                        testbench: 5.20.*
                 exclude:
+                    -   laravel: 7.*
+                        php: 8.1
                     -   laravel: 9.*
                         php: 7.3
                     -   laravel: 9.*
@@ -52,7 +56,6 @@ jobs:
 
                 # Test suite for Laravel
             -   name: Execute Laravel tests
-                if: matrix.laravel == '8.*' || matrix.laravel == '9.*'
                 run: vendor/bin/phpunit --testsuite Laravel
 
                 # Upload coverage only for latest versions.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,22 +10,14 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1]
-                laravel: [6.*, 7.*, 8.*, 9.*]
+                laravel: [8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 9.*
                         testbench: 7.*
                     -   laravel: 8.*
                         testbench: 6.22.*
-                    -   laravel: 7.*
-                        testbench: 5.20.*
-                    -   laravel: 6.*
-                        testbench: 4.18.*
                 exclude:
-                    -   laravel: 6.*
-                        php: 8.1
-                    -   laravel: 7.*
-                        php: 8.1
                     -   laravel: 9.*
                         php: 7.3
                     -   laravel: 9.*
@@ -58,15 +50,10 @@ jobs:
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-                # Test suite for Laravel 6.x versions.
-            -   name: Execute Laravel 6.x tests
-                if: matrix.laravel == '6.*'
-                run: vendor/bin/phpunit --testsuite Laravel6
-
-                # Test suite for Laravel 7+ versions.
-            -   name: Execute Laravel 7+ tests
-                if: matrix.laravel == '7.*' || matrix.laravel == '8.*' || matrix.laravel == '9.*'
-                run: vendor/bin/phpunit --testsuite Laravel7+
+                # Test suite for Laravel
+            -   name: Execute Laravel tests
+                if: matrix.laravel == '8.*' || matrix.laravel == '9.*'
+                run: vendor/bin/phpunit --testsuite Laravel
 
                 # Upload coverage only for latest versions.
             -   name: Upload coverage to scrutinizer-ci

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Packagist Version](https://img.shields.io/packagist/v/jeroennoten/Laravel-AdminLTE?logo=github&logoColor=white&style=flat-square)](https://packagist.org/packages/jeroennoten/Laravel-AdminLTE)
 [![Total Downloads](https://img.shields.io/packagist/dt/jeroennoten/Laravel-AdminLTE.svg?logo=github&logoColor=white&style=flat-square)](https://packagist.org/packages/jeroennoten/Laravel-AdminLTE)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jeroennoten/Laravel-AdminLTE/run-tests?logo=github-actions&logoColor=white&style=flat-square)](https://github.com/jeroennoten/Laravel-AdminLTE/actions)
+[![GitHub Checks Status](https://img.shields.io/github/checks-status/jeroennoten/Laravel-AdminLTE/master?logo=github-actions&logoColor=white&style=flat-square)](https://github.com/jeroennoten/Laravel-AdminLTE/actions)
 [![Quality Score](https://img.shields.io/scrutinizer/quality/g/jeroennoten/Laravel-AdminLTE.svg?logo=scrutinizer&style=flat-square)](https://scrutinizer-ci.com/g/jeroennoten/Laravel-AdminLTE)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/jeroennoten/Laravel-AdminLTE.svg?logo=scrutinizer&style=flat-square)](https://scrutinizer-ci.com/g/jeroennoten/Laravel-AdminLTE)
 [![StyleCI](https://styleci.io/repos/38200433/shield?branch=master)](https://styleci.io/repos/38200433)

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
       }
   },
   "require": {
-    "laravel/framework": ">=8.0",
-    "php": ">=7.3.0",
+    "laravel/framework": ">=7.0",
+    "php": ">=7.2.5",
     "almasaeed2010/adminlte": "3.2.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5.10",
+    "phpunit/phpunit": ">=9.1",
     "orchestra/testbench": ">=4.0",
     "scrutinizer/ocular": "^1.9"
   }

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
       }
   },
   "require": {
-    "laravel/framework": ">=6.0",
-    "php": ">=7.2.0",
+    "laravel/framework": ">=8.0",
+    "php": ">=7.3.0",
     "almasaeed2010/adminlte": "3.2.*"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=9.1",
+    "phpunit/phpunit": "^9.5.10",
     "orchestra/testbench": ">=4.0",
     "scrutinizer/ocular": "^1.9"
   }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,12 +6,8 @@
     </include>
   </coverage>
   <testsuites>
-    <testsuite name="Laravel7+">
+    <testsuite name="Laravel">
       <directory suffix="Test.php">./tests</directory>
-    </testsuite>
-    <testsuite name="Laravel6">
-      <directory suffix="Test.php">./tests</directory>
-      <exclude>./tests/Components</exclude>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Date Range Input --}}

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Color --}}

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Date --}}

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -1,0 +1,70 @@
+{{--
+Note: we don't extends the 'input-group-component' blade layout as we have done
+with other form components. The reason is that the underlying Krajee file input
+plugin already generates an 'input-group' structure and will conflict with the
+one provided by the mentioned layout. So instead, we define a new layout.
+--}}
+
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors ?? null))
+
+{{-- Create the form group layout --}}
+
+<div class="{{ $makeFormGroupClass() }}">
+
+    {{-- Input label --}}
+    @isset($label)
+        <label for="{{ $id }}" @isset($labelClass) class="{{ $labelClass }}" @endisset>
+            {{ $label }}
+        </label>
+    @endisset
+
+    {{-- Krajee file input --}}
+    <input type="file" id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
+
+    {{-- Error feedback --}}
+    @if($isInvalid())
+        <span class="{{ $makeInvalidFeedbackClass() }}" role="alert">
+            <strong>{{ $errors->first($errorKey) }}</strong>
+        </span>
+    @endif
+
+</div>
+
+{{-- Add the plugin initialization code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+
+        // Initialize the plugin.
+
+        $('#{{ $id }}').fileinput( @json($config) );
+
+        // Workaround to force setup of invalid class.
+
+        @if($isInvalid())
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-caption-name')
+                .addClass('is-invalid')
+
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-preview')
+                .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
+        @endif
+
+        // Make custom style for particular scenarios (modes).
+
+        @if($presetMode == 'avatar')
+            $('#{{ $id }}').closest('.file-input')
+                .addClass('text-center')
+                .find('.file-drop-zone')
+                .addClass('border-0');
+        @endif
+    })
+
+</script>
+@endpush

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     <div class="custom-file">
@@ -24,7 +30,9 @@
 @push('js')
 <script>
 
-    $(() => {bsCustomFileInput.init();})
+    $(() => {
+        bsCustomFileInput.init();
+    })
 
 </script>
 @endpush

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -1,9 +1,3 @@
-{{-- Setup the internal errors bag for the component --}}
-
-@php
-    $setErrorsBag($errors);
-@endphp
-
 {{-- Setup the input group component structure --}}
 
 <div class="{{ $makeFormGroupClass() }}">
@@ -34,7 +28,7 @@
     </div>
 
     {{-- Error feedback --}}
-    @if($isInvalid() && ! isset($disableFeedback))
+    @if($isInvalid())
         <span class="invalid-feedback d-block" role="alert">
             <strong>{{ $errors->first($errorKey) }}</strong>
         </span>

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Slider --}}

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Switch --}}

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input --}}

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Summernote Textarea --}}

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Textarea --}}

--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -8,7 +8,8 @@
     <thead @isset($headTheme) class="thead-{{ $headTheme }}" @endisset>
         <tr>
             @foreach($heads as $th)
-                <th @isset($th['width']) style="width:{{ $th['width'] }}%" @endisset
+                <th @isset($th['classes']) class="{{ $th['classes'] }}" @endisset
+                    @isset($th['width']) style="width:{{ $th['width'] }}%" @endisset
                     @isset($th['no-export']) dt-no-export @endisset>
                     {{ is_array($th) ? ($th['label'] ?? '') : $th }}
                 </th>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -26,10 +26,6 @@
     @if(!config('adminlte.enabled_laravel_mix'))
         <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
         <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-
-        {{-- Configured Stylesheets --}}
-        @include('adminlte::plugins', ['type' => 'css'])
-
         <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
 
         @if(config('adminlte.google_fonts.allowed', true))
@@ -38,6 +34,9 @@
     @else
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @endif
+
+    {{-- Extra Configured Plugins Stylesheets --}}
+    @include('adminlte::plugins', ['type' => 'css'])
 
     {{-- Livewire Styles --}}
     @if(config('adminlte.livewire'))
@@ -86,14 +85,13 @@
         <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
         <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
         <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-
-        {{-- Configured Scripts --}}
-        @include('adminlte::plugins', ['type' => 'js'])
-
         <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
     @else
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @endif
+
+    {{-- Extra Configured Plugins Scripts --}}
+    @include('adminlte::plugins', ['type' => 'js'])
 
     {{-- Livewire Script --}}
     @if(config('adminlte.livewire'))

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -50,6 +50,7 @@ class AdminLteServiceProvider extends BaseServiceProvider
         'input-color' => Form\InputColor::class,
         'input-date' => Form\InputDate::class,
         'input-file' => Form\InputFile::class,
+        'input-file-krajee' => Form\InputFileKrajee::class,
         'input-slider' => Form\InputSlider::class,
         'input-switch' => Form\InputSwitch::class,
         'options' => Form\Options::class,

--- a/src/Console/AdminLteInstallCommand.php
+++ b/src/Console/AdminLteInstallCommand.php
@@ -203,7 +203,6 @@ class AdminLteInstallCommand extends Command
     protected function exportPackageResources(...$resources)
     {
         foreach ($resources as $resource) {
-
             // Check if resource was already installed on the current command
             // execution. This can happen, for example, when using:
             // php artisan --type=full --with=auth_views

--- a/src/Console/AdminLtePluginCommand.php
+++ b/src/Console/AdminLtePluginCommand.php
@@ -172,7 +172,6 @@ class AdminLtePluginCommand extends Command
         $bar->start();
 
         foreach ($pluginsKeys as $key) {
-
             // Advance the progress bar one step.
 
             $bar->advance();
@@ -289,7 +288,6 @@ class AdminLtePluginCommand extends Command
         // Install the plugins.
 
         foreach ($pluginsKeys as $pluginKey) {
-
             // Advance the progress bar one step.
 
             $bar->advance();
@@ -385,7 +383,6 @@ class AdminLtePluginCommand extends Command
         // Remove the plugins.
 
         foreach ($pluginsKeys as $pluginKey) {
-
             // Advance the progress bar one step.
 
             $bar->advance();

--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -144,7 +144,6 @@ class AdminLteStatusCommand extends Command
         $bar->start();
 
         foreach ($this->pkgResources as $name => $resource) {
-
             // Fill the status row of the current resource.
 
             $tblContent[] = [

--- a/src/Helpers/CommandHelper.php
+++ b/src/Helpers/CommandHelper.php
@@ -61,7 +61,6 @@ class CommandHelper
         // Copy the source files to destination.
 
         while (($file = readdir($dirHandler)) !== false) {
-
             // Check if this file should be ignored.
 
             $filesToIgnore = array_merge($ignores, ['.', '..']);
@@ -114,7 +113,6 @@ class CommandHelper
         // Now, compare the folders.
 
         while (($file = readdir($dirHandler)) !== false) {
-
             // Check if this file should be ignored.
 
             $filesToIgnore = array_merge($ignores, ['.', '..']);

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -146,7 +146,6 @@ class Builder
             if (isset($item['key']) && $item['key'] === $itemKey) {
                 return [$key];
             } elseif (MenuItemHelper::isSubmenu($item)) {
-
                 // Do the recursive call to search on submenu. If we found the
                 // item, merge the path with the current one.
 
@@ -186,7 +185,6 @@ class Builder
         // Now, apply all the filters on the item.
 
         foreach ($this->filters as $filter) {
-
             // If the item is not allowed to be shown, there is no sense to
             // continue applying the filters.
 

--- a/src/Menu/Filters/LangFilter.php
+++ b/src/Menu/Filters/LangFilter.php
@@ -42,7 +42,6 @@ class LangFilter implements FilterInterface
         // Translate the menu item properties.
 
         foreach ($this->itemProperties as $prop) {
-
             // Check if the property exists for the item.
 
             if (! isset($item[$prop])) {

--- a/src/View/Components/Form/DateRange.php
+++ b/src/View/Components/Form/DateRange.php
@@ -8,7 +8,7 @@ class DateRange extends InputGroupComponent
 
     /**
      * The DateRangePicker plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array

--- a/src/View/Components/Form/InputColor.php
+++ b/src/View/Components/Form/InputColor.php
@@ -8,7 +8,7 @@ class InputColor extends InputGroupComponent
 
     /**
      * The Bootstrap Colorpicker plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array

--- a/src/View/Components/Form/InputDate.php
+++ b/src/View/Components/Form/InputDate.php
@@ -34,7 +34,7 @@ class InputDate extends InputGroupComponent
 
     /**
      * The Tempus Dominus plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array
@@ -70,7 +70,8 @@ class InputDate extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */
@@ -78,7 +79,7 @@ class InputDate extends InputGroupComponent
     {
         $classes = ['form-control', 'datetimepicker'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/InputFile.php
+++ b/src/View/Components/Form/InputFile.php
@@ -12,7 +12,7 @@ class InputFile extends InputGroupComponent
     public $placeholder;
 
     /**
-     * A legend for replace the default 'Browse' text.
+     * A legend for the replacement of the default 'Browser' text.
      *
      * @var string
      */
@@ -39,7 +39,8 @@ class InputFile extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */
@@ -47,7 +48,7 @@ class InputFile extends InputGroupComponent
     {
         $classes = ['custom-file-input'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/InputFileKrajee.php
+++ b/src/View/Components/Form/InputFileKrajee.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
+
+use Illuminate\Support\Str;
+
+class InputFileKrajee extends InputGroupComponent
+{
+    /**
+     * The Krajee file input plugin configuration parameters. Array with
+     * 'key => value' pairs, where the key should be an existing configuration
+     * property of the Krajee file input plugin.
+     *
+     * @var array
+     */
+    public $config;
+
+    /**
+     * The plugin preset mode. Used to make specific plugin configuration for
+     * some particular scenarios. The current supported set of values are:
+     * 'avatar', 'minimalist'.
+     *
+     * @var string
+     */
+    public $presetMode;
+
+    /**
+     * Create a new component instance.
+     * Note this component requires the Krajee 'bootstrap-fileinput' plugin.
+     *
+     * @return void
+     */
+    public function __construct(
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = [], $presetMode = null
+    ) {
+        parent::__construct(
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
+        );
+
+        $this->config = is_array($config) ? $config : [];
+        $this->presetMode = $presetMode;
+
+        // Make some default configuration for the underlying plugin.
+
+        $this->makePluginDefaultCfg();
+
+        // Make the plugin 'inputGroupClass' configuration.
+
+        $this->makePluginInputGroupClassCfg();
+
+        // Get the preset mode config and merge with the current plugin config.
+
+        $this->config = array_merge($this->config, $this->getPresetModeCfg());
+    }
+
+    /**
+     * Make the class attribute for the invalid feedback block.
+     *
+     * @return string
+     */
+    public function makeInvalidFeedbackClass()
+    {
+        $classes = ['invalid-feedback', 'd-block'];
+
+        if ($this->presetMode == 'avatar') {
+            $classes[] = 'text-center';
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Make some default configuration for the plugin, when it's not provided
+     * by the config property.
+     *
+     * @return void
+     */
+    protected function makePluginDefaultCfg()
+    {
+        // By default, force the plugin theme to 'Font Awesome 5'. Note this
+        // requires the theme files provided by the plugin to be imported.
+
+        if (! isset($this->config['theme'])) {
+            $this->config['theme'] = 'fa5';
+        }
+
+        // By default, force the plugin language to the configured application
+        // locale. However, note you will still need to import the locale
+        // files provided by the plugin.
+
+        if (! isset($this->config['language'])) {
+            $this->config['language'] = config('app.locale');
+        }
+    }
+
+    /**
+     * Make the plugin 'inputGroupClass' configuration. These classes will be
+     * appended to the 'input-group' DOM element that is internally generated
+     * by the plugin.
+     *
+     * @return void
+     */
+    protected function makePluginInputGroupClassCfg()
+    {
+        // Use the parent method to create the input group classes, but
+        // remove the 'input-group' CSS class to avoid duplication, since it's
+        // already added by the underlying plugin.
+
+        $inputGroupClasses = Str::of($this->makeInputGroupClass())
+            ->replaceFirst('input-group', '')
+            ->trim();
+
+        if (empty($this->config['inputGroupClass'])) {
+            $this->config['inputGroupClass'] = $inputGroupClasses;
+        } else {
+            $this->config['inputGroupClass'] .= " {$inputGroupClasses}";
+        }
+    }
+
+    /**
+     * Get the preset mode configuration.
+     *
+     * @return array
+     */
+    protected function getPresetModeCfg()
+    {
+        $modeCfg = [];
+
+        // Check for valid preset mode and generate the related plugin config.
+
+        switch ($this->presetMode) {
+            case 'avatar':
+                $modeCfg = $this->makeAvatarCfg();
+                break;
+
+            case 'minimalist':
+                $modeCfg = $this->makeMinimalistCfg();
+                break;
+
+            default:
+                break;
+        }
+
+        // Return the preset mode config.
+
+        return $modeCfg;
+    }
+
+    /**
+     * Generates the plugin configuration for an avatar image upload mode.
+     *
+     * @return array
+     */
+    protected function makeAvatarCfg()
+    {
+        // Setup the additional classes for the upload preview zone.
+
+        $previewZoneClasses = ['bg-light', 'd-flex', 'justify-content-center'];
+
+        // Setup the allowed image extensions.
+
+        $allowedImageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'tif', 'tiff'];
+
+        // Return the configuration for the avatar mode.
+
+        return [
+            'showUpload' => false,
+            'showClose' => false,
+            'showCaption' => false,
+            'showCancel' => false,
+            'browseOnZoneClick' => true,
+            'allowedFileExtensions' => $allowedImageExtensions,
+            'maxFileCount' => 1,
+            'previewClass' => implode(' ', $previewZoneClasses),
+            'browseLabel' => '',
+            'removeLabel' => '',
+        ];
+    }
+
+    /**
+     * Generates the plugin configuration for a minimalist style.
+     *
+     * @return array
+     */
+    protected function makeMinimalistCfg()
+    {
+        // Return the configuration for the avatar mode.
+
+        return [
+            'showPreview' => false,
+            'browseLabel' => '',
+            'removeLabel' => '',
+            'uploadLabel' => '',
+        ];
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('adminlte::components.form.input-file-krajee');
+    }
+}

--- a/src/View/Components/Form/InputGroupComponent.php
+++ b/src/View/Components/Form/InputGroupComponent.php
@@ -25,8 +25,8 @@ class InputGroupComponent extends Component
 
     /**
      * The name attribute for the underlying input group item. This value will
-     * be used as the default id attribute when not provided. The input group
-     * item may be an "input", a "select", a "textarea", etc.
+     * be also used as the default id attribute when no other is provided. The
+     * input group item may be an "input", a "select", a "textarea", etc.
      *
      * @var string
      */
@@ -47,7 +47,7 @@ class InputGroupComponent extends Component
     public $size;
 
     /**
-     * Additional classes for "input-group" element. This provides a way to
+     * Additional classes for the "input-group" element. This provides a way to
      * customize the input group container style.
      *
      * @var string
@@ -143,7 +143,7 @@ class InputGroupComponent extends Component
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-igroup';
         }
 
@@ -163,7 +163,7 @@ class InputGroupComponent extends Component
     {
         $classes = ['form-control'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 
@@ -171,8 +171,8 @@ class InputGroupComponent extends Component
     }
 
     /**
-     * Check if there exists validation errors on the session related to the
-     * configured error key.
+     * Check if there are validation errors in the session related to the
+     * error key.
      *
      * @return bool
      */
@@ -185,13 +185,16 @@ class InputGroupComponent extends Component
 
         $errors = $this->errorsBag ?? session()->get('errors');
 
-        // Check if exists any error related to the configured error key.
+        // Check if the invalid feedback is enabled and there exists an error
+        // related to the configured error key.
 
-        return ! empty($errors) && $errors->has($this->errorKey);
+        return ! isset($this->disableFeedback)
+            && ! empty($errors)
+            && $errors->has($this->errorKey);
     }
 
     /**
-     * Setup the internal errors bag.
+     * Setup the errors bag internally.
      *
      * @param  \Illuminate\Support\MessageBag  $errorsBag
      * @return void

--- a/src/View/Components/Form/InputSlider.php
+++ b/src/View/Components/Form/InputSlider.php
@@ -8,7 +8,7 @@ class InputSlider extends InputGroupComponent
 
     /**
      * The bootstrap-slider plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array
@@ -61,7 +61,7 @@ class InputSlider extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-islgroup';
         }
 

--- a/src/View/Components/Form/InputSwitch.php
+++ b/src/View/Components/Form/InputSwitch.php
@@ -8,7 +8,7 @@ class InputSwitch extends InputGroupComponent
 
     /**
      * The Bootstrap Switch plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array
@@ -49,7 +49,7 @@ class InputSwitch extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-iswgroup';
         }
 
@@ -61,7 +61,8 @@ class InputSwitch extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */
@@ -69,7 +70,7 @@ class InputSwitch extends InputGroupComponent
     {
         $classes = [];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/Options.php
+++ b/src/View/Components/Form/Options.php
@@ -9,7 +9,7 @@ use JeroenNoten\LaravelAdminLte\Helpers\UtilsHelper;
 class Options extends Component
 {
     /**
-     * The list of options as key value pairs.
+     * The list of options as 'key => value' pairs.
      *
      * @var array
      */

--- a/src/View/Components/Form/Select2.php
+++ b/src/View/Components/Form/Select2.php
@@ -7,7 +7,7 @@ class Select2 extends InputGroupComponent
     use Traits\OldValueSupportTrait;
 
     /**
-     * The select2 plugin configuration parameters. Array with key => value
+     * The select2 plugin configuration parameters. Array with 'key => value'
      * pairs, where the key should be an existing configuration property of
      * the select2 plugin.
      *

--- a/src/View/Components/Form/SelectBs.php
+++ b/src/View/Components/Form/SelectBs.php
@@ -8,7 +8,7 @@ class SelectBs extends InputGroupComponent
 
     /**
      * The bootstrap-select plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the bootstrap-select plugin.
      *
      * @var array
@@ -36,7 +36,8 @@ class SelectBs extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */
@@ -44,7 +45,7 @@ class SelectBs extends InputGroupComponent
     {
         $classes = ['form-control'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/TextEditor.php
+++ b/src/View/Components/Form/TextEditor.php
@@ -7,7 +7,7 @@ class TextEditor extends InputGroupComponent
     use Traits\OldValueSupportTrait;
 
     /**
-     * The Summernote plugin configuration parameters. Array with key => value
+     * The Summernote plugin configuration parameters. Array with 'key => value'
      * pairs, where the key should be an existing configuration property of
      * the plugin.
      *
@@ -54,7 +54,7 @@ class TextEditor extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-itegroup';
         }
 

--- a/src/View/Components/Widget/InfoBox.php
+++ b/src/View/Components/Widget/InfoBox.php
@@ -83,7 +83,13 @@ class InfoBox extends Component
         $this->description = UtilsHelper::applyHtmlEntityDecoder($description);
         $this->theme = $theme;
         $this->iconTheme = $iconTheme;
-        $this->progress = $progress;
+
+        // Setup the progress property, to be between 0 and 100 when defined.
+
+        $this->progress = isset($progress)
+            ? max(min($progress, 100), 0)
+            : null;
+
         $this->progressTheme = $progressTheme;
     }
 

--- a/src/View/Components/Widget/Progress.php
+++ b/src/View/Components/Widget/Progress.php
@@ -72,9 +72,9 @@ class Progress extends Component
         $value = 0, $theme = 'info', $size = null, $striped = null,
         $vertical = null, $animated = null, $withLabel = null
     ) {
-        // Control and setup the value property.
+        // Setup the value property, to be between 0 and 100.
 
-        $this->value = ($value >= 0 && $value <= 100) ? $value : 0;
+        $this->value = max(min($value, 100), 0);
 
         // Initialize other properties.
 

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -16,20 +16,21 @@ class FormComponentsTest extends TestCase
 
         return [
             "{$base}.input-group-component" => new Components\Form\InputGroupComponent('name'),
-            "{$base}.button"       => new Components\Form\Button(),
-            "{$base}.date-range"   => new Components\Form\DateRange('name'),
-            "{$base}.input"        => new Components\Form\Input('name'),
-            "{$base}.input-color"  => new Components\Form\InputColor('name'),
-            "{$base}.input-date"   => new Components\Form\InputDate('name'),
-            "{$base}.input-file"   => new Components\Form\InputFile('name'),
+            "{$base}.button" => new Components\Form\Button(),
+            "{$base}.date-range" => new Components\Form\DateRange('name'),
+            "{$base}.input" => new Components\Form\Input('name'),
+            "{$base}.input-color" => new Components\Form\InputColor('name'),
+            "{$base}.input-date" => new Components\Form\InputDate('name'),
+            "{$base}.input-file" => new Components\Form\InputFile('name'),
+            "{$base}.input-file-krajee" => new Components\Form\InputFileKrajee('name'),
             "{$base}.input-slider" => new Components\Form\InputSlider('name'),
             "{$base}.input-switch" => new Components\Form\InputSwitch('name'),
-            "{$base}.select"       => new Components\Form\Select('name'),
-            "{$base}.select2"      => new Components\Form\Select2('name'),
-            "{$base}.select-bs"    => new Components\Form\SelectBs('name'),
-            "{$base}.textarea"     => new Components\Form\Textarea('name'),
-            "{$base}.text-editor"  => new Components\Form\TextEditor('name'),
-            "{$base}.options"      => new Components\Form\Options(['o1, o2']),
+            "{$base}.select" => new Components\Form\Select('name'),
+            "{$base}.select2" => new Components\Form\Select2('name'),
+            "{$base}.select-bs" => new Components\Form\SelectBs('name'),
+            "{$base}.textarea" => new Components\Form\Textarea('name'),
+            "{$base}.text-editor" => new Components\Form\TextEditor('name'),
+            "{$base}.options" => new Components\Form\Options(['o1, o2']),
         ];
     }
 
@@ -263,6 +264,96 @@ class FormComponentsTest extends TestCase
 
         $this->assertStringContainsString('custom-file-input', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input file Krajee component tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testInputFileKrajeeComponentBasic()
+    {
+        app()->setLocale('es');
+        $component = new Components\Form\InputFileKrajee('name');
+
+        // Test default values for the plugin configuration.
+
+        $this->assertEquals('fa5', $component->config['theme']);
+        $this->assertEquals('es', $component->config['language']);
+
+        $this->assertStringNotContainsString(
+            'input-group',
+            $component->config['inputGroupClass']
+        );
+
+        // Test invalid feedback classes.
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+    }
+
+    public function testInputFileKrajeeComponentAdvanced()
+    {
+        app()->setLocale('en');
+
+        $cfg = [
+            'inputGroupClass' => 'ig-class-1',
+            'theme' => 'theme-foo',
+            'language' => 'br',
+        ];
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, 'lg', null, null, 'ig-class-2', null, null, $cfg
+        );
+
+        // Test default values for the plugin configuration.
+
+        $this->assertEquals('theme-foo', $component->config['theme']);
+        $this->assertEquals('br', $component->config['language']);
+
+        $pluginIGroupClasses = explode(
+            ' ',
+            $component->config['inputGroupClass']
+        );
+
+        $this->assertContains('ig-class-1', $pluginIGroupClasses);
+        $this->assertContains('ig-class-2', $pluginIGroupClasses);
+        $this->assertContains('input-group-lg', $pluginIGroupClasses);
+        $this->assertNotContains('input-group', $pluginIGroupClasses);
+    }
+
+    public function testInputFileKrajeeComponentWithPresets()
+    {
+        // Test avatar preset mode.
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, null, null, null, null,
+            null, null, null, 'avatar'
+        );
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertEquals('avatar', $component->presetMode);
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+        $this->assertStringContainsString('text-center', $ifClass);
+
+        // Test minimalist preset mode.
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, null, null, null, null,
+            null, null, null, 'minimalist'
+        );
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertEquals('minimalist', $component->presetMode);
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+        $this->assertStringNotContainsString('text-center', $ifClass);
     }
 
     /*

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -191,6 +191,39 @@ class WidgetComponentsTest extends TestCase
         $this->assertStringContainsString('bg-primary', $iClass);
     }
 
+    public function testInfoBoxComponentProgressAttribute()
+    {
+        // Test that the progress attribute always stays in the range [0, 100].
+
+        $component = new Components\Widget\InfoBox();
+        $this->assertNull($component->progress);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 67
+        );
+        $this->assertEquals($component->progress, 67);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 100
+        );
+        $this->assertEquals($component->progress, 100);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 0
+        );
+        $this->assertEquals($component->progress, 0);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, -21.14
+        );
+        $this->assertEquals($component->progress, 0);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 527.67
+        );
+        $this->assertEquals($component->progress, 100);
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Profile col item component tests.
@@ -324,6 +357,26 @@ class WidgetComponentsTest extends TestCase
 
         $pbStyle = $component->makeProgressBarStyle();
         $this->assertStringContainsString('height:75%', $pbStyle);
+    }
+
+    public function testProgressComponentValueAttribute()
+    {
+        // test that the value attribute always stays in the range [0, 100].
+
+        $component = new Components\Widget\Progress(67);
+        $this->assertEquals($component->value, 67);
+
+        $component = new Components\Widget\Progress(100);
+        $this->assertEquals($component->value, 100);
+
+        $component = new Components\Widget\Progress(0);
+        $this->assertEquals($component->value, 0);
+
+        $component = new Components\Widget\Progress(-21.14);
+        $this->assertEquals($component->value, 0);
+
+        $component = new Components\Widget\Progress(527.67);
+        $this->assertEquals($component->value, 100);
     }
 
     /*

--- a/tests/Console/InstallTest.php
+++ b/tests/Console/InstallTest.php
@@ -34,7 +34,6 @@ class InstallTest extends CommandTestCase
         // Test installation of the resources.
 
         foreach ($this->getResources() as $name => $res) {
-
             // Ensure the required vendor assets exists, if needed.
 
             if ($name === 'assets') {


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

This PR drops the support for Laravel 6.

Laravel 6 outdated since September 6th, 2022

(https://laravel.com/docs/9.x/releases)

#### Checklist

- [x] I tested these changes.
- [ ] Update README to explain these changes.
