### PR TITLE
Add new adminlte:remove command

### DIFF
--- a/src/AdminLteServiceProvider.php
+++ b/src/AdminLteServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use JeroenNoten\LaravelAdminLte\Console\AdminLteInstallCommand;
 use JeroenNoten\LaravelAdminLte\Console\AdminLtePluginCommand;
+use JeroenNoten\LaravelAdminLte\Console\AdminLteRemoveCommand;
 use JeroenNoten\LaravelAdminLte\Console\AdminLteStatusCommand;
 use JeroenNoten\LaravelAdminLte\Console\AdminLteUpdateCommand;
 use JeroenNoten\LaravelAdminLte\View\Components\Form;
@@ -157,9 +158,10 @@ class AdminLteServiceProvider extends BaseServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 AdminLteInstallCommand::class,
+                AdminLtePluginCommand::class,
+                AdminLteRemoveCommand::class,
                 AdminLteStatusCommand::class,
                 AdminLteUpdateCommand::class,
-                AdminLtePluginCommand::class,
             ]);
         }
     }

--- a/src/Console/AdminLteRemoveCommand.php
+++ b/src/Console/AdminLteRemoveCommand.php
@@ -69,7 +69,6 @@ class AdminLteRemoveCommand extends Command
         // Read and verify the resources to be uninstalled.
 
         foreach ($this->argument('resource') as $res) {
-
             // Check if resource is valid.
 
             if (! isset($this->pkgResources[$res])) {
@@ -116,6 +115,6 @@ class AdminLteRemoveCommand extends Command
         // Uninstall the resource.
 
         $resource->uninstall();
-        $this->info('The resource was successfully removed.');
+        $this->info('The resource was successfully removed');
     }
 }

--- a/src/Console/AdminLteRemoveCommand.php
+++ b/src/Console/AdminLteRemoveCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace JeroenNoten\LaravelAdminLte\Console;
+
+use Illuminate\Console\Command;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\AdminlteAssetsResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\AuthRoutesResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\AuthViewsResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\BladeComponentsResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\ConfigResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\LayoutViewsResource;
+use JeroenNoten\LaravelAdminLte\Console\PackageResources\TranslationsResource;
+
+class AdminLteRemoveCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'adminlte:remove
+        {resource* : The resource to uninstall: assets, config, translations, auth_views, auth_routes, main_views or components}
+        {--force : To force the uninstall procedure without warnings alerts}
+        {--interactive : To allow the uninstall process guide you through it}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Uninstalls one or more specified resources';
+
+    /**
+     * Array with all the available package resources.
+     *
+     * @var array
+     */
+    protected $pkgResources;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Fill the array with the available package resources.
+
+        $this->pkgResources = [
+            'assets' => new AdminlteAssetsResource(),
+            'config' => new ConfigResource(),
+            'translations' => new TranslationsResource(),
+            'main_views' => new LayoutViewsResource(),
+            'auth_views' => new AuthViewsResource(),
+            'auth_routes' => new AuthRoutesResource(),
+            'components' => new BladeComponentsResource(),
+        ];
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Read and verify the resources to be uninstalled.
+
+        foreach ($this->argument('resource') as $res) {
+
+            // Check if resource is valid.
+
+            if (! isset($this->pkgResources[$res])) {
+                $this->comment("The provided resource: {$res} is invalid!");
+
+                continue;
+            }
+
+            // Uninstall the resource.
+
+            $this->uninstallPackageResource($res);
+        }
+    }
+
+    /**
+     * Uninstalls a package resource.
+     *
+     * @param  string  $resource  The keyword of the resource to uninstall
+     * @return void
+     */
+    protected function uninstallPackageResource($resource)
+    {
+        $removeMsg = 'Do you really want to uninstall the resource: :res?';
+        $removeMsg = str_replace(':res', $resource, $removeMsg);
+        $resource = $this->pkgResources[$resource];
+
+        // Check if the --interactive option is enabled.
+
+        if ($this->option('interactive') && ! $this->confirm($removeMsg)) {
+            return;
+        }
+
+        // Check whether to warn for uninstalling a required resource.
+
+        $requiredWarnMsg = 'This resource is required by the package, ';
+        $requiredWarnMsg .= 'do you really want to uninstall it?';
+
+        $shouldWarn = ! $this->option('force') && $resource->required;
+
+        if ($shouldWarn && ! $this->confirm($requiredWarnMsg)) {
+            return;
+        }
+
+        // Uninstall the resource.
+
+        $resource->uninstall();
+        $this->info('The resource was successfully removed.');
+    }
+}

