### PR TITLE
Add krajee file input component

### DIFF
--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -1,0 +1,70 @@
+{{--
+Note: we don't extends the 'input-group-component' blade layout as we have done
+with other form components. The reason is that the underlying Krajee file input
+plugin already generates an 'input-group' structure and will conflict with the
+one provided by the mentioned layout. So instead, we define a new layout.
+--}}
+
+{{-- Set errors bag internallly --}}
+
+@php($setErrorsBag($errors ?? null))
+
+{{-- Create the form group layout --}}
+
+<div class="{{ $makeFormGroupClass() }}">
+
+    {{-- Input label --}}
+    @isset($label)
+        <label for="{{ $id }}" @isset($labelClass) class="{{ $labelClass }}" @endisset>
+            {{ $label }}
+        </label>
+    @endisset
+
+    {{-- Krajee file input --}}
+    <input type="file" id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
+
+    {{-- Error feedback --}}
+    @if($isInvalid())
+        <span class="{{ $makeInvalidFeedbackClass() }}" role="alert">
+            <strong>{{ $errors->first($errorKey) }}</strong>
+        </span>
+    @endif
+
+</div>
+
+{{-- Add the plugin initialization code --}}
+
+@push('js')
+<script>
+
+    $(() => {
+
+        // Initialize the plugin.
+
+        $('#{{ $id }}').fileinput( @json($config) );
+
+        // Workaround to force setup of invalid class.
+
+        @if($isInvalid())
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-caption-name')
+                .addClass('is-invalid')
+
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-preview')
+                .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
+        @endif
+
+        // Make custom style for particular scenarios (modes).
+
+        @if($presetMode == 'avatar')
+            $('#{{ $id }}').closest('.file-input')
+                .addClass('text-center')
+                .find('.file-drop-zone')
+                .addClass('border-0');
+        @endif
+    })
+
+</script>
+@endpush

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -50,6 +50,7 @@ class AdminLteServiceProvider extends BaseServiceProvider
         'input-color' => Form\InputColor::class,
         'input-date' => Form\InputDate::class,
         'input-file' => Form\InputFile::class,
+        'input-file-krajee' => Form\InputFileKrajee::class,
         'input-slider' => Form\InputSlider::class,
         'input-switch' => Form\InputSwitch::class,
         'options' => Form\Options::class,

