### PR TITLE
Add compatibility with the IFrame mode on the DarkMode Widget

### DIFF
--- a/resources/views/components/layout/navbar-darkmode-widget.blade.php
+++ b/resources/views/components/layout/navbar-darkmode-widget.blade.php
@@ -31,9 +31,19 @@
 
         widget.addEventListener('click', () => {
 
-            // Toggle dark-mode class on the body tag.
+            // Toggle dark-mode class on the main body tag.
 
             body.classList.toggle('dark-mode');
+
+            // Support to IFrame mode: toggle dark-mode class on the body of
+            // any present iframe.
+
+            let iframes = document.querySelectorAll('div.iframe-mode iframe');
+
+            iframes.forEach((f) => {
+                b = f.contentDocument.querySelector('body');
+                b.classList.toggle('dark-mode');
+            });
 
             // Toggle the classes on the widget icon.
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Issue
| License                 | MIT

#### What's in this PR?

Improve the **Dark Mode Widget** in order to add compatibility to the **IFrame Mode** of the AdminLTE template.

Fix  #1242

#### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
