### PR TITLE
Improve menu filters (last stage)

### DIFF
--- a/src/Menu/Filters/ActiveFilter.php
+++ b/src/Menu/Filters/ActiveFilter.php
@@ -25,10 +25,11 @@ class ActiveFilter implements FilterInterface
     }
 
     /**
-     * Transforms a menu item. Adds the active attribute when suitable.
+     * Transforms a menu item. Check if an item is active based on the current
+     * requested URL and compile it's active property.
      *
      * @param  array  $item  A menu item
-     * @return array The transformed menu item
+     * @return array
      */
     public function transform($item)
     {

--- a/src/Menu/Filters/HrefFilter.php
+++ b/src/Menu/Filters/HrefFilter.php
@@ -47,7 +47,7 @@ class HrefFilter implements FilterInterface
      * Make and return the href HTML attribute fom the route attribute of a
      * menu item.
      *
-     * @param  string|array  $routeAttr  The route attribute of a menu item
+     * @param  mixed  $routeAttr  The route attribute of a menu item
      * @return string
      */
     protected function makeHrefFromRouteAttr($routeAttr)

--- a/src/Menu/Filters/HrefFilter.php
+++ b/src/Menu/Filters/HrefFilter.php
@@ -2,33 +2,15 @@
 
 namespace JeroenNoten\LaravelAdminLte\Menu\Filters;
 
-use Illuminate\Contracts\Routing\UrlGenerator;
 use JeroenNoten\LaravelAdminLte\Helpers\MenuItemHelper;
 
 class HrefFilter implements FilterInterface
 {
     /**
-     * The url generator instance.
-     *
-     * @var UrlGenerator
-     */
-    protected $urlGenerator;
-
-    /**
-     * Constructor.
-     *
-     * @param  UrlGenerator  $urlGenerator
-     */
-    public function __construct(UrlGenerator $urlGenerator)
-    {
-        $this->urlGenerator = $urlGenerator;
-    }
-
-    /**
-     * Transforms a menu item. Make the href attribute when situable.
+     * Transforms a menu item. Compile the href HTML attribute when situable.
      *
      * @param  array  $item  A menu item
-     * @return array The transformed menu item
+     * @return array
      */
     public function transform($item)
     {
@@ -40,34 +22,47 @@ class HrefFilter implements FilterInterface
     }
 
     /**
-     * Make the href attribute for a menu item.
+     * Make and return the href HTML attribute for a menu item.
      *
      * @param  array  $item  A menu item
-     * @return string The href attribute
+     * @return string
      */
     protected function makeHref($item)
     {
-        // If url attribute is available, use it to make the href.
+        // If url attribute is available, use it to make the href property.
+        // Otherwise, check if route attribute is available.
 
-        if (isset($item['url'])) {
-            return $this->urlGenerator->to($item['url']);
+        if (! empty($item['url'])) {
+            return url($item['url']);
+        } elseif (! empty($item['route'])) {
+            return $this->makeHrefFromRouteAttr($item['route']);
         }
 
-        // When url is not available, check for route attribute.
-
-        if (isset($item['route'])) {
-            if (is_array($item['route'])) {
-                $route = $item['route'][0];
-                $params = is_array($item['route'][1]) ? $item['route'][1] : [];
-
-                return $this->urlGenerator->route($route, $params);
-            }
-
-            return $this->urlGenerator->route($item['route']);
-        }
-
-        // When no url or route, return a default value.
+        // When url and route are not available, return a default value.
 
         return '#';
+    }
+
+    /**
+     * Make and return the href HTML attribute fom the route attribute of a
+     * menu item.
+     *
+     * @param  string|array  $routeAttr  The route attribute of a menu item
+     * @return string
+     */
+    protected function makeHrefFromRouteAttr($routeAttr)
+    {
+        $routeName = $routeParams = null;
+
+        // Check type of the route attribute.
+
+        if (is_array($routeAttr)) {
+            $routeName = $routeAttr[0] ?? null;
+            $routeParams = is_array($routeAttr[1]) ? $routeAttr[1] : null;
+        } elseif (is_string($routeAttr)) {
+            $routeName = $routeAttr;
+        }
+
+        return $routeName ? route($routeName, $routeParams) : '#';
     }
 }

--- a/tests/Menu/BuilderTest.php
+++ b/tests/Menu/BuilderTest.php
@@ -1,14 +1,15 @@
 <?php
 
-use Illuminate\Routing\Route;
-
 class BuilderTest extends TestCase
 {
     public function testAddOneItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -17,11 +18,14 @@ class BuilderTest extends TestCase
 
     public function testAddMultipleItems()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add('MENU');
         $builder->add(['text' => 'Home', 'url' => '/']);
         $builder->add(['text' => 'About', 'url' => '/about']);
+
+        // Make assertions.
 
         $this->assertCount(3, $builder->menu);
         $this->assertEquals('MENU', $builder->menu[0]);
@@ -33,12 +37,16 @@ class BuilderTest extends TestCase
 
     public function testAddMultipleItemsAtOnce()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add(
             ['text' => 'Home', 'url' => '/'],
             ['text' => 'About', 'url' => '/about']
         );
+
+        // Make assertions.
 
         $this->assertCount(2, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -49,10 +57,13 @@ class BuilderTest extends TestCase
 
     public function testAddAfterOneItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addAfter('home', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(2, $builder->menu);
         $this->assertEquals('Profile', $builder->menu[1]['text']);
@@ -61,23 +72,29 @@ class BuilderTest extends TestCase
 
     public function testAddAfterOneNotFoundItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addAfter('foo', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
         $this->assertEquals('/', $builder->menu[0]['url']);
     }
 
-    public function testAddAfterMultipleItems()
+    public function testAddAfterMultipleTimes()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addAfter('home', ['text' => 'About', 'url' => '/about']);
         $builder->addAfter('home', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(3, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -88,16 +105,19 @@ class BuilderTest extends TestCase
         $this->assertEquals('/about', $builder->menu[2]['url']);
     }
 
-    public function testAddAfterMultipleItemsAtOnce()
+    public function testAddAfterWithMultipleItemsAtOnce()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
 
         $builder->addAfter('home',
             ['text' => 'Profile', 'url' => '/profile'],
             ['text' => 'About', 'url' => '/about']
         );
+
+        // Make assertions.
 
         $this->assertCount(3, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -110,23 +130,22 @@ class BuilderTest extends TestCase
 
     public function testAddAfterOneSubItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
-        $builder->add(
-            [
-                'text' => 'Home',
-                'url' => '/',
-                'key' => 'home',
-                'submenu' => [
-                    [
-                        'text' => 'Test',
-                        'url' => '/test',
-                        'key' => 'test',
-                    ],
-                ],
-            ]
-        );
+        $builder->add([
+            'text' => 'Home',
+            'url' => '/',
+            'key' => 'home',
+            'submenu' => [
+                ['text' => 'Test', 'url' => '/test', 'key' => 'test'],
+            ],
+        ]);
+
         $builder->addAfter('test', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertCount(2, $builder->menu[0]['submenu']);
@@ -136,10 +155,17 @@ class BuilderTest extends TestCase
 
     public function testAddBeforeOneItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
-        $builder->add(['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']);
+        $builder->add(
+            ['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']
+        );
+
         $builder->addBefore('profile', ['text' => 'Home', 'url' => '/']);
+
+        // Make assertions.
 
         $this->assertCount(2, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -148,10 +174,13 @@ class BuilderTest extends TestCase
 
     public function testAddBeforeOneNotFoundItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addBefore('foo', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -160,23 +189,22 @@ class BuilderTest extends TestCase
 
     public function testAddBeforeOneSubItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
-        $builder->add(
-            [
-                'text' => 'Home',
-                'url' => '/',
-                'key' => 'home',
-                'submenu' => [
-                    [
-                        'text' => 'Test',
-                        'url' => '/test',
-                        'key' => 'test',
-                    ],
-                ],
-            ]
-        );
+        $builder->add([
+            'text' => 'Home',
+            'url' => '/',
+            'key' => 'home',
+            'submenu' => [
+                ['text' => 'Test', 'url' => '/test', 'key' => 'test'],
+            ],
+        ]);
+
         $builder->addBefore('test', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertCount(2, $builder->menu[0]['submenu']);
@@ -184,13 +212,20 @@ class BuilderTest extends TestCase
         $this->assertEquals('/profile', $builder->menu[0]['submenu'][0]['url']);
     }
 
-    public function testAddBeforeMultipleItems()
+    public function testAddBeforeMultipleTimes()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
-        $builder->add(['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']);
+        $builder->add(
+            ['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']
+        );
+
         $builder->addBefore('profile', ['text' => 'Home', 'url' => '/']);
         $builder->addBefore('profile', ['text' => 'About', 'url' => '/about']);
+
+        // Make assertions.
 
         $this->assertCount(3, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -201,16 +236,22 @@ class BuilderTest extends TestCase
         $this->assertEquals('/profile', $builder->menu[2]['url']);
     }
 
-    public function testAddBeforeMultipleItemsAtOnce()
+    public function testAddBeforeWithMultipleItemsAtOnce()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
-        $builder->add(['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']);
+        $builder->add(
+            ['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']
+        );
 
         $builder->addBefore('profile',
             ['text' => 'Home', 'url' => '/'],
             ['text' => 'About', 'url' => '/about']
         );
+
+        // Make assertions.
 
         $this->assertCount(3, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
@@ -223,10 +264,13 @@ class BuilderTest extends TestCase
 
     public function testAddInOneItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addIn('home', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertCount(1, $builder->menu[0]['submenu']);
@@ -236,23 +280,29 @@ class BuilderTest extends TestCase
 
     public function testAddInOneNotFoundItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addIn('foo', ['text' => 'Profile', 'url' => '/profile']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
         $this->assertEquals('/', $builder->menu[0]['url']);
     }
 
-    public function testAddInMultipleItems()
+    public function testAddInMultipleTimes()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->addIn('home', ['text' => 'Profile', 'url' => '/profile']);
         $builder->addIn('home', ['text' => 'About', 'url' => '/about']);
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertCount(2, $builder->menu[0]['submenu']);
@@ -264,16 +314,19 @@ class BuilderTest extends TestCase
         $this->assertEquals('/about', $builder->menu[0]['submenu'][1]['url']);
     }
 
-    public function testAddInMultipleItemsAtOnce()
+    public function testAddInWithMultipleItemsAtOnce()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
 
         $builder->addIn('home',
             ['text' => 'Profile', 'url' => '/profile'],
             ['text' => 'About', 'url' => '/about']
         );
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertCount(2, $builder->menu[0]['submenu']);
@@ -287,12 +340,17 @@ class BuilderTest extends TestCase
 
     public function testRemoveOneItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
-        $builder->add(['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']);
+        $builder->add(
+            ['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']
+        );
 
         $builder->remove('home');
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Profile', $builder->menu[0]['text']);
@@ -301,26 +359,34 @@ class BuilderTest extends TestCase
 
     public function testRemoveOneNotFoundItem()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->remove('foo');
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Home', $builder->menu[0]['text']);
         $this->assertEquals('/', $builder->menu[0]['url']);
     }
 
-    public function testRemoveMultipleItem()
+    public function testRemoveMultipleItems()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
         $builder->add(['text' => 'About', 'url' => '/about', 'key' => 'about']);
-        $builder->add(['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']);
+        $builder->add(
+            ['text' => 'Profile', 'url' => '/profile', 'key' => 'profile']
+        );
 
         $builder->remove('home');
         $builder->remove('about');
+
+        // Make assertions.
 
         $this->assertCount(1, $builder->menu);
         $this->assertEquals('Profile', $builder->menu[0]['text']);
@@ -329,6 +395,8 @@ class BuilderTest extends TestCase
 
     public function testRemoveOneSubItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add([
@@ -343,14 +411,18 @@ class BuilderTest extends TestCase
 
         $builder->remove('about');
 
+        // Make assertions.
+
         $this->assertCount(1, $builder->menu);
         $this->assertCount(1, $builder->menu[0]['submenu']);
         $this->assertEquals('Profile', $builder->menu[0]['submenu'][0]['text']);
         $this->assertEquals('/profile', $builder->menu[0]['submenu'][0]['url']);
     }
 
-    public function testRemoveMultipleSubItem()
+    public function testRemoveMultipleSubItems()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add([
@@ -367,6 +439,8 @@ class BuilderTest extends TestCase
         $builder->remove('about');
         $builder->remove('demos');
 
+        // Make assertions.
+
         $this->assertCount(1, $builder->menu);
         $this->assertCount(1, $builder->menu[0]['submenu']);
         $this->assertEquals('Profile', $builder->menu[0]['submenu'][0]['text']);
@@ -375,15 +449,20 @@ class BuilderTest extends TestCase
 
     public function testItemKeyExists()
     {
-        $builder = $this->makeMenuBuilder();
+        // Build the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
+
+        // Make assertions.
 
         $this->assertTrue($builder->itemKeyExists('home'));
     }
 
-    public function testItemSubKeyExists()
+    public function testItemKeyExistsOnSubItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add([
@@ -396,14 +475,18 @@ class BuilderTest extends TestCase
             ],
         ]);
 
+        // Make assertions.
+
         $this->assertTrue($builder->itemKeyExists('home'));
         $this->assertTrue($builder->itemKeyExists('about'));
         $this->assertTrue($builder->itemKeyExists('profile'));
-        $this->assertFalse($builder->itemKeyExists('demos'));
+        $this->assertFalse($builder->itemKeyExists('foo'));
     }
 
-    public function testItemSubSubKeyExists()
+    public function testItemKeyExistsOnNestedSubItem()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add([
@@ -422,94 +505,11 @@ class BuilderTest extends TestCase
             ],
         ]);
 
+        // Make assertions.
+
         $this->assertTrue($builder->itemKeyExists('home'));
         $this->assertTrue($builder->itemKeyExists('about'));
         $this->assertTrue($builder->itemKeyExists('profile'));
-        $this->assertFalse($builder->itemKeyExists('demos'));
-    }
-
-    public function testHrefWillBeAdded()
-    {
-        $builder = $this->makeMenuBuilder();
-
-        $builder->add(['text' => 'Home', 'url' => '/']);
-        $builder->add(['text' => 'About', 'url' => '/about']);
-
-        $this->assertEquals('http://example.com', $builder->menu[0]['href']);
-        $this->assertEquals(
-            'http://example.com/about',
-            $builder->menu[1]['href']
-        );
-    }
-
-    public function testDefaultHref()
-    {
-        $builder = $this->makeMenuBuilder();
-
-        $builder->add(['text' => 'Home']);
-
-        $this->assertEquals('#', $builder->menu[0]['href']);
-    }
-
-    public function testSubmenuHref()
-    {
-        $builder = $this->makeMenuBuilder();
-
-        $builder->add(
-            [
-                'text' => 'Home',
-                'submenu' => [
-                    ['text' => 'About', 'url' => '/about'],
-                ],
-            ]
-        );
-
-        $this->assertEquals(
-            'http://example.com/about',
-            $builder->menu[0]['submenu'][0]['href']
-        );
-    }
-
-    public function testMultiLevelSubmenuHref()
-    {
-        $builder = $this->makeMenuBuilder();
-
-        $builder->add(
-            [
-                'text' => 'Home',
-                'submenu' => [
-                    [
-                        'text' => 'About',
-                        'url' => '/about',
-                        'submenu' => [
-                            ['text' => 'Test', 'url' => '/test'],
-                        ],
-                    ],
-                ],
-            ]
-        );
-
-        $this->assertEquals(
-            'http://example.com/test',
-            $builder->menu[0]['submenu'][0]['submenu'][0]['href']
-        );
-    }
-
-    public function testRouteHref()
-    {
-        $builder = $this->makeMenuBuilder();
-        $this->getRouteCollection()->add(new Route('GET', 'about', ['as' => 'pages.about']));
-        $this->getRouteCollection()->add(new Route('GET', 'profile', ['as' => 'pages.profile']));
-
-        $builder->add(['text' => 'About', 'route' => 'pages.about']);
-        $builder->add(
-            [
-                'text' => 'Profile',
-                'route' => ['pages.profile', ['user' => 'data']],
-            ]
-        );
-
-        $this->assertEquals('http://example.com/about', $builder->menu[0]['href']);
-        $this->assertEquals('http://example.com/profile?user=data', $builder->menu[1]['href']);
+        $this->assertFalse($builder->itemKeyExists('foo'));
     }
 }

--- a/tests/Menu/ClassesFilterTest.php
+++ b/tests/Menu/ClassesFilterTest.php
@@ -1,16 +1,25 @@
 <?php
 
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
 
 class ClassesFilterTest extends TestCase
 {
     public function testActiveClassIsAdded()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Emulate a request.
+
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
         $builder->add(
             ['text' => 'About', 'url' => 'about'],
             ['text' => 'Profile', 'url' => 'profile'],
         );
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);
@@ -19,14 +28,21 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedWhenUsingRoute()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Define a route name and emulate a request.
 
-        $this->getRouteCollection()->add(
+        RouteFacade::getRoutes()->add(
             new Route('GET', 'about', ['as' => 'pages.about'])
         );
 
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'About', 'route' => 'pages.about']);
         $builder->add(['text' => 'Profile', 'url' => 'profile']);
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertEquals('active', $menu[0]['class']);
@@ -35,19 +51,24 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedOnSubmenu()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Emulate a request.
+
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [
                 'text' => 'Menu',
                 'submenu' => [
-                    [
-                        'text' => 'About',
-                        'url' => 'about',
-                    ],
+                    ['text' => 'About', 'url' => 'about'],
                 ],
             ]
         );
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);
@@ -57,23 +78,28 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedOnSubmenuUsingRoute()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Define a route name and emulate a request.
 
-        $this->getRouteCollection()->add(
+        RouteFacade::getRoutes()->add(
             new Route('GET', 'about', ['as' => 'pages.about'])
         );
+
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [
                 'text' => 'Menu',
                 'submenu' => [
-                    [
-                        'text' => 'About',
-                        'route' => 'pages.about',
-                    ],
+                    ['text' => 'About', 'route' => 'pages.about'],
                 ],
             ]
         );
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);
@@ -83,7 +109,13 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedOnSubmenuUsingHashUrl()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/home');
+        // Emulate a request.
+
+        $this->get('http://example.com/home');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [
@@ -95,6 +127,8 @@ class ClassesFilterTest extends TestCase
             ]
         );
 
+        // Make assertions.
+
         $menu = $builder->menu;
         $this->assertTrue($menu[0]['active']);
         $this->assertStringContainsString('active', $menu[0]['class']);
@@ -104,8 +138,16 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedOnTopNavItem()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Emulate a request.
+
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'About', 'url' => 'about', 'topnav' => true]);
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);
@@ -113,36 +155,53 @@ class ClassesFilterTest extends TestCase
 
     public function testActiveClassIsAddedOnTopNavRightItem()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
