### PR TITLE
Review Livewire validations compatibility.

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Date Range Input --}}

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Color --}}

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Date --}}

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -30,7 +30,9 @@
 @push('js')
 <script>
 
-    $(() => {bsCustomFileInput.init();})
+    $(() => {
+        bsCustomFileInput.init();
+    })
 
 </script>
 @endpush

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     <div class="custom-file">

--- a/resources/views/components/form/input-group-component.blade.php
+++ b/resources/views/components/form/input-group-component.blade.php
@@ -1,9 +1,3 @@
-{{-- Setup the internal errors bag for the component --}}
-
-@php
-    $setErrorsBag($errors);
-@endphp
-
 {{-- Setup the input group component structure --}}
 
 <div class="{{ $makeFormGroupClass() }}">
@@ -34,7 +28,7 @@
     </div>
 
     {{-- Error feedback --}}
-    @if($isInvalid() && ! isset($disableFeedback))
+    @if($isInvalid())
         <span class="invalid-feedback d-block" role="alert">
             <strong>{{ $errors->first($errorKey) }}</strong>
         </span>

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Slider --}}

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input Switch --}}

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Input --}}

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Select --}}

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Summernote Textarea --}}

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -1,5 +1,11 @@
 @extends('adminlte::components.form.input-group-component')
 
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors))
+
+{{-- Set input group item section --}}
+
 @section('input_group_item')
 
     {{-- Textarea --}}

--- a/src/View/Components/Form/DateRange.php
+++ b/src/View/Components/Form/DateRange.php
@@ -8,7 +8,7 @@ class DateRange extends InputGroupComponent
 
     /**
      * The DateRangePicker plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array

--- a/src/View/Components/Form/InputColor.php
+++ b/src/View/Components/Form/InputColor.php
@@ -8,7 +8,7 @@ class InputColor extends InputGroupComponent
 
     /**
      * The Bootstrap Colorpicker plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array

--- a/src/View/Components/Form/InputDate.php
+++ b/src/View/Components/Form/InputDate.php
@@ -78,7 +78,7 @@ class InputDate extends InputGroupComponent
     {
         $classes = ['form-control', 'datetimepicker'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/InputDate.php
+++ b/src/View/Components/Form/InputDate.php
@@ -34,7 +34,7 @@ class InputDate extends InputGroupComponent
 
     /**
      * The Tempus Dominus plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array
@@ -70,7 +70,8 @@ class InputDate extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */

