### PR TITLE
Auto show right sidebar when section is present

### DIFF
--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -45,7 +45,7 @@
         @endif
 
         {{-- Right Control Sidebar --}}
-        @if(config('adminlte.right_sidebar'))
+        @if($layoutHelper->isRightSidebarEnabled())
             @include('adminlte::partials.sidebar.right-sidebar')
         @endif
 

--- a/resources/views/partials/navbar/navbar-layout-topnav.blade.php
+++ b/resources/views/partials/navbar/navbar-layout-topnav.blade.php
@@ -1,3 +1,5 @@
+@inject('layoutHelper', 'JeroenNoten\LaravelAdminLte\Helpers\LayoutHelper')
+
 <nav class="main-header navbar
     {{ config('adminlte.classes_topnav_nav', 'navbar-expand-md') }}
     {{ config('adminlte.classes_topnav', 'navbar-white navbar-light') }}">
@@ -47,7 +49,7 @@
             @endif
 
             {{-- Right sidebar toggler link --}}
-            @if(config('adminlte.right_sidebar'))
+            @if($layoutHelper->isRightSidebarEnabled())
                 @include('adminlte::partials.navbar.menu-item-right-sidebar-toggler')
             @endif
         </ul>

--- a/resources/views/partials/navbar/navbar.blade.php
+++ b/resources/views/partials/navbar/navbar.blade.php
@@ -1,3 +1,5 @@
+@inject('layoutHelper', 'JeroenNoten\LaravelAdminLte\Helpers\LayoutHelper')
+
 <nav class="main-header navbar
     {{ config('adminlte.classes_topnav_nav', 'navbar-expand') }}
     {{ config('adminlte.classes_topnav', 'navbar-white navbar-light') }}">
@@ -32,7 +34,7 @@
         @endif
 
         {{-- Right sidebar toggler link --}}
-        @if(config('adminlte.right_sidebar'))
+        @if($layoutHelper->isRightSidebarEnabled())
             @include('adminlte::partials.navbar.menu-item-right-sidebar-toggler')
         @endif
     </ul>

--- a/resources/views/partials/sidebar/right-sidebar.blade.php
+++ b/resources/views/partials/sidebar/right-sidebar.blade.php
@@ -1,3 +1,3 @@
 <aside class="control-sidebar control-sidebar-{{ config('adminlte.right_sidebar_theme') }}">
-    @yield('right-sidebar')
+    @yield('right_sidebar')
 </aside>

--- a/src/Helpers/LayoutHelper.php
+++ b/src/Helpers/LayoutHelper.php
@@ -46,6 +46,17 @@ class LayoutHelper
     }
 
     /**
+     * Checks if right sidebar is enabled.
+     *
+     * @return bool
+     */
+    public static function isRightSidebarEnabled()
+    {
+        return config('adminlte.right_sidebar', false)
+            || ! empty(View::getSection('right_sidebar'));
+    }
+
+    /**
      * Makes and return the set of classes related to the body tag.
      *
      * @return string

--- a/tests/Helpers/LayoutHelperTest.php
+++ b/tests/Helpers/LayoutHelperTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\View;
 use JeroenNoten\LaravelAdminLte\Helpers\LayoutHelper;
 
 class LayoutHelperTest extends TestCase
@@ -380,5 +381,28 @@ class LayoutHelperTest extends TestCase
         config(['adminlte.layout_dark_mode' => true]);
         $data = LayoutHelper::makeBodyClasses();
         $this->assertStringContainsString('dark-mode', $data);
+    }
+
+    public function testRightSidebarEnabledMethod()
+    {
+        // Test config 'right_sidebar' => true.
+
+        config(['adminlte.right_sidebar' => true]);
+        $this->assertTrue(LayoutHelper::isRightSidebarEnabled());
+
+        // Test config 'right_sidebar' => false.
+
+        config(['adminlte.right_sidebar' => false]);
+        $this->assertFalse(LayoutHelper::isRightSidebarEnabled());
+
+        // Test when section "right_sidebar" is defined.
+
+        View::inject('right_sidebar', 'dummy-content');
+        $this->assertTrue(LayoutHelper::isRightSidebarEnabled());
+
+        // Test when section "right_sidebar" is not defined.
+
+        View::flushSections();
+        $this->assertFalse(LayoutHelper::isRightSidebarEnabled());
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Fix #1140 

Changes to auto show the right sidebar when section `right_sidebar` is present on a blade file extending the layout.
Also, the section was renamed from `right-sidebar` to `right_sidebar` to keep consistency with other section names.

> [!CAUTION]
> When introducing this change on a new release, people using the `right-sidebar` section must rename it to `right_sidebar`. Also, if the views were published, they will require an update for the auto show feature to work.

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
- [x] Update Usage section on the Wiki 
