### PR TITLE
Add title url in info-box component

### DIFF
--- a/resources/views/components/widget/info-box.blade.php
+++ b/resources/views/components/widget/info-box.blade.php
@@ -12,7 +12,13 @@
 
         {{-- Box title --}}
         @isset($title)
-            <span class="info-box-text">{{ $title }}</span>
+            <span class="info-box-text">
+                @if(isset($url))
+                    <a href="{{ $url }}">{{ $title }}</a>
+                @else
+                    {{ $title }}
+                @endif
+            </span>
         @endisset
 
         {{-- Box short text --}}

--- a/resources/views/components/widget/info-box.blade.php
+++ b/resources/views/components/widget/info-box.blade.php
@@ -13,17 +13,31 @@
         {{-- Box title --}}
         @isset($title)
             <span class="info-box-text">
-                @if(isset($url))
-                    <a href="{{ $url }}">{{ $title }}</a>
+
+                @if(isset($url) && $urlTarget == 'title')
+                    <a class="info-box-url text-reset" href="{{ $url }}">
+                        <u>{{ $title }}</u>
+                    </a>
                 @else
                     {{ $title }}
                 @endif
+
             </span>
         @endisset
 
         {{-- Box short text --}}
         @isset($text)
-            <span class="info-box-number">{{ $text }}</span>
+            <span class="info-box-number">
+
+                @if(isset($url) && $urlTarget == 'text')
+                    <a class="info-box-url text-reset" href="{{ $url }}">
+                        <u>{{ $text }}</u>
+                    </a>
+                @else
+                    {{ $text }}
+                @endif
+
+            </span>
         @endisset
 
         {{-- Box progress bar --}}
@@ -92,6 +106,10 @@
 
             if (data.description) {
                 t.find('.progress-description').html(data.description);
+            }
+
+            if (data.url) {
+                t.find('.info-box-url').attr('href', data.url);
             }
 
             // Update progress bar.

--- a/src/View/Components/Widget/InfoBox.php
+++ b/src/View/Components/Widget/InfoBox.php
@@ -15,6 +15,13 @@ class InfoBox extends Component
     public $title;
 
     /**
+     * An URL for the title.
+     * 
+     * @var string
+     */
+    public $url;
+
+    /**
      * A short text description for the box.
      *
      * @var string
@@ -73,11 +80,12 @@ class InfoBox extends Component
      * @return void
      */
     public function __construct(
-        $title = null, $text = null, $icon = null, $description = null,
+        $title = null, $url = null, $text = null, $icon = null, $description = null,
         $theme = null, $iconTheme = null, $progress = null,
         $progressTheme = 'white'
     ) {
         $this->title = UtilsHelper::applyHtmlEntityDecoder($title);
+        $this->url = UtilsHelper::applyHtmlEntityDecoder($url);
         $this->text = UtilsHelper::applyHtmlEntityDecoder($text);
         $this->icon = $icon;
         $this->description = UtilsHelper::applyHtmlEntityDecoder($description);

--- a/src/View/Components/Widget/InfoBox.php
+++ b/src/View/Components/Widget/InfoBox.php
@@ -16,7 +16,7 @@ class InfoBox extends Component
 
     /**
      * An URL for the title.
-     * 
+     *
      * @var string
      */
     public $url;

--- a/src/View/Components/Widget/InfoBox.php
+++ b/src/View/Components/Widget/InfoBox.php
@@ -15,13 +15,6 @@ class InfoBox extends Component
     public $title;
 
     /**
-     * An URL for the title.
-     *
-     * @var string
-     */
-    public $url;
-
-    /**
      * A short text description for the box.
      *
      * @var string
@@ -41,6 +34,20 @@ class InfoBox extends Component
      * @var string
      */
     public $icon;
+
+    /**
+     * An URL for the box.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
+     * The target element of the box for the URL (title or text).
+     *
+     * @var string
+     */
+    public $urlTarget;
 
     /**
      * The box theme (light, dark, primary, secondary, info, success, warning,
@@ -80,15 +87,16 @@ class InfoBox extends Component
      * @return void
      */
     public function __construct(
-        $title = null, $url = null, $text = null, $icon = null, $description = null,
-        $theme = null, $iconTheme = null, $progress = null,
-        $progressTheme = 'white'
+        $title = null, $text = null, $icon = null, $description = null,
+        $url = null, $urlTarget = 'title', $theme = null, $iconTheme = null,
+        $progress = null, $progressTheme = 'white'
     ) {
         $this->title = UtilsHelper::applyHtmlEntityDecoder($title);
-        $this->url = UtilsHelper::applyHtmlEntityDecoder($url);
         $this->text = UtilsHelper::applyHtmlEntityDecoder($text);
         $this->icon = $icon;
         $this->description = UtilsHelper::applyHtmlEntityDecoder($description);
+        $this->url = $url;
+        $this->urlTarget = $urlTarget;
         $this->theme = $theme;
         $this->iconTheme = $iconTheme;
 

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -179,7 +179,7 @@ class WidgetComponentsTest extends TestCase
     public function testInfoBoxComponent()
     {
         $component = new Components\Widget\InfoBox(
-            'title', 'text', null, null, 'danger', 'primary'
+            'title', null, 'text', null, null, 'danger', 'primary'
         );
 
         $bClass = $component->makeBoxClass();
@@ -199,27 +199,27 @@ class WidgetComponentsTest extends TestCase
         $this->assertNull($component->progress);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, 67
+            null, null, null, null, null, null, null, 67
         );
         $this->assertEquals($component->progress, 67);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, 100
+            null, null, null, null, null, null, null, 100
         );
         $this->assertEquals($component->progress, 100);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, 0
+            null, null, null, null, null, null, null, 0
         );
         $this->assertEquals($component->progress, 0);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, -21.14
+            null, null, null, null, null, null, null, -21.14
         );
         $this->assertEquals($component->progress, 0);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, 527.67
+            null, null, null, null, null, null, null, 527.67
         );
         $this->assertEquals($component->progress, 100);
     }

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -179,7 +179,7 @@ class WidgetComponentsTest extends TestCase
     public function testInfoBoxComponent()
     {
         $component = new Components\Widget\InfoBox(
-            'title', null, 'text', null, null, 'danger', 'primary'
+            'title', 'text', 'icon', null, null, null, 'danger', 'primary'
         );
 
         $bClass = $component->makeBoxClass();
@@ -199,27 +199,27 @@ class WidgetComponentsTest extends TestCase
         $this->assertNull($component->progress);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, null, 67
+            null, null, null, null, null, null, null, null, 67
         );
         $this->assertEquals($component->progress, 67);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, null, 100
+            null, null, null, null, null, null, null, null, 100
         );
         $this->assertEquals($component->progress, 100);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, null, 0
+            null, null, null, null, null, null, null, null, 0
         );
         $this->assertEquals($component->progress, 0);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, null, -21.14
+            null, null, null, null, null, null, null, null, -21.14
         );
         $this->assertEquals($component->progress, 0);
 
         $component = new Components\Widget\infoBox(
-            null, null, null, null, null, null, null, 527.67
+            null, null, null, null, null, null, null, null, 527.67
         );
         $this->assertEquals($component->progress, 100);
     }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

There is no option or attribute to add a URL in the info box component. After this pull request, it is easy to navigate any module through the info box.

Before
```
<x-adminlte-info-box title="Employees" text="10" icon="fas fa-user-friends " icon-theme="green" />
```
After
```
<x-adminlte-info-box title="Employees" text="10" url="/employees" icon="fas fa-user-friends " icon-theme="green" />
```

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [x] Add on Wiki docs