--- a/tests/Console/RemoveTest.php
+++ b/tests/Console/RemoveTest.php
@@ -1,0 +1,146 @@
+<?php
+
+class RemoveTest extends CommandTestCase
+{
+    public function testRemoveWithInvalidResource()
+    {
+        $this->artisan('adminlte:remove dummy')
+             ->expectsOutput('The provided resource: dummy is invalid!')
+             ->assertExitCode(0);
+    }
+
+    public function testRemoveOnAllResources()
+    {
+        // We can't perfom these tests on old Laravel versions. We need support
+        // for the expect confirmation method.
+
+        if (! $this->canExpectsConfirmation()) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        // Test remove command over the available resources.
+
+        foreach ($this->getResources() as $name => $res) {
+            // Ensure the required vendor assets exists, if needed.
+
+            if ($name === 'assets') {
+                $this->installVendorAssets();
+            }
+
+            // Ensure the target resource is installed.
+
+            $res->install();
+
+            // Remove resource using the artisan command.
+
+            if ($res->required) {
+                $msg = 'This resource is required by the package, ';
+                $msg .= 'do you really want to uninstall it?';
+
+                $this->artisan("adminlte:remove {$name}")
+                    ->expectsConfirmation($msg, 'yes');
+            } else {
+                $this->artisan("adminlte:remove {$name}");
+            }
+
+            $this->assertFalse($res->installed());
+        }
+    }
+
+    public function testNotConfirmRemoveOnRequiredResources()
+    {
+        // We can't perfom these tests on old Laravel versions. We need support
+        // for the expect confirmation method.
+
+        if (! $this->canExpectsConfirmation()) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        // Get set of required resources.
+
+        $resources = array_filter(
+            $this->getResources(),
+            fn ($r) => $r->required
+        );
+
+        // Test remove command over the required resources, without
+        // confirming the action.
+
+        foreach ($resources as $name => $res) {
+            // Ensure the required vendor assets exists, if needed.
+
+            if ($name === 'assets') {
+                $this->installVendorAssets();
+            }
+
+            // Ensure the target resource is installed.
+
+            $res->install();
+
+            // Remove resource using the artisan command, but don't confirm the
+            // action.
+
+            $msg = 'This resource is required by the package, ';
+            $msg .= 'do you really want to uninstall it?';
+
+            $this->artisan("adminlte:remove {$name}")
+                ->expectsConfirmation($msg, 'no');
+
+            // Assert the resource is still installed.
+
+            $this->assertTrue($res->installed());
+
+            // Clear the installed resource.
+
+            $res->uninstall();
+            $this->assertFalse($res->installed());
+        }
+    }
+
+    public function testNotConfirmRemoveWithInteractiveFlag()
+    {
+        // We can't perfom these tests on old Laravel versions. We need support
+        // for the expect confirmation method.
+
+        if (! $this->canExpectsConfirmation()) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        // Test remove command over the resources when using --interactive.
+
+        foreach ($this->getResources() as $name => $res) {
+            $confirmMsg = 'Do you really want to uninstall the resource: :res?';
+            $confirmMsg = str_replace(':res', $name, $confirmMsg);
+
+            // Ensure the required vendor assets exists, if needed.
+
+            if ($name === 'assets') {
+                $this->installVendorAssets();
+            }
+
+            // Ensure the target resource is installed.
+
+            $res->install();
+
+            // Test with --interactive option and respond with NO.
+
+            $this->artisan("adminlte:remove {$name} --interactive")
+                 ->expectsConfirmation($confirmMsg, 'no');
+
+            // Assert the resource is still installed.
+
+            $this->assertTrue($res->installed());
+
+            // Clear the installed resource.
+
+            $res->uninstall();
+            $this->assertFalse($res->installed());
+        }
+    }
+}

--- a/tests/Console/RemoveTest.php
+++ b/tests/Console/RemoveTest.php
@@ -64,7 +64,7 @@ class RemoveTest extends CommandTestCase
 
         $resources = array_filter(
             $this->getResources(),
-            fn ($r) => $r->required
+            function ($r) { return $r->required; }
         );
 
         // Test remove command over the required resources, without

--- a/tests/Console/RemoveTest.php
+++ b/tests/Console/RemoveTest.php
@@ -64,7 +64,9 @@ class RemoveTest extends CommandTestCase
 
         $resources = array_filter(
             $this->getResources(),
-            function ($r) { return $r->required; }
+            function ($r) {
+                return $r->required;
+            }
         );
 
         // Test remove command over the required resources, without


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Add a new `adminlte:remove` command to allow uninstalling already published package resources.

```sh
> php artisan adminlte:remove --help

Description:
  Uninstalls one or more specified resources

Usage:
  adminlte:remove [options] [--] <resource>...

Arguments:
  resource              The resource to uninstall: assets, config, translations, auth_views, auth_routes, main_views or components

Options:
      --force           To force the uninstall procedure without warnings alerts
      --interactive     To allow the uninstall process guide you through it
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --env[=ENV]       The environment the command should run under
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

```

### Checklist

- [x] I tested these changes.
- [x] Add documentation on Wiki
