### PR TITLE
Add safety check for when the $errors bag variable is undefined

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Set errors bag internallly --}}
 
-@php($setErrorsBag($errors))
+@php($setErrorsBag($errors ?? null))
 
 {{-- Set input group item section --}}
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Add safety check on the **form components** to cover the case when the `$errors` bag variable is `undefined`, probably because the `web` middleware was not applied to the route that is rendering the blade view that is using the mentioned components.

Fix #1158

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
