### PR TITLE
Improve profile items

### DIFF
--- a/resources/views/components/widget/profile-col-item.blade.php
+++ b/resources/views/components/widget/profile-col-item.blade.php
@@ -10,7 +10,7 @@
         {{-- Header --}}
         @isset($title)
             <h5 class="description-header">
-                @if(! empty($url))
+                @if(! empty($url) && $urlTarget === 'title')
                     <a href="{{ $url }}">{{ $title }}</a>
                 @else
                     {{ $title }}
@@ -22,7 +22,11 @@
         @isset($text)
             <p class="description-text">
                 <span class="{{ $makeTextWrapperClass() }}">
-                    {{ $text }}
+                    @if(! empty($url) && $urlTarget === 'text')
+                        <a href="{{ $url }}">{{ $text }}</a>
+                    @else
+                        {{ $text }}
+                    @endif
                 </span>
             </p>
         @endisset

--- a/resources/views/components/widget/profile-row-item.blade.php
+++ b/resources/views/components/widget/profile-row-item.blade.php
@@ -9,7 +9,7 @@
 
         {{-- Header --}}
         @isset($title)
-            @if(! empty($url))
+            @if(! empty($url) && $urlTarget === 'title')
                 <a href="{{ $url }}">{{ $title }}</a>
             @else
                 {{ $title }}
@@ -19,7 +19,11 @@
         {{-- Text --}}
         @isset($text)
             <span class="{{ $makeTextWrapperClass() }}">
-                {{ $text }}
+                @if(! empty($url) && $urlTarget === 'text')
+                    <a href="{{ $url }}">{{ $text }}</a>
+                @else
+                    {{ $text }}
+                @endif
             </span>
         @endisset
 

--- a/src/View/Components/Widget/ProfileColItem.php
+++ b/src/View/Components/Widget/ProfileColItem.php
@@ -39,7 +39,8 @@ class ProfileColItem extends Component
      * The badge theme for the text attribute. When used, the text attribute
      * will be wrapped inside a badge of the configured theme. Available themes
      * are: light, dark, primary, secondary, info, success, warning, danger or
-     * any other AdminLTE color like lighblue or teal.
+     * any other AdminLTE color like lighblue or teal. You can also prepend
+     * the 'pill-' token for a pill badge, for example: 'pill-info'.
      *
      * @var string
      */
@@ -54,13 +55,20 @@ class ProfileColItem extends Component
     public $url;
 
     /**
+     * The target element for the URL (title or text).
+     *
+     * @var string
+     */
+    public $urlTarget;
+
+    /**
      * Create a new component instance.
      *
      * @return void
      */
     public function __construct(
         $title = null, $text = null, $icon = null, $size = 4,
-        $badge = null, $url = null
+        $badge = null, $url = null, $urlTarget = 'title'
     ) {
         $this->title = UtilsHelper::applyHtmlEntityDecoder($title);
         $this->text = UtilsHelper::applyHtmlEntityDecoder($text);
@@ -68,6 +76,7 @@ class ProfileColItem extends Component
         $this->size = $size;
         $this->badge = $badge;
         $this->url = $url;
+        $this->urlTarget = $urlTarget;
     }
 
     /**
@@ -80,7 +89,12 @@ class ProfileColItem extends Component
         $classes = [];
 
         if (isset($this->badge)) {
-            $classes[] = "badge bg-{$this->badge}";
+            $badgeMode = str_starts_with($this->badge, 'pill-')
+                ? 'badge-pill'
+                : 'badge';
+
+            $badgeTheme = str_replace('pill-', '', $this->badge);
+            $classes[] = "{$badgeMode} bg-{$badgeTheme}";
         }
 
         return implode(' ', $classes);

--- a/src/View/Components/Widget/ProfileRowItem.php
+++ b/src/View/Components/Widget/ProfileRowItem.php
@@ -39,7 +39,8 @@ class ProfileRowItem extends Component
      * The badge theme for the text attribute. When used, the text attribute
      * will be wrapped inside a badge of the configured theme. Available themes
      * are: light, dark, primary, secondary, info, success, warning, danger or
-     * any other AdminLTE color like lighblue or teal.
+     * any other AdminLTE color like lighblue or teal. You can also prepend
+     * the 'pill-' token for a pill badge, for example: 'pill-info'.
      *
      * @var string
      */