--- a/src/View/Components/Form/InputFileKrajee.php
+++ b/src/View/Components/Form/InputFileKrajee.php
@@ -123,7 +123,7 @@ class InputFileKrajee extends InputGroupComponent
     /**
      * Get the preset mode configuration.
      *
-     * @return void
+     * @return array
      */
     protected function getPresetModeCfg()
     {

--- a/src/View/Components/Form/InputFileKrajee.php
+++ b/src/View/Components/Form/InputFileKrajee.php
@@ -132,7 +132,6 @@ class InputFileKrajee extends InputGroupComponent
         // Check for valid preset mode and generate the related plugin config.
 
         switch ($this->presetMode) {
-
             case 'avatar':
                 $modeCfg = $this->makeAvatarCfg();
                 break;

--- a/src/View/Components/Form/InputFileKrajee.php
+++ b/src/View/Components/Form/InputFileKrajee.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\View\Components\Form;
+
+use Illuminate\Support\Str;
+
+class InputFileKrajee extends InputGroupComponent
+{
+    /**
+     * The Krajee file input plugin configuration parameters. Array with
+     * 'key => value' pairs, where the key should be an existing configuration
+     * property of the Krajee file input plugin.
+     *
+     * @var array
+     */
+    public $config;
+
+    /**
+     * The plugin preset mode. Used to make specific plugin configuration for
+     * some particular scenarios. The current supported set of values are:
+     * 'avatar', 'minimalist'.
+     *
+     * @var string
+     */
+    public $presetMode;
+
+    /**
+     * Create a new component instance.
+     * Note this component requires the Krajee 'bootstrap-fileinput' plugin.
+     *
+     * @return void
+     */
+    public function __construct(
+        $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
+        $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
+        $errorKey = null, $config = [], $presetMode = null
+    ) {
+        parent::__construct(
+            $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
+            $igroupClass, $disableFeedback, $errorKey
+        );
+
+        $this->config = is_array($config) ? $config : [];
+        $this->presetMode = $presetMode;
+
+        // Make some default configuration for the underlying plugin.
+
+        $this->makePluginDefaultCfg();
+
+        // Make the plugin 'inputGroupClass' configuration.
+
+        $this->makePluginInputGroupClassCfg();
+
+        // Get the preset mode config and merge with the current plugin config.
+
+        $this->config = array_merge($this->config, $this->getPresetModeCfg());
+    }
+
+    /**
+     * Make the class attribute for the invalid feedback block.
+     *
+     * @return string
+     */
+    public function makeInvalidFeedbackClass()
+    {
+        $classes = ['invalid-feedback', 'd-block'];
+
+        if ($this->presetMode == 'avatar') {
+            $classes[] = 'text-center';
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
+     * Make some default configuration for the plugin, when it's not provided
+     * by the config property.
+     *
+     * @return void
+     */
+    protected function makePluginDefaultCfg()
+    {
+        // By default, force the plugin theme to 'Font Awesome 5'. Note this
+        // requires the theme files provided by the plugin to be imported.
+
+        if (! isset($this->config['theme'])) {
+            $this->config['theme'] = 'fa5';
+        }
+
+        // By default, force the plugin language to the configured application
+        // locale. However, note you will still need to import the locale
+        // files provided by the plugin.
+
+        if (! isset($this->config['language'])) {
+            $this->config['language'] = config('app.locale');
+        }
+    }
+
+    /**
+     * Make the plugin 'inputGroupClass' configuration. These classes will be
+     * appended to the 'input-group' DOM element that is internally generated
+     * by the plugin.
+     *
+     * @return void
+     */
+    protected function makePluginInputGroupClassCfg()
+    {
+        // Use the parent method to create the input group classes, but
+        // remove the 'input-group' CSS class to avoid duplication, since it's
+        // already added by the underlying plugin.
+
+        $inputGroupClasses = Str::of($this->makeInputGroupClass())
+            ->replaceFirst('input-group', '')
+            ->trim();
+
+        if (empty($this->config['inputGroupClass'])) {
+            $this->config['inputGroupClass'] = $inputGroupClasses;
+        } else {
+            $this->config['inputGroupClass'] .= " {$inputGroupClasses}";
+        }
+    }
+
+    /**
+     * Get the preset mode configuration.
+     *
+     * @return void
+     */
+    protected function getPresetModeCfg()
+    {
+        $modeCfg = [];
+
+        // Check for valid preset mode and generate the related plugin config.
+
+        switch ($this->presetMode) {
+
+            case 'avatar':
+                $modeCfg = $this->makeAvatarCfg();
+                break;
+
+            case 'minimalist':
+                $modeCfg = $this->makeMinimalistCfg();
+                break;
+
+            default:
+                break;
+        }
+
+        // Return the preset mode config.
+
+        return $modeCfg;
+    }
+
+    /**
+     * Generates the plugin configuration for an avatar image upload mode.
+     *
+     * @return array
+     */
+    protected function makeAvatarCfg()
+    {
+        // Setup the additional classes for the upload preview zone.
+
+        $previewZoneClasses = ['bg-light', 'd-flex', 'justify-content-center'];
+
+        // Setup the allowed image extensions.
+
+        $allowedImageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'tif', 'tiff'];
+
+        // Return the configuration for the avatar mode.
+
+        return [
+            'showUpload' => false,
+            'showClose' => false,
+            'showCaption' => false,
+            'showCancel' => false,
+            'browseOnZoneClick' => true,
+            'allowedFileExtensions' => $allowedImageExtensions,
+            'maxFileCount' => 1,
+            'previewClass' => implode(' ', $previewZoneClasses),
+            'browseLabel' => '',
+            'removeLabel' => '',
+        ];
+    }
+
+    /**
+     * Generates the plugin configuration for a minimalist style.
+     *
+     * @return array
+     */
+    protected function makeMinimalistCfg()
+    {
+        // Return the configuration for the avatar mode.
+
+        return [
+            'showPreview' => false,
+            'browseLabel' => '',
+            'removeLabel' => '',
+            'uploadLabel' => '',
+        ];
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('adminlte::components.form.input-file-krajee');
+    }
+}

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -16,20 +16,21 @@ class FormComponentsTest extends TestCase
 
         return [
             "{$base}.input-group-component" => new Components\Form\InputGroupComponent('name'),
-            "{$base}.button"       => new Components\Form\Button(),
-            "{$base}.date-range"   => new Components\Form\DateRange('name'),
-            "{$base}.input"        => new Components\Form\Input('name'),
-            "{$base}.input-color"  => new Components\Form\InputColor('name'),
-            "{$base}.input-date"   => new Components\Form\InputDate('name'),
-            "{$base}.input-file"   => new Components\Form\InputFile('name'),
+            "{$base}.button" => new Components\Form\Button(),
+            "{$base}.date-range" => new Components\Form\DateRange('name'),
+            "{$base}.input" => new Components\Form\Input('name'),
+            "{$base}.input-color" => new Components\Form\InputColor('name'),
+            "{$base}.input-date" => new Components\Form\InputDate('name'),
+            "{$base}.input-file" => new Components\Form\InputFile('name'),
+            "{$base}.input-file-krajee" => new Components\Form\InputFileKrajee('name'),
             "{$base}.input-slider" => new Components\Form\InputSlider('name'),
             "{$base}.input-switch" => new Components\Form\InputSwitch('name'),
-            "{$base}.select"       => new Components\Form\Select('name'),
-            "{$base}.select2"      => new Components\Form\Select2('name'),
-            "{$base}.select-bs"    => new Components\Form\SelectBs('name'),
-            "{$base}.textarea"     => new Components\Form\Textarea('name'),
-            "{$base}.text-editor"  => new Components\Form\TextEditor('name'),
-            "{$base}.options"      => new Components\Form\Options(['o1, o2']),
+            "{$base}.select" => new Components\Form\Select('name'),
+            "{$base}.select2" => new Components\Form\Select2('name'),
+            "{$base}.select-bs" => new Components\Form\SelectBs('name'),
+            "{$base}.textarea" => new Components\Form\Textarea('name'),
+            "{$base}.text-editor" => new Components\Form\TextEditor('name'),
+            "{$base}.options" => new Components\Form\Options(['o1, o2']),
         ];
     }
 
@@ -263,6 +264,96 @@ class FormComponentsTest extends TestCase
 
         $this->assertStringContainsString('custom-file-input', $iClass);
         $this->assertStringContainsString('is-invalid', $iClass);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Input file Krajee component tests.
+    |--------------------------------------------------------------------------
+    */
+
+    public function testInputFileKrajeeComponentBasic()
+    {
+        app()->setLocale('es');
+        $component = new Components\Form\InputFileKrajee('name');
+
+        // Test default values for the plugin configuration.
+
+        $this->assertEquals('fa5', $component->config['theme']);
+        $this->assertEquals('es', $component->config['language']);
+
+        $this->assertStringNotContainsString(
+            'input-group',
+            $component->config['inputGroupClass']
+        );
+
+        // Test invalid feedback classes.
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+    }
+
+    public function testInputFileKrajeeComponentAdvanced()
+    {
+        app()->setLocale('en');
+
+        $cfg = [
+            'inputGroupClass' => 'ig-class-1',
+            'theme' => 'theme-foo',
+            'language' => 'br',
+        ];
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, 'lg', null, null, 'ig-class-2', null, null, $cfg
+        );
+
+        // Test default values for the plugin configuration.
+
+        $this->assertEquals('theme-foo', $component->config['theme']);
+        $this->assertEquals('br', $component->config['language']);
+
+        $pluginIGroupClasses = explode(
+            ' ',
+            $component->config['inputGroupClass']
+        );
+
+        $this->assertContains('ig-class-1', $pluginIGroupClasses);
+        $this->assertContains('ig-class-2', $pluginIGroupClasses);
+        $this->assertContains('input-group-lg', $pluginIGroupClasses);
+        $this->assertNotContains('input-group', $pluginIGroupClasses);
+    }
+
+    public function testInputFileKrajeeComponentWithPresets()
+    {
+        // Test avatar preset mode.
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, null, null, null, null,
+            null, null, null, 'avatar'
+        );
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertEquals('avatar', $component->presetMode);
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+        $this->assertStringContainsString('text-center', $ifClass);
+
+        // Test minimalist preset mode.
+
+        $component = new Components\Form\InputFileKrajee(
+            'name', null, null, null, null, null, null,
+            null, null, null, 'minimalist'
+        );
+
+        $ifClass = $component->makeInvalidFeedbackClass();
+
+        $this->assertEquals('minimalist', $component->presetMode);
+        $this->assertStringContainsString('invalid-feedback', $ifClass);
+        $this->assertStringContainsString('d-block', $ifClass);
+        $this->assertStringNotContainsString('text-center', $ifClass);
     }
 
     /*


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

Add a new **blade form component** around the [Krajee - Bootstrap File Input](https://plugins.krajee.com/file-input) plugin.

#### Example

The next blade markup...

```blade
<div class="row">
    <div class="col-md-4">
        <x-adminlte-input-file-krajee name="kifAvatar" label="Set Profile Picture"
            preset-mode="avatar"/>
    </div>
</div>
```

Will render something like next...

![Screenshot 2023-03-24 at 16-51-07 LaradminTest Tests](https://user-images.githubusercontent.com/63609705/227626105-29361e1f-8ff9-47f0-bf62-89b1f984f90f.png)

#### Checklist

- [x] I tested these changes.
- [x] Add documentation on Wiki pages
