### PR TITLE
Add support for testing on Laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [7.3, 7.4, 8.0, 8.1]
-                laravel: [7.*, 8.*, 9.*]
+                php: [7.3, 7.4, 8.0, 8.1, 8.2]
+                laravel: [7.*, 8.*, 9.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
+                    -   laravel: 10.*
+                        testbench: 8.*
                     -   laravel: 9.*
                         testbench: 7.*
                     -   laravel: 8.*
@@ -22,10 +24,20 @@ jobs:
                 exclude:
                     -   laravel: 7.*
                         php: 8.1
+                    -   laravel: 7.*
+                        php: 8.2
+                    -   laravel: 8.*
+                        php: 8.2
                     -   laravel: 9.*
                         php: 7.3
                     -   laravel: 9.*
                         php: 7.4
+                    -   laravel: 10.*
+                        php: 7.3
+                    -   laravel: 10.*
+                        php: 7.4
+                    -   laravel: 10.*
+                        php: 8.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -60,7 +72,7 @@ jobs:
 
                 # Upload coverage only for latest versions.
             -   name: Upload coverage to scrutinizer-ci
-                if: matrix.php == '8.1' && matrix.laravel == '9.*' && matrix.dependency-version == 'prefer-stable'
+                if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.dependency-version == 'prefer-stable'
                 run: |
                     vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
                     vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,13 +43,13 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     ref: ${{ github.event.pull_request.head.sha }}
                     fetch-depth: 0
 
             -   name: Cache dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 php: [7.3, 7.4, 8.0, 8.1, 8.2]
                 laravel: [7.*, 8.*, 9.*, 10.*]
-                dependency-version: [prefer-lowest, prefer-stable]
+                stability: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 10.*
                         testbench: 8.*
@@ -39,7 +39,7 @@ jobs:
                     -   laravel: 10.*
                         php: 8.0
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
         steps:
             -   name: Checkout code
@@ -64,7 +64,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                    composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
                 # Test suite for Laravel.
             -   name: Execute Laravel tests
@@ -72,7 +72,7 @@ jobs:
 
                 # Upload coverage only for latest versions.
             -   name: Upload coverage to scrutinizer-ci
-                if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.dependency-version == 'prefer-stable'
+                if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.stability == 'prefer-stable'
                 run: |
                     vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
                     vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,14 @@ jobs:
                 laravel: [7.*, 8.*, 9.*, 10.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: 10.*
-                        testbench: 8.*
-                    -   laravel: 9.*
-                        testbench: 7.*
-                    -   laravel: 8.*
-                        testbench: 6.22.*
                     -   laravel: 7.*
                         testbench: 5.20.*
+                    -   laravel: 8.*
+                        testbench: 6.22.*
+                    -   laravel: 9.*
+                        testbench: 7.*
+                    -   laravel: 10.*
+                        testbench: 8.*
                 exclude:
                     -   laravel: 7.*
                         php: 8.1
@@ -63,7 +63,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
                     composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
                 # Test suite for Laravel.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
+  <coverage>
     <include>
       <directory suffix=".php">./src</directory>
     </include>

--- a/tests/AdminLteTest.php
+++ b/tests/AdminLteTest.php
@@ -4,9 +4,9 @@ use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
 
 class AdminLteTest extends TestCase
 {
-    public function __construct()
+    public function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
 
         // Register a listener to 'BuildingMenu' event in order to add items
         // to the menu.


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- [x] Improve `run-tests` action to run tests on **Laravel 10**
- [x] Update `actions/checkout@v2` and `actions/cache@v2`. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- [x] Fix `phpunit.xml` schema for testing on **phpunit 10**
- [x] Add dependency restriction on `neston/carbon` due to problems when testing with old versions.

#### Checklist

- [x] I tested these changes.