@@ -54,13 +55,20 @@ class ProfileRowItem extends Component
     public $url;
 
     /**
+     * The target element for the URL (title or text).
+     *
+     * @var string
+     */
+    public $urlTarget;
+
+    /**
      * Create a new component instance.
      *
      * @return void
      */
     public function __construct(
         $title = null, $text = null, $icon = null, $size = 12,
-        $badge = null, $url = null
+        $badge = null, $url = null, $urlTarget = 'title'
     ) {
         $this->title = UtilsHelper::applyHtmlEntityDecoder($title);
         $this->text = UtilsHelper::applyHtmlEntityDecoder($text);
@@ -68,6 +76,7 @@ class ProfileRowItem extends Component
         $this->size = $size;
         $this->badge = $badge;
         $this->url = $url;
+        $this->urlTarget = $urlTarget;
     }
 
     /**
@@ -80,7 +89,12 @@ class ProfileRowItem extends Component
         $classes = ['float-right'];
 
         if (isset($this->badge)) {
-            $classes[] = "badge bg-{$this->badge}";
+            $badgeMode = str_starts_with($this->badge, 'pill-')
+                ? 'badge-pill'
+                : 'badge';
+
+            $badgeTheme = str_replace('pill-', '', $this->badge);
+            $classes[] = "{$badgeMode} bg-{$badgeTheme}";
         }
 
         return implode(' ', $classes);

--- a/tests/Components/WidgetComponentsTest.php
+++ b/tests/Components/WidgetComponentsTest.php
@@ -232,12 +232,24 @@ class WidgetComponentsTest extends TestCase
 
     public function testProfileColItemComponent()
     {
+        // Test with common badge.
+
         $component = new Components\Widget\ProfileColItem(
             'title', 'text', null, null, 'b-theme'
         );
 
         $twClass = $component->makeTextWrapperClass();
         $this->assertStringContainsString('badge', $twClass);
+        $this->assertStringContainsString('bg-b-theme', $twClass);
+
+        // Test with common pill badge.
+
+        $component = new Components\Widget\ProfileColItem(
+            'title', 'text', null, null, 'pill-b-theme'
+        );
+
+        $twClass = $component->makeTextWrapperClass();
+        $this->assertStringContainsString('badge-pill', $twClass);
         $this->assertStringContainsString('bg-b-theme', $twClass);
     }
 
@@ -249,12 +261,24 @@ class WidgetComponentsTest extends TestCase
 
     public function testProfileRowItemComponent()
     {
+        // Test with common badge.
+
         $component = new Components\Widget\ProfileRowItem(
             'title', 'text', null, null, 'b-theme'
         );
 
         $twClass = $component->makeTextWrapperClass();
         $this->assertStringContainsString('badge', $twClass);
+        $this->assertStringContainsString('bg-b-theme', $twClass);
+
+        // Test with common pill badge.
+
+        $component = new Components\Widget\ProfileRowItem(
+            'title', 'text', null, null, 'pill-b-theme'
+        );
+
+        $twClass = $component->makeTextWrapperClass();
+        $this->assertStringContainsString('badge-pill', $twClass);
         $this->assertStringContainsString('bg-b-theme', $twClass);
     }
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Improve the profile items used in the profile widget component:
- Now the items accepts an `url-target` property to set the target element of the configured url (`title` or `text`). This was already supported on other widgets like the `info-box`.
- Now you can prepend the badge theme with the `pill-` token (for example, `badge="pill-info"`) to get a **pill badge** instead of a normal badge on the text.

### Checklist

- [x] I tested these changes.