### PR TITLE
Fixed plugins not loading when using laravel mix

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -26,10 +26,7 @@
     @if(!config('adminlte.enabled_laravel_mix'))
         <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
         <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-
-        {{-- Configured Stylesheets --}}
-        @include('adminlte::plugins', ['type' => 'css'])
-
+        
         <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
 
         @if(config('adminlte.google_fonts.allowed', true))
@@ -38,6 +35,9 @@
     @else
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @endif
+
+    {{-- Configured Stylesheets --}}
+    @include('adminlte::plugins', ['type' => 'css'])
 
     {{-- Livewire Styles --}}
     @if(config('adminlte.livewire'))
@@ -87,13 +87,14 @@
         <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
         <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
 
-        {{-- Configured Scripts --}}
-        @include('adminlte::plugins', ['type' => 'js'])
-
         <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
     @else
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @endif
+
+     {{-- Configured Scripts --}}
+     @include('adminlte::plugins', ['type' => 'js'])
+
 
     {{-- Livewire Script --}}
     @if(config('adminlte.livewire'))

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -26,7 +26,6 @@
     @if(!config('adminlte.enabled_laravel_mix'))
         <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
         <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-        
         <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
 
         @if(config('adminlte.google_fonts.allowed', true))
@@ -36,7 +35,7 @@
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @endif
 
-    {{-- Configured Stylesheets --}}
+    {{-- Extra Configured Plugins Stylesheets --}}
     @include('adminlte::plugins', ['type' => 'css'])
 
     {{-- Livewire Styles --}}
@@ -86,15 +85,13 @@
         <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
         <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
         <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-
         <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
     @else
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @endif
 
-     {{-- Configured Scripts --}}
-     @include('adminlte::plugins', ['type' => 'js'])
-
+    {{-- Extra Configured Plugins Scripts --}}
+    @include('adminlte::plugins', ['type' => 'js'])
 
     {{-- Livewire Script --}}
     @if(config('adminlte.livewire'))


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue|Enhancement
| License                 | MIT

#### What's in this PR?

Fixed plugins not being loaded for **Laravel Mix** users. This **PR** enables the possibility of including extra plugins from the config file while using `Laravel Mix`. Without this, a user may end with huge compiled files to reach the same goal (note that in most cases not all the plugins are needed in all the pages).

<!-- Explain what the changes in this Pull Request (PR) do. -->
Fix #1160 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
