### PR TITLE
Fix inputColor wire live

### DIFF
--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -37,6 +37,10 @@
         $('#{{ $id }}').colorpicker( @json($config) )
             .on('change', setAddonColor);
 
+        $('#{{ $id }}').on('colorpickerChange', function(e) {
+            this.dispatchEvent(new Event('input'));
+        });
+
         // Add support to auto select the previous submitted value in case
         // of validation errors.
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ISSUE
| License                 | MIT

### What's in this PR?

This PR addresses (partially) the issue I described [here](https://github.com/jeroennoten/Laravel-AdminLTE/issues/1276).
Not sure this is the best approach to deal with it.
At very best its missing a wrap to check if livewire is active. Something in the lines of `@if(config('adminlte.livewire')) { ... }`

### Checklist

- [x] I tested these changes.
- [ ] I have linked the related issues.