--- a/src/View/Components/Form/InputFile.php
+++ b/src/View/Components/Form/InputFile.php
@@ -47,7 +47,7 @@ class InputFile extends InputGroupComponent
     {
         $classes = ['custom-file-input'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/InputFile.php
+++ b/src/View/Components/Form/InputFile.php
@@ -12,7 +12,7 @@ class InputFile extends InputGroupComponent
     public $placeholder;
 
     /**
-     * A legend for replace the default 'Browse' text.
+     * A legend for the replacement of the default 'Browser' text.
      *
      * @var string
      */
@@ -39,7 +39,8 @@ class InputFile extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */

--- a/src/View/Components/Form/InputGroupComponent.php
+++ b/src/View/Components/Form/InputGroupComponent.php
@@ -143,7 +143,7 @@ class InputGroupComponent extends Component
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-igroup';
         }
 
@@ -163,7 +163,7 @@ class InputGroupComponent extends Component
     {
         $classes = ['form-control'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 
@@ -185,13 +185,16 @@ class InputGroupComponent extends Component
 
         $errors = $this->errorsBag ?? session()->get('errors');
 
-        // Check if exists any error related to the configured error key.
+        // Check if the invalid feedback is enabled and there exists an error
+        // related to the configured error key.
 
-        return ! empty($errors) && $errors->has($this->errorKey);
+        return ! isset($this->disableFeedback)
+            && ! empty($errors)
+            && $errors->has($this->errorKey);
     }
 
     /**
-     * Setup the internal errors bag.
+     * Setup the errors bag internally.
      *
      * @param  \Illuminate\Support\MessageBag  $errorsBag
      * @return void

--- a/src/View/Components/Form/InputGroupComponent.php
+++ b/src/View/Components/Form/InputGroupComponent.php
@@ -25,8 +25,8 @@ class InputGroupComponent extends Component
 
     /**
      * The name attribute for the underlying input group item. This value will
-     * be used as the default id attribute when not provided. The input group
-     * item may be an "input", a "select", a "textarea", etc.
+     * be also used as the default id attribute when no other is provided. The
+     * input group item may be an "input", a "select", a "textarea", etc.
      *
      * @var string
      */
@@ -47,7 +47,7 @@ class InputGroupComponent extends Component
     public $size;
 
     /**
-     * Additional classes for "input-group" element. This provides a way to
+     * Additional classes for the "input-group" element. This provides a way to
      * customize the input group container style.
      *
      * @var string
@@ -171,8 +171,8 @@ class InputGroupComponent extends Component
     }
 
     /**
-     * Check if there exists validation errors on the session related to the
-     * configured error key.
+     * Check if there are validation errors in the session related to the
+     * error key.
      *
      * @return bool
      */

--- a/src/View/Components/Form/InputSlider.php
+++ b/src/View/Components/Form/InputSlider.php
@@ -8,7 +8,7 @@ class InputSlider extends InputGroupComponent
 
     /**
      * The bootstrap-slider plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array

--- a/src/View/Components/Form/InputSlider.php
+++ b/src/View/Components/Form/InputSlider.php
@@ -61,7 +61,7 @@ class InputSlider extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-islgroup';
         }
 

--- a/src/View/Components/Form/InputSwitch.php
+++ b/src/View/Components/Form/InputSwitch.php
@@ -49,7 +49,7 @@ class InputSwitch extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-iswgroup';
         }
 
@@ -69,7 +69,7 @@ class InputSwitch extends InputGroupComponent
     {
         $classes = [];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/InputSwitch.php
+++ b/src/View/Components/Form/InputSwitch.php
@@ -8,7 +8,7 @@ class InputSwitch extends InputGroupComponent
 
     /**
      * The Bootstrap Switch plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the plugin.
      *
      * @var array
@@ -61,7 +61,8 @@ class InputSwitch extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */

--- a/src/View/Components/Form/Options.php
+++ b/src/View/Components/Form/Options.php
@@ -9,7 +9,7 @@ use JeroenNoten\LaravelAdminLte\Helpers\UtilsHelper;
 class Options extends Component
 {
     /**
-     * The list of options as key value pairs.
+     * The list of options as 'key => value' pairs.
      *
      * @var array
      */

--- a/src/View/Components/Form/Select2.php
+++ b/src/View/Components/Form/Select2.php
@@ -7,7 +7,7 @@ class Select2 extends InputGroupComponent
     use Traits\OldValueSupportTrait;
 
     /**
-     * The select2 plugin configuration parameters. Array with key => value
+     * The select2 plugin configuration parameters. Array with 'key => value'
      * pairs, where the key should be an existing configuration property of
      * the select2 plugin.
      *

--- a/src/View/Components/Form/SelectBs.php
+++ b/src/View/Components/Form/SelectBs.php
@@ -44,7 +44,7 @@ class SelectBs extends InputGroupComponent
     {
         $classes = ['form-control'];
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'is-invalid';
         }
 

--- a/src/View/Components/Form/SelectBs.php
+++ b/src/View/Components/Form/SelectBs.php
@@ -8,7 +8,7 @@ class SelectBs extends InputGroupComponent
 
     /**
      * The bootstrap-select plugin configuration parameters. Array with
-     * key => value pairs, where the key should be an existing configuration
+     * 'key => value' pairs, where the key should be an existing configuration
      * property of the bootstrap-select plugin.
      *
      * @var array
@@ -36,7 +36,8 @@ class SelectBs extends InputGroupComponent
     }
 
     /**
-     * Make the class attribute for the input group item.
+     * Make the class attribute for the input group item. Note we overwrite
+     * the method of the parent class.
      *
      * @return string
      */

--- a/src/View/Components/Form/TextEditor.php
+++ b/src/View/Components/Form/TextEditor.php
@@ -54,7 +54,7 @@ class TextEditor extends InputGroupComponent
             $classes[] = "input-group-{$this->size}";
         }
 
-        if ($this->isInvalid() && ! isset($this->disableFeedback)) {
+        if ($this->isInvalid()) {
             $classes[] = 'adminlte-invalid-itegroup';
         }
 

--- a/src/View/Components/Form/TextEditor.php
+++ b/src/View/Components/Form/TextEditor.php
@@ -7,7 +7,7 @@ class TextEditor extends InputGroupComponent
     use Traits\OldValueSupportTrait;
 
     /**
-     * The Summernote plugin configuration parameters. Array with key => value
+     * The Summernote plugin configuration parameters. Array with 'key => value'
      * pairs, where the key should be an existing configuration property of
      * the plugin.
      *


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Review compatibility with `Livewire` validations by moving manual setup of the **errors bag** from the `input-group-component` to the blade file of each form component extending the `input-group-component`.
Fix #1149 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