-        $builder->add(['text' => 'About', 'url' => 'about', 'topnav_right' => true]);
+        // Emulate a request.
+
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+        $builder->add(
+            ['text' => 'About', 'url' => 'about', 'topnav_right' => true]
+        );
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);
     }
 
-    public function testSubmenuClassIsAddedWhenAddInMultipleItems()
+    public function testSubmenuIsActiveWhenAddInAnActiveItem()
     {
-        $builder = $this->makeMenuBuilder('http://example.com');
+        // Emulate a request.
 
-        // Add a new link item.
+        $this->get('http://example.com/about');
 
+        // Build the menu. Add a new link, and then add new elements inside
+        // this one, including one active item. An active submenu item should
+        // be created after this sequence.
+
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'Home', 'url' => '/', 'key' => 'home']);
-
-        // Add elements inside the previous one, now it will be a submenu item.
-
         $builder->addIn('home', ['text' => 'Profile', 'url' => '/profile']);
         $builder->addIn('home', ['text' => 'About', 'url' => '/about']);
 
-        // Check the "submenu_class" attribute is added.
+        // Make assertions.
 
         $menu = $builder->menu;
+        $this->assertStringContainsString('active', $menu[0]['class']);
         $this->assertStringContainsString('menu-open', $menu[0]['submenu_class']);
     }
 
     public function testAddingCustomClassesAttributes()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'About', 'classes' => 'foo bar']);
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('foo', $menu[0]['class']);
@@ -151,13 +210,19 @@ class ClassesFilterTest extends TestCase
 
     public function testAddingCustomClassesAttributesOnActiveItem()
     {
-        $builder = $this->makeMenuBuilder('http://example.com/about');
+        // Emulate a request.
 
-        $builder->add([
-            'text' => 'About',
-            'url' => 'about',
-            'classes' => 'foo bar',
-        ]);
+        $this->get('http://example.com/about');
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+
+        $builder->add(
+            ['text' => 'About', 'url' => 'about', 'classes' => 'foo bar']
+        );
+
+        // Make assertions.
 
         $menu = $builder->menu;
         $this->assertStringContainsString('active', $menu[0]['class']);

--- a/tests/Menu/DataFilterTest.php
+++ b/tests/Menu/DataFilterTest.php
@@ -4,6 +4,8 @@ class DataFilterTest extends TestCase
 {
     public function testDataAttributesAreCompiled()
     {
+        // Build the menu.
+
         $builder = $this->makeMenuBuilder();
 
         $builder->add([
@@ -13,6 +15,8 @@ class DataFilterTest extends TestCase
                 'param2' => 'value2',
             ],
         ]);
+
+        // Make assertions.
 
         $this->assertEquals(
             'data-param1="value1" data-param2="value2"',

--- a/tests/Menu/GateFilterTest.php
+++ b/tests/Menu/GateFilterTest.php
@@ -27,7 +27,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             ['text' => 'About', 'url' => 'about', 'can' => 'show-about'],
@@ -50,7 +50,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             ['text' => 'Home', 'url' => '/', 'can' => 'show-home']
@@ -74,7 +74,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             ['text' => 'LinkA', 'url' => 'link_a', 'can' => false],
@@ -110,7 +110,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [
@@ -144,7 +144,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             ['header' => 'HEADER', 'can' => 'show-header'],
@@ -170,7 +170,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [
@@ -210,7 +210,7 @@ class GateFilterTest extends TestCase
 
         // Create the menu.
 
-        $builder = $this->makeMenuBuilder('http://example.com');
+        $builder = $this->makeMenuBuilder();
 
         $builder->add(
             [

--- a/tests/Menu/HrefFilterTest.php
+++ b/tests/Menu/HrefFilterTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+class HrefFilterTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup Laravel base url.
+
+        url()->forceRootUrl('http://example.com');
+    }
+
+    public function testHrefWillBeAdded()
+    {
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+        $builder->add(['text' => 'Home', 'url' => '/']);
+        $builder->add(['text' => 'About', 'url' => '/about']);
+
+        // Make assertions.
+
+        $menu = $builder->menu;
+        $this->assertEquals('http://example.com', $menu[0]['href']);
+        $this->assertEquals('http://example.com/about', $menu[1]['href']);
+    }
+
+    public function testDefaultHrefWillBeAdded()
+    {
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+        $builder->add(['text' => 'Home']);
+
+        // Make assertions.
+
+        $this->assertEquals('#', $builder->menu[0]['href']);
+    }
+
+    public function testHrefOnSubmenu()
+    {
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+
+        $builder->add(
+            [
+                'text' => 'Home',
+                'submenu' => [
+                    ['text' => 'About', 'url' => '/about'],
+                ],
+            ]
+        );
+
+        // Make assertions.
+
+        $this->assertEquals(
+            'http://example.com/about',
+            $builder->menu[0]['submenu'][0]['href']
+        );
+    }
+
+    public function testHrefOnMultiLevelSubmenu()
+    {
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+
+        $builder->add(
+            [
+                'text' => 'Home',
+                'submenu' => [
+                    [
+                        'text' => 'About',
+                        'url' => '/about',
+                        'submenu' => [
+                            ['text' => 'Test', 'url' => '/test'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        // Make assertions.
+
+        $this->assertEquals(
+            'http://example.com/test',
+            $builder->menu[0]['submenu'][0]['submenu'][0]['href']
+        );
+    }
+
+    public function testHrefWhenUsingRoute()
+    {
+        // Define the route names.
+
+        RouteFacade::getRoutes()->add(
+            new Route('GET', 'about', ['as' => 'pages.about'])
+        );
+
+        RouteFacade::getRoutes()->add(
+            new Route('GET', 'profile', ['as' => 'pages.profile'])
+        );
+
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+        $builder->add(['text' => 'About', 'route' => 'pages.about']);
+
+        $builder->add([
+            'text' => 'Profile',
+            'route' => ['pages.profile', ['user' => 'data']],
+        ]);
+
+        // Make assertions.
+
+        $this->assertEquals(
+            'http://example.com/about',
+            $builder->menu[0]['href']
+        );
+        $this->assertEquals(
+            'http://example.com/profile?user=data',
+            $builder->menu[1]['href']
+        );
+    }
+
+    public function testHrefWhenUsingInvalidRoutesValues()
+    {
+        // Build the menu.
+
+        $builder = $this->makeMenuBuilder();
+        $builder->add(['text' => 'Invalid1', 'route' => null]);
+        $builder->add(['text' => 'Invalid2', 'route' => 1]);
+        $builder->add(['text' => 'Invalid3', 'route' => []]);
+
+        // Make assertions.
+
+        $this->assertEquals('#', $builder->menu[0]['href']);
+        $this->assertEquals('#', $builder->menu[1]['href']);
+        $this->assertEquals('#', $builder->menu[2]['href']);
+    }
+}

--- a/tests/Menu/SearchFilterTest.php
+++ b/tests/Menu/SearchFilterTest.php
@@ -4,11 +4,14 @@ class SearchFilterTest extends TestCase
 {
     public function testDefaultMethodOnSearchBar()
     {
-        $builder = $this->makeMenuBuilder();
+        // Make the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'search', 'search' => true]);
         $builder->add(['text' => 'Search', 'search' => true, 'method' => 'foo']);
         $builder->add(['text' => 'Search', 'search' => true, 'method' => 'post']);
+
+        // Make assertions.
 
         $this->assertEquals('get', $builder->menu[0]['method']);
         $this->assertEquals('get', $builder->menu[1]['method']);
@@ -17,10 +20,13 @@ class SearchFilterTest extends TestCase
 
     public function testDefaultNameOnSearchBar()
     {
-        $builder = $this->makeMenuBuilder();
+        // Make the menu.
 
+        $builder = $this->makeMenuBuilder();
         $builder->add(['text' => 'search', 'search' => true]);
         $builder->add(['text' => 'Search', 'search' => true, 'input_name' => 'foo']);
+
+        // Make assertions.
 
         $this->assertEquals('adminlteSearch', $builder->menu[0]['input_name']);
         $this->assertEquals('foo', $builder->menu[1]['input_name']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Routing\RouteCollection;
-use Illuminate\Routing\UrlGenerator;
 use JeroenNoten\LaravelAdminLte\AdminLte;
 use JeroenNoten\LaravelAdminLte\Menu\ActiveChecker;
 use JeroenNoten\LaravelAdminLte\Menu\Builder;
@@ -14,12 +11,9 @@ use JeroenNoten\LaravelAdminLte\Menu\Filters\HrefFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\LangFilter;
 use JeroenNoten\LaravelAdminLte\Menu\Filters\SearchFilter;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TestCase extends BaseTestCase
 {
-    private $routeCollection;
-
     /**
      * Load the package services providers.
      *
@@ -37,12 +31,12 @@ class TestCase extends BaseTestCase
      *
      * @return Builder
      */
-    protected function makeMenuBuilder($uri = 'http://example.com')
+    protected function makeMenuBuilder()
     {
         return new Builder([
             new GateFilter(),
-            new HrefFilter($this->makeUrlGenerator($uri)),
-            new ActiveFilter($this->makeActiveChecker($uri)),
+            new HrefFilter(),
+            new ActiveFilter($this->makeActiveChecker()),
             new ClassesFilter(),
             new DataFilter(),
             new LangFilter(),
@@ -50,41 +44,23 @@ class TestCase extends BaseTestCase
         ]);
     }
 
-    protected function makeActiveChecker($uri = 'http://example.com', $scheme = null)
+    /**
+     * Make an ActiveChecker instance.
+     *
+     * @return ActiveChecker
+     */
+    protected function makeActiveChecker()
     {
-        return new ActiveChecker($this->makeUrlGenerator($uri, $scheme));
+        return new ActiveChecker();
     }
 
-    private function makeRequest($uri)
-    {
-        return Request::createFromBase(SymfonyRequest::create($uri));
-    }
-
+    /**
+     * Make an AdminLte instance.
+     *
+     * @return AdminLte
+     */
     protected function makeAdminLte($filters = [])
     {
         return new AdminLte($filters);
-    }
-
-    protected function makeUrlGenerator($uri = 'http://example.com', $scheme = null)
-    {
-        $UrlGenerator = new UrlGenerator(
-            $this->getRouteCollection(),
-            $this->makeRequest($uri)
-        );
-
-        if ($scheme) {
-            $UrlGenerator->forceScheme($scheme);
-        }
-
-        return $UrlGenerator;
-    }
-
-    protected function getRouteCollection()
-    {
-        if (! $this->routeCollection) {
-            $this->routeCollection = new RouteCollection();
-        }
-
-        return $this->routeCollection;
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Improve the `ActiveChecker` class:
- Internal `UrlGenerator` instance was removed, instead `url()` helper from Laravel is used now.
- Internal `Request` instance was removed, instead `request()` helper from Laravel is used now.
- Improve the logic of the class.

Improve the `HrefFilter` class:
- Internal `UrlGenerator` instance was removed, instead `url()` helper from Laravel is used now.
- Improve the internal filter logic.

Tests were modified to adapt to the previous improvements:
- The `HrefFilter` tests were separated into a different test class.
- Since the `ActiveChecker` and `HrefFilter` constructor methods were changed, most of the test were adapted.

### Checklist

- [x] I tested these changes.