### PR TITLE
Add Laravel 11 support on tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,11 +85,11 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-        # Execute the test suite for Laravel.
+      # Execute the test suite for Laravel.
       - name: Execute Laravel tests
         run: vendor/bin/phpunit --testsuite Laravel
 
-        # Upload code coverage to Scrutinizer CI, only for specific version.
+      # Upload code coverage to Scrutinizer CI, only for specific version.
       - name: Upload coverage to scrutinizer-ci
         if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.stability == 'prefer-stable'
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
-        laravel: [7.*, 8.*, 9.*, 10.*]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        laravel: [7.*, 8.*, 9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 7.*
@@ -21,13 +21,19 @@ jobs:
             testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
         exclude:
           - laravel: 7.*
             php: 8.1
           - laravel: 7.*
             php: 8.2
+          - laravel: 7.*
+            php: 8.3
           - laravel: 8.*
             php: 8.2
+          - laravel: 8.*
+            php: 8.3
           - laravel: 9.*
             php: 7.3
           - laravel: 9.*
@@ -38,18 +44,26 @@ jobs:
             php: 7.4
           - laravel: 10.*
             php: 8.0
+          - laravel: 11.*
+            php: 7.3
+          - laravel: 11.*
+            php: 7.4
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -72,7 +86,7 @@ jobs:
 
         # Upload coverage only for latest versions.
       - name: Upload coverage to scrutinizer-ci
-        if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.stability == 'prefer-stable'
+        if: matrix.php == '8.3' && matrix.laravel == '11.*' && matrix.stability == 'prefer-stable'
         run: |
           vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
           vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,9 +82,7 @@ jobs:
 
         # Test suite for Laravel.
       - name: Execute Laravel tests
-        run: |
-          vendor/bin/phpunit --migrate-configuration
-          vendor/bin/phpunit --testsuite Laravel
+        run: vendor/bin/phpunit --testsuite Laravel
 
         # Upload coverage only for latest versions.
       - name: Upload coverage to scrutinizer-ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -89,4 +89,6 @@ jobs:
         if: matrix.php == '8.3' && matrix.laravel == '11.*' && matrix.stability == 'prefer-stable'
         run: |
           vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
-          vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+          wget https://scrutinizer-ci.com/ocular.phar
+          php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+          #vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,12 +82,15 @@ jobs:
 
         # Test suite for Laravel.
       - name: Execute Laravel tests
-        run: vendor/bin/phpunit --testsuite Laravel
+        run: |
+          vendor/bin/phpunit --migrate-configuration
+          vendor/bin/phpunit --testsuite Laravel
 
         # Upload coverage only for latest versions.
       - name: Upload coverage to scrutinizer-ci
         if: matrix.php == '8.3' && matrix.laravel == '11.*' && matrix.stability == 'prefer-stable'
         run: |
+          vendor/bin/phpunit --migrate-configuration
           vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
           wget https://scrutinizer-ci.com/ocular.phar
           php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
-            testbench: 9.*
+            testbench: 8.*
         exclude:
           - laravel: 7.*
             php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,18 +56,22 @@ jobs:
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
+
+      # Checkout the package code.
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      # Cache dependencies and build outputs to improve workflow execution time.
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
+      # Setup PHP and extensions.
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -75,16 +79,17 @@ jobs:
           extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
           coverage: xdebug
 
+      # Install the package dependencies.
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-        # Test suite for Laravel.
+        # Execute the test suite for Laravel.
       - name: Execute Laravel tests
         run: vendor/bin/phpunit --testsuite Laravel
 
-        # Upload coverage only for specific version.
+        # Upload code coverage to Scrutinizer CI, only for specific version.
       - name: Upload coverage to scrutinizer-ci
         if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.stability == 'prefer-stable'
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,12 +84,12 @@ jobs:
       - name: Execute Laravel tests
         run: vendor/bin/phpunit --testsuite Laravel
 
-        # Upload coverage only for latest versions.
+        # Upload coverage only for specific version.
       - name: Upload coverage to scrutinizer-ci
-        if: matrix.php == '8.3' && matrix.laravel == '11.*' && matrix.stability == 'prefer-stable'
+        if: matrix.php == '8.2' && matrix.laravel == '10.*' && matrix.stability == 'prefer-stable'
         run: |
+          composer require scrutinizer/ocular
+          cp phpunit.xml.dist phpunit.xml
           vendor/bin/phpunit --migrate-configuration
           vendor/bin/phpunit --testsuite Laravel --coverage-clover=coverage.clover
-          wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-          #vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+          vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
-            testbench: 8.*
+            testbench: 9.*
         exclude:
           - laravel: 7.*
             php: 8.1

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": ">=9.1",
-    "orchestra/testbench": ">=4.0",
-    "scrutinizer/ocular": "^1.9"
+    "orchestra/testbench": ">=4.0"
   }
 }

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -57,7 +57,7 @@ class FormComponentsTest extends TestCase
     protected function addInputOnCurrentRequest($key, $val)
     {
         session()->flashInput([$key => $val]);
-        request()->setLaravelsession(session());
+        request()->setLaravelsession(session()->driver());
     }
 
     /*


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Issue or Enhancement    | Enhancement
| License                 | MIT

#### What's in this PR?

- Include **Laravel 11** and **PHP 8.3** on the tests matrix
- Update `checkout` and `cache` actions to `v4`
- Improve commentaries on the workflow
- Improve the upload code coverage step
- Remove `scrutinizer/ocular` from dev dependencies, it's instead required in the upload coverage step
- Fix tests to provide compatibility with **Laravel 11**

#### Checklist

- [x] I tested these changes.