### PR TITLE
Protect progress bar values in the widget components

### DIFF
--- a/src/View/Components/Widget/InfoBox.php
+++ b/src/View/Components/Widget/InfoBox.php
@@ -83,7 +83,13 @@ class InfoBox extends Component
         $this->description = UtilsHelper::applyHtmlEntityDecoder($description);
         $this->theme = $theme;
         $this->iconTheme = $iconTheme;
-        $this->progress = $progress;
+
+        // Setup the progress property, to be between 0 and 100 when defined.
+
+        $this->progress = isset($progress)
+            ? max(min($progress, 100), 0)
+            : null;
+
         $this->progressTheme = $progressTheme;
     }
 

--- a/src/View/Components/Widget/Progress.php
+++ b/src/View/Components/Widget/Progress.php
@@ -72,9 +72,9 @@ class Progress extends Component
         $value = 0, $theme = 'info', $size = null, $striped = null,
         $vertical = null, $animated = null, $withLabel = null
     ) {
-        // Control and setup the value property.
+        // Setup the value property, to be between 0 and 100.
 
-        $this->value = ($value >= 0 && $value <= 100) ? $value : 0;
+        $this->value = max(min($value, 100), 0);
 
         // Initialize other properties.
 

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -191,6 +191,39 @@ class WidgetComponentsTest extends TestCase
         $this->assertStringContainsString('bg-primary', $iClass);
     }
 
+    public function testInfoBoxComponentProgressAttribute()
+    {
+        // Test that the progress attribute always stays in the range [0, 100].
+
+        $component = new Components\Widget\InfoBox();
+        $this->assertNull($component->progress);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 67
+        );
+        $this->assertEquals($component->progress, 67);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 100
+        );
+        $this->assertEquals($component->progress, 100);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 0
+        );
+        $this->assertEquals($component->progress, 0);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, -21.14
+        );
+        $this->assertEquals($component->progress, 0);
+
+        $component = new Components\Widget\infoBox(
+            null, null, null, null, null, null, 527.67
+        );
+        $this->assertEquals($component->progress, 100);
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Profile col item component tests.
@@ -324,6 +357,26 @@ class WidgetComponentsTest extends TestCase
 
         $pbStyle = $component->makeProgressBarStyle();
         $this->assertStringContainsString('height:75%', $pbStyle);
+    }
+
+    public function testProgressComponentValueAttribute()
+    {
+        // test that the value attribute always stays in the range [0, 100].
+
+        $component = new Components\Widget\Progress(67);
+        $this->assertEquals($component->value, 67);
+
+        $component = new Components\Widget\Progress(100);
+        $this->assertEquals($component->value, 100);
+
+        $component = new Components\Widget\Progress(0);
+        $this->assertEquals($component->value, 0);
+
+        $component = new Components\Widget\Progress(-21.14);
+        $this->assertEquals($component->value, 0);
+
+        $component = new Components\Widget\Progress(527.67);
+        $this->assertEquals($component->value, 100);
     }
 
     /*


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

For the `Progress` and `InfoBox` components, ensure a progress bar is always between the range `[0, 100]`.

Fix #1162 

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
