### PR TITLE
Drop support to Laravel 6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1]
-                laravel: [6.*, 7.*, 8.*, 9.*]
+                laravel: [7.*, 8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 9.*
@@ -19,11 +19,7 @@ jobs:
                         testbench: 6.22.*
                     -   laravel: 7.*
                         testbench: 5.20.*
-                    -   laravel: 6.*
-                        testbench: 4.18.*
                 exclude:
-                    -   laravel: 6.*
-                        php: 8.1
                     -   laravel: 7.*
                         php: 8.1
                     -   laravel: 9.*
@@ -58,19 +54,13 @@ jobs:
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-                # Test suite for Laravel 6.x versions.
-            -   name: Execute Laravel 6.x tests
-                if: matrix.laravel == '6.*'
-                run: vendor/bin/phpunit --testsuite Laravel6
-
-                # Test suite for Laravel 7+ versions.
-            -   name: Execute Laravel 7+ tests
-                if: matrix.laravel == '7.*' || matrix.laravel == '8.*' || matrix.laravel == '9.*'
-                run: vendor/bin/phpunit --testsuite Laravel7+
+                # Test suite for Laravel.
+            -   name: Execute Laravel tests
+                run: vendor/bin/phpunit --testsuite Laravel
 
                 # Upload coverage only for latest versions.
             -   name: Upload coverage to scrutinizer-ci
                 if: matrix.php == '8.1' && matrix.laravel == '9.*' && matrix.dependency-version == 'prefer-stable'
                 run: |
-                    vendor/bin/phpunit --testsuite Laravel7+ --coverage-clover=coverage.clover
+                    vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
                     vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If you want to use an older **Laravel** or **AdminLTE** version, review the foll
 - **Releases 1.x**:
   These releases supports Laravel 5 and include AdminLTE v2
 - **Releases 2.x**:
-  These releases supports Laravel 6 or higher and include AdminLTE v2
+  These releases supports Laravel 6 and include AdminLTE v2
 - **Releases 3.x (<=3.8.6)**:
-  These releases supports Laravel 6 or higher and include AdminLTE v3
+  These releases supports Laravel 6 and include AdminLTE v3
 
 ## Documentation
 
@@ -33,6 +33,8 @@ The current package requirements are:
 ## Issues, Questions and Pull Requests
 
 You can report issues or ask questions in the [issues section](https://github.com/jeroennoten/Laravel-AdminLTE/issues). Please, start your issue with `[BUG]` and your question with `[QUESTION]` in the subject.
+
+You may also use the issues to propose changes for the **Wiki Pages**, in that case use `[WIKI]` at the beginning of the subject.
 
 If you have a question, it is recommended to make a search over the closed issues first.
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/jeroennoten/Laravel-AdminLTE.svg?logo=scrutinizer&style=flat-square)](https://scrutinizer-ci.com/g/jeroennoten/Laravel-AdminLTE)
 [![StyleCI](https://styleci.io/repos/38200433/shield?branch=master)](https://styleci.io/repos/38200433)
 
-This package provides an easy way to quickly set up [AdminLTE v3](https://adminlte.io/themes/v3/) with [Laravel](https://laravel.com/) (6 or higher). It has no requirements and dependencies besides **Laravel**, so you can start building your admin panel immediately. The package provides a [blade template](https://laravel.com/docs/blade) that you can extend and an advanced menu configuration system. Also, and optionally, the package offers a set of **AdminLTE** styled authentication views that you can use in replacement of the ones that are provided by the legacy [laravel/ui](https://github.com/laravel/ui) authentication scaffolding.
+This package provides an easy way to quickly set up [AdminLTE v3](https://adminlte.io/themes/v3/) with [Laravel](https://laravel.com/) (7 or higher). It has no others requirements and dependencies besides **Laravel**, so you can start building your admin panel immediately. The package provides a [blade template](https://laravel.com/docs/blade) that you can extend and an advanced menu configuration system. Also, and optionally, the package offers a set of **AdminLTE** styled authentication views that you can use in replacement of the ones that are provided by the legacy [laravel/ui](https://github.com/laravel/ui) authentication scaffolding.
 
 If you want to use an older **Laravel** or **AdminLTE** version, review the following package releases:
 - **Releases 1.x**:
   These releases supports Laravel 5 and include AdminLTE v2
 - **Releases 2.x**:
   These releases supports Laravel 6 or higher and include AdminLTE v2
+- **Releases 3.x (<=3.8.6)**:
+  These releases supports Laravel 6 or higher and include AdminLTE v3
 
 ## Documentation
 
@@ -24,8 +26,8 @@ All documentation is available on the [Wiki Pages](https://github.com/jeroennote
 
 The current package requirements are:
 
-- Laravel >= 6.x
-- PHP >= 7.2
+- Laravel >= 7.x
+- PHP >= 7.2.5
 
 
 ## Issues, Questions and Pull Requests
@@ -36,6 +38,6 @@ If you have a question, it is recommended to make a search over the closed issue
 
 To submit a Pull Request, fork this repository and create a new branch to commit your new changes there. Finally, open a Pull Request from your new branch. Refer to the [contribution guidelines](https://github.com/jeroennoten/Laravel-AdminLTE/blob/master/.github/CONTRIBUTING.md) for detailed instructions. When submitting a Pull Request take the next notes into consideration:
 
-- Verify that the Pull Request don't introduce a high downgrade on the code quality.
-- If the Pull Request introduces a new feature, consider adding a proposal of the documentation for the Wiki.
-- Keep the package focused, don't add special support to other packages or to solve very particular situations. These changes will make the package more hard to maintain.
+- Verify that the Pull Request doesn't introduce a high downgrade on the code quality.
+- If the Pull Request adds a new feature, consider adding a proposal of the documentation for the Wiki.
+- Keep the package focused, don't add special support to other packages or to solve very particular situations. These changes will make the package harder to maintain.

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
       }
   },
   "require": {
-    "laravel/framework": ">=6.0",
-    "php": ">=7.2.0",
+    "laravel/framework": ">=7.0",
+    "php": ">=7.2.5",
     "almasaeed2010/adminlte": "3.2.*"
   },
   "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,12 +6,8 @@
     </include>
   </coverage>
   <testsuites>
-    <testsuite name="Laravel7+">
+    <testsuite name="Laravel">
       <directory suffix="Test.php">./tests</directory>
-    </testsuite>
-    <testsuite name="Laravel6">
-      <directory suffix="Test.php">./tests</directory>
-      <exclude>./tests/Components</exclude>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -220,18 +220,6 @@ class AdminLteServiceProvider extends BaseServiceProvider
      */
     private function loadComponents()
     {
-        // Support of x-components is only available for Laravel >= 7.x
-        // versions. So, we check if we can load components.
-
-        $canLoadComponents = method_exists(
-            'Illuminate\Support\ServiceProvider',
-            'loadViewComponentsAs'
-        );
-
-        if (! $canLoadComponents) {
-            return;
-        }
-
         // Load all the blade-x components.
 
         $components = array_merge(


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

This PR drops the support for **Laravel 6**.

**Laravel 6** outdated since September 6th, 2022

(https://laravel.com/docs/9.x/releases)

#### Checklist

- [x] I tested these changes.
- [x] Update README
- [x] Update Wiki pages
