### PR TITLE
Improve the artisan commands

### DIFF
--- a/src/Console/AdminLteInstallCommand.php
+++ b/src/Console/AdminLteInstallCommand.php
@@ -18,18 +18,18 @@ class AdminLteInstallCommand extends Command
      * @var string
      */
     protected $signature = 'adminlte:install
-        {--type=basic : The installation type: basic (default), enhanced or full}
-        {--only=* : To install only specific resources: assets, config, translations, auth_views, basic_routes or main_views. Can\'t be used with option --with}
-        {--with=* : To install with additional resources: auth_views, basic_routes or main_views}
-        {--force : To force the overwrite of existing files}
-        {--interactive : The installation will guide you through the process}';
+        {--type=basic : The installation type: basic, basic_with_auth, basic_with_views or full}
+        {--only=* : To install only specific resources: assets, config, translations, auth_views, auth_routes or main_views. Can\'t be mixed with option --with}
+        {--with=* : To install with additional resources: auth_views, auth_routes or main_views}
+        {--force : To force the overwrite of existing files during the installation process}
+        {--interactive : To allow the installation process guide you through it}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Install all the required files for AdminLTE, and additional resources';
+    protected $description = 'Publishes the required files, and other resources, for use the AdminLTE template';
 
     /**
      * Array with all the available package resources.
@@ -75,7 +75,7 @@ class AdminLteInstallCommand extends Command
     {
         parent::__construct();
 
-        // Fill the array with the package resources.
+        // Fill the array with the available package resources.
 
         $this->pkgResources = [
             'assets' => new AdminlteAssetsResource(),
@@ -83,18 +83,20 @@ class AdminLteInstallCommand extends Command
             'translations' => new TranslationsResource(),
             'main_views' => new LayoutViewsResource(),
             'auth_views' => new AuthViewsResource(),
-            'basic_routes' => new AuthRoutesResource(),
+            'auth_routes' => new AuthRoutesResource(),
         ];
 
         // Add the resources related to each available --type option.
 
         $basic = ['assets', 'config', 'translations'];
-        $enhanced = array_merge($basic, ['auth_views']);
-        $full = array_merge($enhanced, ['basic_routes']);
+        $basicWithAuth = array_merge($basic, ['auth_views', 'auth_routes']);
+        $basicWithViews = array_merge($basic, ['main_views']);
+        $full = array_merge($basicWithAuth, ['main_views']);
 
         $this->optTypeResources = [
             'basic' => $basic,
-            'enhanced' => $enhanced,
+            'basic_with_auth' => $basicWithAuth,
+            'basic_with_views' => $basicWithViews,
             'full' => $full,
         ];
 
@@ -106,7 +108,7 @@ class AdminLteInstallCommand extends Command
             'translations' => ['translations'],
             'main_views' => ['main_views'],
             'auth_views' => ['auth_views'],
-            'basic_routes' => ['basic_routes'],
+            'auth_routes' => ['auth_routes'],
         ];
 
         // Add the resources related to each available --with option.
@@ -114,7 +116,7 @@ class AdminLteInstallCommand extends Command
         $this->optWithResources = [
             'main_views' => ['main_views'],
             'auth_views' => ['auth_views'],
-            'basic_routes' => ['basic_routes'],
+            'auth_routes' => ['auth_routes'],
         ];
     }
 
@@ -129,8 +131,8 @@ class AdminLteInstallCommand extends Command
 
         $this->installedResources = [];
 
-        // Check if option --only is used. In this case, install the specified
-        // parts and return.
+        // Check if option --only is used. In this case, install only the
+        // specified resources and finish.
 
         if ($optValues = $this->option('only')) {
             $this->handleOptions($optValues, $this->optOnlyResources, 'only');
@@ -144,8 +146,8 @@ class AdminLteInstallCommand extends Command
         $optValue = $this->option('type');
         $this->handleOption($optValue, $this->optTypeResources, 'type');
 
-        // Check if option --with is used. In this case, also install the
-        // specified parts.
+        // Check if option --with is used. In this case, we also need to install
+        // the specified additional resources.
 
         if ($optValues = $this->option('with')) {
             $this->handleOptions($optValues, $this->optWithResources, 'with');
@@ -155,7 +157,7 @@ class AdminLteInstallCommand extends Command
     }
 
     /**
-     * Handle multiple option values.
+     * Handles multiple option values.
      *
      * @param  array  $values  An array with the option values
      * @param  array  $resources  An array with the resources of each option
@@ -170,7 +172,7 @@ class AdminLteInstallCommand extends Command
     }
 
     /**
-     * Handle an option value.
+     * Handles an option value.
      *
      * @param  string  $value  A string with the option value
      * @param  array  $resources  An array with the resources of each option
@@ -191,7 +193,7 @@ class AdminLteInstallCommand extends Command
     }
 
     /**
-     * Install multiple packages resources.
+     * Installs multiple packages resources.
      *
      * @param  string  $resources  The resources to install
      * @return void
@@ -199,8 +201,8 @@ class AdminLteInstallCommand extends Command
     protected function exportPackageResources(...$resources)
     {
         foreach ($resources as $resource) {
-            // Check if resource was already installed on the current command
-            // execution. This can happen, for example, when using:
+            // Check if the resource was already installed on the current
+            // command execution. This can happen, for example, when using:
             // php artisan --type=full --with=auth_views
 
             if (isset($this->installedResources[$resource])) {
@@ -213,7 +215,7 @@ class AdminLteInstallCommand extends Command
     }
 
     /**
-     * Install a package resource.
+     * Installs a package resource.
      *
      * @param  string  $resource  The keyword of the resource to install
      * @return void
@@ -233,9 +235,9 @@ class AdminLteInstallCommand extends Command
 
         // Check for overwrite warning.
 
-        $isOverwrite = ! $this->option('force') && $resource->exists();
+        $shouldWarnOverwrite = ! $this->option('force') && $resource->exists();
 
-        if ($isOverwrite && ! $this->confirm($overwriteMsg)) {
+        if ($shouldWarnOverwrite && ! $this->confirm($overwriteMsg)) {
             return;
         }
 

--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -158,8 +158,8 @@ class AdminLteStatusCommand extends Command
 
         foreach ($this->pkgResources as $name => $resource) {
             $requiredLabel = $resource->required
-                ? 'yes'
-                : $this->styleOutput('no', '#606060');
+                ? $this->styleOutput('yes', 'green')
+                : 'no';
 
             $tblContent[] = [
                 $name,

--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -24,7 +24,7 @@ class AdminLteStatusCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Checks the installation status of the AdminLTE resources';
+    protected $description = 'Checks the installation status of the package resources';
 
     /**
      * Array with all the available package resources.
@@ -41,17 +41,17 @@ class AdminLteStatusCommand extends Command
     protected $status = [
         'installed' => [
             'label' => 'Installed',
-            'legend' => 'The resource is installed and matches with the default package resource',
+            'legend' => 'The resource is published and matches with the package original resource',
             'color' => 'green',
         ],
         'mismatch' => [
             'label' => 'Mismatch',
-            'legend' => 'The installed resource mismatch the package resource (update available or resource modified)',
+            'legend' => 'The resource is published but mismatches with the package original resource (update available or resource modified)',
             'color' => 'yellow',
         ],
         'uninstalled' => [
             'label' => 'Not Installed',
-            'legend' => 'The package resource is not installed',
+            'legend' => 'The resource is not published',
             'color' => 'red',
         ],
     ];
@@ -73,7 +73,7 @@ class AdminLteStatusCommand extends Command
             'translations' => new TranslationsResource(),
             'main_views' => new LayoutViewsResource(),
             'auth_views' => new AuthViewsResource(),
-            'basic_routes' => new AuthRoutesResource(),
+            'auth_routes' => new AuthRoutesResource(),
         ];
     }
 
@@ -84,94 +84,102 @@ class AdminLteStatusCommand extends Command
      */
     public function handle()
     {
+        // Get the installation status of each resource.
+
+        $this->line('Verifying the installation of the resources...');
+        $resStatus = $this->getResourcesStatus();
+        $this->line('');
+        $this->line('All resources verified successfully!');
+
         // Display the resources installation status.
 
-        $this->showResourcesStatus();
+        $this->line('');
+        $this->line('Resources Status:');
+        $this->showResourcesStatus($resStatus);
 
-        // Display the legends table.
+        // Display the status legends table.
 
         $this->line('');
+        $this->line('Status Legends:');
         $this->showStatusLegends();
     }
 
     /**
-     * Display the resources status.
+     * Gets the resources installation status array.
      *
+     * @return array
+     */
+    protected function getResourcesStatus()
+    {
+        // Define the array that will hold the resources status.
+
+        $resStatus = [];
+
+        // Create and initialize a progress bar.
+
+        $bar = $this->output->createProgressBar(count($this->pkgResources));
+        $bar->start();
+
+        // Get the installation status of each resource.
+
+        foreach ($this->pkgResources as $name => $resource) {
+            $resStatus[$name] = $this->getResourceStatus($resource);
+            $bar->advance();
+        }
+
+        $bar->finish();
+
+        // Return the resources status.
+
+        return $resStatus;
+    }
+
+    /**
+     * Displays the status of the resources.
+     *
+     * @param  array  $resStatus  Array with the status of each resource
      * @return void
      */
-    protected function showResourcesStatus()
+    protected function showResourcesStatus($resStatus)
     {
         // Define the table headers.
 
         $tblHeader = [
             $this->styleOutput('Package Resource', 'cyan'),
             $this->styleOutput('Description', 'cyan'),
-            $this->styleOutput('Status', 'cyan'),
+            $this->styleOutput('Publishing Target', 'cyan'),
             $this->styleOutput('Required', 'cyan'),
+            $this->styleOutput('Status', 'cyan'),
         ];
 
-        // Get the table rows.
-
-        $tblContent = $this->getResourcesStatusRows();
-
-        // Display the table.
-
-        $this->line('');
-        $this->table($tblHeader, $tblContent);
-    }
-
-    /**
-     * Get the rows for the resources status table.
-     *
-     * @return array
-     */
-    protected function getResourcesStatusRows()
-    {
-        // Define the array that will hold the table rows.
+        // Create the table rows.
 
         $tblContent = [];
 
-        // Create a progress bar.
-
-        $steps = count($this->pkgResources);
-        $bar = $this->output->createProgressBar($steps);
-
-        // Initialize the status check procedure.
-
-        $this->line('Checking the resources installation ...');
-        $bar->start();
-
         foreach ($this->pkgResources as $name => $resource) {
-            // Fill the status row of the current resource.
+            $requiredLabel = $resource->required
+                ? 'yes'
+                : $this->styleOutput('no', 'gray');
 
             $tblContent[] = [
                 $name,
                 $resource->description,
-                $this->getResourceStatus($resource),
-                var_export($resource->required, true),
+                str_replace(base_path('/'), '', $resource->target),
+                $requiredLabel,
+                $resStatus[$name] ?? 'Unknown',
             ];
-
-            // Advance the progress bar one step.
-
-            $bar->advance();
         }
 
-        // Finish the progress bar.
+        // Display the table.
 
-        $bar->finish();
-        $this->line('');
-        $this->line('All resources checked succesfully!');
-
-        // Return the rows.
-
-        return $tblContent;
+        $this->table($tblHeader, $tblContent);
     }
 
     /**
-     * Get the installation status of a package resource.
+     * Gets the installation status of the specified package resource.
      *
      * @param  PackageResource  $resource  The package resource to check
-     * @return string The resource status
+     * @return string
      */
     protected function getResourceStatus($resource)
     {
@@ -187,14 +195,12 @@ class AdminLteStatusCommand extends Command
     }
 
     /**
-     * Display the legends of the possible status values.
+     * Displays the legends for the possible status values.
      *
      * @return void
      */
     protected function showStatusLegends()
     {
-        $this->line('Status legends:');
-
         // Create the table headers for the legends.
 
         $tblHeader = [
@@ -219,11 +225,11 @@ class AdminLteStatusCommand extends Command
     }
 
     /**
-     * Give output style to some text.
+     * Gives output style to the provided text.
      *
      * @param  string  $text  The text to be styled
      * @param  string  $color  The output color for the text
-     * @return string The styled text
+     * @return string
      */
     protected function styleOutput($text, $color)
     {

--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -155,11 +155,12 @@ class AdminLteStatusCommand extends Command
         // Create the table rows.
 
         $tblContent = [];
+        $notRequiredColor = intval(app()->version()) >= 8 ? 'gray' : 'default';
 
         foreach ($this->pkgResources as $name => $resource) {
             $requiredLabel = $resource->required
                 ? 'yes'
-                : $this->styleOutput('no', 'gray');
+                : $this->styleOutput('no', $notRequiredColor);
 
             $tblContent[] = [
                 $name,

--- a/src/Console/AdminLteStatusCommand.php
+++ b/src/Console/AdminLteStatusCommand.php
@@ -155,12 +155,11 @@ class AdminLteStatusCommand extends Command
         // Create the table rows.
 
         $tblContent = [];
-        $notRequiredColor = intval(app()->version()) >= 8 ? 'gray' : 'default';
 
         foreach ($this->pkgResources as $name => $resource) {
             $requiredLabel = $resource->required
                 ? 'yes'
-                : $this->styleOutput('no', $notRequiredColor);
+                : $this->styleOutput('no', '#606060');
 
             $tblContent[] = [
                 $name,

--- a/src/Console/AdminLteUpdateCommand.php
+++ b/src/Console/AdminLteUpdateCommand.php
@@ -19,7 +19,7 @@ class AdminLteUpdateCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Update all the required assets for AdminLTE';
+    protected $description = 'Updates the AdminLTE distribution files and its dependencies';
 
     /**
      * A warning notification to be used when main views were previously

--- a/tests/Console/CommandTestCase.php
+++ b/tests/Console/CommandTestCase.php
@@ -34,7 +34,7 @@ class CommandTestCase extends TestCase
             'translations' => new TranslationsResource(),
             'main_views' => new LayoutViewsResource(),
             'auth_views' => new AuthViewsResource(),
-            'basic_routes' => new AuthRoutesResource(),
+            'auth_routes' => new AuthRoutesResource(),
         ];
     }
 
@@ -83,7 +83,7 @@ class CommandTestCase extends TestCase
             $target = $target.DIRECTORY_SEPARATOR.'login.blade.php';
             $loginContent = '@extends(\'adminlte::auth.login\')';
             $this->createDummyFile($target, $loginContent);
-        } elseif ($name === 'basic_routes') {
+        } elseif ($name === 'auth_routes') {
             $stubFile = CommandHelper::getStubPath('routes.stub');
             $content = File::get($stubFile);
             $this->createDummyFile($target, $content);

--- a/tests/Console/InstallTest.php
+++ b/tests/Console/InstallTest.php
@@ -134,7 +134,7 @@ class InstallTest extends CommandTestCase
             $this->artisan("adminlte:install --only={$name}")
                  ->expectsConfirmation($confirmMsg, 'no');
 
-            if ($name === 'basic_routes') {
+            if ($name === 'auth_routes') {
                 $this->assertTrue($res->installed());
             } else {
                 $this->assertFalse($res->installed());
@@ -232,13 +232,14 @@ class InstallTest extends CommandTestCase
         }
     }
 
-    public function testInstallWithTypeEnhanced()
+    public function testInstallWithTypeBasicWithAuth()
     {
         $resources = [
             $this->getResources('assets'),
             $this->getResources('config'),
             $this->getResources('translations'),
             $this->getResources('auth_views'),
+            $this->getResources('auth_routes'),
         ];
 
         // Ensure the required vendor assets exists.
@@ -253,7 +254,43 @@ class InstallTest extends CommandTestCase
 
         // Install resources using the artisan command.
 
-        $this->artisan('adminlte:install --type=enhanced');
+        $this->artisan('adminlte:install --type=basic_with_auth');
+
+        // Assert that the resources are installed.
+
+        foreach ($resources as $res) {
+            $this->assertTrue($res->installed());
+        }
+
+        // Clear installed resources.
+
+        foreach ($resources as $res) {
+            $res->uninstall();
+        }
+    }
+
+    public function testInstallWithTypeBasicWithViews()
+    {
+        $resources = [
+            $this->getResources('assets'),
+            $this->getResources('config'),
+            $this->getResources('translations'),
+            $this->getResources('main_views'),
+        ];
+
+        // Ensure the required vendor assets exists.
+
+        $this->installVendorAssets();
+
+        // Ensure the target resources do not exists.
+
+        foreach ($resources as $res) {
+            $res->uninstall();
+        }
+
+        // Install resources using the artisan command.
+
+        $this->artisan('adminlte:install --type=basic_with_views');
 
         // Assert that the resources are installed.
 
@@ -275,7 +312,8 @@ class InstallTest extends CommandTestCase
             $this->getResources('config'),
             $this->getResources('translations'),
             $this->getResources('auth_views'),
-            $this->getResources('basic_routes'),
+            $this->getResources('auth_routes'),
+            $this->getResources('main_views'),
         ];
 
         // Ensure the required vendor assets exists.
@@ -319,7 +357,7 @@ class InstallTest extends CommandTestCase
             $this->getResources('translations'),
         ];
 
-        $newRes = ['main_views', 'auth_views', 'basic_routes'];
+        $newRes = ['main_views', 'auth_views', 'auth_routes'];
 
         // Ensure the required vendor assets exists.
 
@@ -363,8 +401,9 @@ class InstallTest extends CommandTestCase
             $this->getResources('assets'),
             $this->getResources('config'),
             $this->getResources('translations'),
-            $this->getResources('basic_routes'),
+            $this->getResources('auth_routes'),
             $this->getResources('auth_views'),
+            $this->getResources('main_views'),
         ];
 
         // Ensure the required vendor assets exists.
@@ -385,7 +424,7 @@ class InstallTest extends CommandTestCase
 
         // Install resources using the artisan command.
 
-        $this->artisan('adminlte:install --type=enhanced --with=basic_routes --with=auth_views');
+        $this->artisan('adminlte:install --type=basic_with_auth --with=auth_routes --with=main_views');
 
         // Assert that the resources are installed.
 

--- a/tests/Console/PluginsTest.php
+++ b/tests/Console/PluginsTest.php
@@ -217,8 +217,8 @@ class PluginsTest extends CommandTestCase
         // Run the check of the plugin status.
 
         $this->artisan('adminlte:plugins')
-             ->expectsOutput('Checking the plugins installation ...')
-             ->expectsOutput('All plugins checked succesfully!')
+             ->expectsOutput('Verifying the installation of the plugins...')
+             ->expectsOutput('All plugins verified successfully!')
              ->assertExitCode(0);
 
         // Clear installed resources.
@@ -242,9 +242,9 @@ class PluginsTest extends CommandTestCase
         // Run the check of the plugin status.
 
         $this->artisan('adminlte:plugins --plugin=icheckBootstrap --plugin=dummy')
-             ->expectsOutput('Checking the plugins installation ...')
+             ->expectsOutput('Verifying the installation of the plugins...')
              ->expectsOutput('The plugin key: dummy is not valid!')
-             ->expectsOutput('All plugins checked succesfully!')
+             ->expectsOutput('All plugins verified successfully!')
              ->assertExitCode(0);
 
         // Clear installed resources.

--- a/tests/Console/StatusTest.php
+++ b/tests/Console/StatusTest.php
@@ -23,8 +23,8 @@ class StatusTest extends CommandTestCase
         // Run the check of the resources status.
 
         $this->artisan('adminlte:status')
-             ->expectsOutput('Checking the resources installation ...')
-             ->expectsOutput('All resources checked succesfully!')
+             ->expectsOutput('Verifying the installation of the resources...')
+             ->expectsOutput('All resources verified successfully!')
              ->assertExitCode(0);
 
         // Clear installed resources.


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Improve the artisan commands available on this package:

#### AdminLteInstallCommand
- `basic_routes` resources renamed to `auth_routes`.
- Installation of type `enhanced` was removed, and replaced by `basic_with_auth` (basic installation + resources related to **Laravel/UI**) and `basic_with_views` (basic installation + layouts views).
- The installation of type `full` now publish all the package resources.

#### AdminLteStatusCommand
- Logic of the command was improved.
- The resources status table now shows a new column named `Publishing Target` with the installation target folder or file for each resource.
- The style of the `Required` column was improved.

#### AdminLtePluginsCommand
- Logic of the command was improved.

### Checklist

- [x] I tested these changes.