### PR TITLE
Add suport to Vite

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -267,19 +267,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Laravel Mix
+    | Laravel Asset Bundling
     |--------------------------------------------------------------------------
     |
-    | Here we can enable the Laravel Mix option for the admin panel.
+    | Here we can enable the Laravel Asset Bundling option for the admin panel.
+    | Currently, two modes are supported: 'mix' and 'vite'.
+    | If you are not using any of these, leave it as 'false'.
     |
-    | For detailed instructions you can look the laravel mix section here:
+    | For detailed instructions you can look the laravel asset bundling section here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Other-Configuration
     |
     */
 
-    'enabled_laravel_mix' => false,
-    'laravel_mix_css_path' => 'css/app.css',
-    'laravel_mix_js_path' => 'js/app.js',
+    'laravel_asset_bundling' => false,
+    'laravel_css_path' => 'css/app.css',
+    'laravel_js_path' => 'js/app.js',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -271,10 +271,12 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here we can enable the Laravel Asset Bundling option for the admin panel.
-    | Currently, two modes are supported: 'mix' and 'vite'.
+    | Currently, the next modes are supported: 'mix', 'vite' and 'vite_js_only'.
+    | When using 'vite_js_only', it's expected that your CSS is imported using
+    | JavaScript. Typically, in your application's 'resources/js/app.js' file.
     | If you are not using any of these, leave it as 'false'.
     |
-    | For detailed instructions you can look the laravel asset bundling section here:
+    | For detailed instructions you can look the asset bundling section here:
     | https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Other-Configuration
     |
     */

--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -18,86 +18,86 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
 
-    $(() => {
-        let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
+            // Add support to display a placeholder. In this situation, the related
+            // input won't be updated automatically and the cancel button will be
+            // used to clear the input.
 
-        // Add support to display a placeholder. In this situation, the related
-        // input won't be updated automatically and the cancel button will be
-        // used to clear the input.
+            @if($attributes->has('placeholder'))
 
-        @if($attributes->has('placeholder'))
+                usrCfg.autoUpdateInput = false;
 
-            usrCfg.autoUpdateInput = false;
+                $('#{{ $id }}').on('apply.daterangepicker', function(ev, picker)
+                {
+                    let startDate = picker.startDate.format(picker.locale.format);
+                    let endDate = picker.endDate.format(picker.locale.format);
 
-            $('#{{ $id }}').on('apply.daterangepicker', function(ev, picker)
-            {
-                let startDate = picker.startDate.format(picker.locale.format);
-                let endDate = picker.endDate.format(picker.locale.format);
+                    let value = picker.singleDatePicker
+                        ? startDate
+                        : startDate + picker.locale.separator + endDate;
 
-                let value = picker.singleDatePicker
-                    ? startDate
-                    : startDate + picker.locale.separator + endDate;
+                    $(this).val(value);
+                });
 
-                $(this).val(value);
-            });
+                $('#{{ $id }}').on('cancel.daterangepicker', function(ev, picker)
+                {
+                    $(this).val('');
+                });
 
-            $('#{{ $id }}').on('cancel.daterangepicker', function(ev, picker)
-            {
-                $(this).val('');
-            });
+            @endif
 
-        @endif
+            // Check if the default set of ranges should be enabled, and if a
+            // default range should be set at initialization.
 
-        // Check if the default set of ranges should be enabled, and if a
-        // default range should be set at initialization.
+            @isset($enableDefaultRanges)
 
-        @isset($enableDefaultRanges)
+                usrCfg.ranges = usrCfg.ranges || _AdminLTE_DateRange.defaultRanges;
+                let range = usrCfg.ranges[ @json($enableDefaultRanges) ];
 
-            usrCfg.ranges = usrCfg.ranges || _AdminLTE_DateRange.defaultRanges;
-            let range = usrCfg.ranges[ @json($enableDefaultRanges) ];
+                if (Array.isArray(range) && range.length > 1) {
+                    usrCfg.startDate = range[0];
+                    usrCfg.endDate = range[1];
+                }
 
-            if (Array.isArray(range) && range.length > 1) {
-                usrCfg.startDate = range[0];
-                usrCfg.endDate = range[1];
-            }
+            @endisset
 
-        @endisset
+            // Add support to auto select the previous submitted value in case
+            // of validation errors. Note the previous value may be a date range or
+            // a single date depending on the plugin configuration.
 
-        // Add support to auto select the previous submitted value in case
-        // of validation errors. Note the previous value may be a date range or
-        // a single date depending on the plugin configuration.
+            @if($errors->any() && $enableOldSupport)
 
-        @if($errors->any() && $enableOldSupport)
+                let oldRange = @json($getOldValue($errorKey, ""));
+                let separator = " - ";
 
-            let oldRange = @json($getOldValue($errorKey, ""));
-            let separator = " - ";
+                if (usrCfg.locale && usrCfg.locale.separator) {
+                    separator = usrCfg.locale.separator;
+                }
 
-            if (usrCfg.locale && usrCfg.locale.separator) {
-                separator = usrCfg.locale.separator;
-            }
+                // Update the related input.
 
-            // Update the related input.
+                if (! usrCfg.autoUpdateInput) {
+                    $('#{{ $id }}').val(oldRange);
+                }
 
-            if (! usrCfg.autoUpdateInput) {
-                $('#{{ $id }}').val(oldRange);
-            }
+                // Update the internal plugin data.
 
-            // Update the internal plugin data.
+                if (oldRange) {
+                    oldRange = oldRange.split(separator);
+                    usrCfg.startDate = oldRange.length > 0 ? oldRange[0] : null;
+                    usrCfg.endDate = oldRange.length > 1 ? oldRange[1] : null;
+                }
 
-            if (oldRange) {
-                oldRange = oldRange.split(separator);
-                usrCfg.startDate = oldRange.length > 0 ? oldRange[0] : null;
-                usrCfg.endDate = oldRange.length > 1 ? oldRange[1] : null;
-            }
+            @endif
 
-        @endif
+            // Setup the underlying date range plugin.
 
-        // Setup the underlying date range plugin.
-
-        $('#{{ $id }}').daterangepicker(usrCfg);
-    })
-
+            $('#{{ $id }}').daterangepicker(usrCfg);
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -18,6 +18,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
 
@@ -96,6 +97,7 @@
 
         $('#{{ $id }}').daterangepicker(usrCfg);
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -17,87 +17,85 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
+<script type="module">
+    $(() => {
+        let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );
 
-            // Add support to display a placeholder. In this situation, the related
-            // input won't be updated automatically and the cancel button will be
-            // used to clear the input.
+        // Add support to display a placeholder. In this situation, the related
+        // input won't be updated automatically and the cancel button will be
+        // used to clear the input.
 
-            @if($attributes->has('placeholder'))
+        @if($attributes->has('placeholder'))
 
-                usrCfg.autoUpdateInput = false;
+            usrCfg.autoUpdateInput = false;
 
-                $('#{{ $id }}').on('apply.daterangepicker', function(ev, picker)
-                {
-                    let startDate = picker.startDate.format(picker.locale.format);
-                    let endDate = picker.endDate.format(picker.locale.format);
+            $('#{{ $id }}').on('apply.daterangepicker', function(ev, picker)
+            {
+                let startDate = picker.startDate.format(picker.locale.format);
+                let endDate = picker.endDate.format(picker.locale.format);
 
-                    let value = picker.singleDatePicker
-                        ? startDate
-                        : startDate + picker.locale.separator + endDate;
+                let value = picker.singleDatePicker
+                    ? startDate
+                    : startDate + picker.locale.separator + endDate;
 
-                    $(this).val(value);
-                });
+                $(this).val(value);
+            });
 
-                $('#{{ $id }}').on('cancel.daterangepicker', function(ev, picker)
-                {
-                    $(this).val('');
-                });
+            $('#{{ $id }}').on('cancel.daterangepicker', function(ev, picker)
+            {
+                $(this).val('');
+            });
 
-            @endif
+        @endif
 
-            // Check if the default set of ranges should be enabled, and if a
-            // default range should be set at initialization.
+        // Check if the default set of ranges should be enabled, and if a
+        // default range should be set at initialization.
 
-            @isset($enableDefaultRanges)
+        @isset($enableDefaultRanges)
 
-                usrCfg.ranges = usrCfg.ranges || _AdminLTE_DateRange.defaultRanges;
-                let range = usrCfg.ranges[ @json($enableDefaultRanges) ];
+            usrCfg.ranges = usrCfg.ranges || _AdminLTE_DateRange.defaultRanges;
+            let range = usrCfg.ranges[ @json($enableDefaultRanges) ];
 
-                if (Array.isArray(range) && range.length > 1) {
-                    usrCfg.startDate = range[0];
-                    usrCfg.endDate = range[1];
-                }
+            if (Array.isArray(range) && range.length > 1) {
+                usrCfg.startDate = range[0];
+                usrCfg.endDate = range[1];
+            }
 
-            @endisset
+        @endisset
 
-            // Add support to auto select the previous submitted value in case
-            // of validation errors. Note the previous value may be a date range or
-            // a single date depending on the plugin configuration.
+        // Add support to auto select the previous submitted value in case
+        // of validation errors. Note the previous value may be a date range or
+        // a single date depending on the plugin configuration.
 
-            @if($errors->any() && $enableOldSupport)
+        @if($errors->any() && $enableOldSupport)
 
-                let oldRange = @json($getOldValue($errorKey, ""));
-                let separator = " - ";
+            let oldRange = @json($getOldValue($errorKey, ""));
+            let separator = " - ";
 
-                if (usrCfg.locale && usrCfg.locale.separator) {
-                    separator = usrCfg.locale.separator;
-                }
+            if (usrCfg.locale && usrCfg.locale.separator) {
+                separator = usrCfg.locale.separator;
+            }
 
-                // Update the related input.
+            // Update the related input.
 
-                if (! usrCfg.autoUpdateInput) {
-                    $('#{{ $id }}').val(oldRange);
-                }
+            if (! usrCfg.autoUpdateInput) {
+                $('#{{ $id }}').val(oldRange);
+            }
 
-                // Update the internal plugin data.
+            // Update the internal plugin data.
 
-                if (oldRange) {
-                    oldRange = oldRange.split(separator);
-                    usrCfg.startDate = oldRange.length > 0 ? oldRange[0] : null;
-                    usrCfg.endDate = oldRange.length > 1 ? oldRange[1] : null;
-                }
+            if (oldRange) {
+                oldRange = oldRange.split(separator);
+                usrCfg.startDate = oldRange.length > 0 ? oldRange[0] : null;
+                usrCfg.endDate = oldRange.length > 1 ? oldRange[1] : null;
+            }
 
-            @endif
+        @endif
 
-            // Setup the underlying date range plugin.
+        // Setup the underlying date range plugin.
 
-            $('#{{ $id }}').daterangepicker(usrCfg);
-        })
-    });
+        $('#{{ $id }}').daterangepicker(usrCfg);
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -18,37 +18,38 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
 
-    $(() => {
+            // Create a method to set the addon color.
 
-        // Create a method to set the addon color.
+            let setAddonColor = function()
+            {
+                let color = $('#{{ $id }}').data('colorpicker').getValue();
 
-        let setAddonColor = function()
-        {
-            let color = $('#{{ $id }}').data('colorpicker').getValue();
+                $('#{{ $id }}').closest('.input-group')
+                    .find('.input-group-text > i')
+                    .css('color', color);
+            }
 
-            $('#{{ $id }}').closest('.input-group')
-                .find('.input-group-text > i')
-                .css('color', color);
-        }
+            // Init the plugin and register the change event listener.
 
-        // Init the plugin and register the change event listener.
+            $('#{{ $id }}').colorpicker( @json($config) )
+                .on('change', setAddonColor);
 
-        $('#{{ $id }}').colorpicker( @json($config) )
-            .on('change', setAddonColor);
+            // Add support to auto select the previous submitted value in case
+            // of validation errors.
 
-        // Add support to auto select the previous submitted value in case
-        // of validation errors.
+            @if($errors->any() && $enableOldSupport)
+                let oldColor = @json($getOldValue($errorKey, ""));
+                $('#{{ $id }}').val(oldColor).change();
+            @endif
 
-        @if($errors->any() && $enableOldSupport)
-            let oldColor = @json($getOldValue($errorKey, ""));
-            $('#{{ $id }}').val(oldColor).change();
-        @endif
+            // Set the initial color for the addon.
 
-        // Set the initial color for the addon.
+            setAddonColor();
+        })
 
-        setAddonColor();
-    })
-
+    });
 </script>
 @endpush

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -17,39 +17,36 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
+<script type="module">
+    $(() => {
 
-            // Create a method to set the addon color.
+        // Create a method to set the addon color.
 
-            let setAddonColor = function()
-            {
-                let color = $('#{{ $id }}').data('colorpicker').getValue();
+        let setAddonColor = function()
+        {
+            let color = $('#{{ $id }}').data('colorpicker').getValue();
 
-                $('#{{ $id }}').closest('.input-group')
-                    .find('.input-group-text > i')
-                    .css('color', color);
-            }
+            $('#{{ $id }}').closest('.input-group')
+                .find('.input-group-text > i')
+                .css('color', color);
+        }
 
-            // Init the plugin and register the change event listener.
+        // Init the plugin and register the change event listener.
 
-            $('#{{ $id }}').colorpicker( @json($config) )
-                .on('change', setAddonColor);
+        $('#{{ $id }}').colorpicker( @json($config) )
+            .on('change', setAddonColor);
 
-            // Add support to auto select the previous submitted value in case
-            // of validation errors.
+        // Add support to auto select the previous submitted value in case
+        // of validation errors.
 
-            @if($errors->any() && $enableOldSupport)
-                let oldColor = @json($getOldValue($errorKey, ""));
-                $('#{{ $id }}').val(oldColor).change();
-            @endif
+        @if($errors->any() && $enableOldSupport)
+            let oldColor = @json($getOldValue($errorKey, ""));
+            $('#{{ $id }}').val(oldColor).change();
+        @endif
 
-            // Set the initial color for the addon.
+        // Set the initial color for the addon.
 
-            setAddonColor();
-        })
-
-    });
+        setAddonColor();
+    })
 </script>
 @endpush

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -18,6 +18,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
 
         // Create a method to set the addon color.
@@ -48,5 +49,6 @@
 
         setAddonColor();
     })
+
 </script>
 @endpush

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -18,6 +18,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
         $('#{{ $id }}').datetimepicker(usrCfg);
@@ -28,6 +29,7 @@
         let value = @json($getOldValue($errorKey, $attributes->get('value')));
         $('#{{ $id }}').val(value || "");
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -17,19 +17,17 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
-            $('#{{ $id }}').datetimepicker(usrCfg);
+<script type="module">
+    $(() => {
+        let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
+        $('#{{ $id }}').datetimepicker(usrCfg);
 
-            // Add support to auto display the old submitted value or values in case
-            // of validation errors.
+        // Add support to auto display the old submitted value or values in case
+        // of validation errors.
 
-            let value = @json($getOldValue($errorKey, $attributes->get('value')));
-            $('#{{ $id }}').val(value || "");
-        })
-    });
+        let value = @json($getOldValue($errorKey, $attributes->get('value')));
+        $('#{{ $id }}').val(value || "");
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -18,18 +18,18 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
+            $('#{{ $id }}').datetimepicker(usrCfg);
 
-    $(() => {
-        let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );
-        $('#{{ $id }}').datetimepicker(usrCfg);
+            // Add support to auto display the old submitted value or values in case
+            // of validation errors.
 
-        // Add support to auto display the old submitted value or values in case
-        // of validation errors.
-
-        let value = @json($getOldValue($errorKey, $attributes->get('value')));
-        $('#{{ $id }}').val(value || "");
-    })
-
+            let value = @json($getOldValue($errorKey, $attributes->get('value')));
+            $('#{{ $id }}').val(value || "");
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -38,33 +38,34 @@ one provided by the mentioned layout. So instead, we define a new layout.
 @push('js')
 <script>
 
-    $(() => {
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
 
-        // Initialize the plugin.
+            // Initialize the plugin.
 
-        $('#{{ $id }}').fileinput( @json($config) );
+            $('#{{ $id }}').fileinput( @json($config) );
 
-        // Workaround to force setup of invalid class.
+            // Workaround to force setup of invalid class.
 
-        @if($isInvalid())
-            $('#{{ $id }}').closest('.file-input')
-                .find('.file-caption-name')
-                .addClass('is-invalid')
+            @if($isInvalid())
+                $('#{{ $id }}').closest('.file-input')
+                    .find('.file-caption-name')
+                    .addClass('is-invalid')
 
-            $('#{{ $id }}').closest('.file-input')
-                .find('.file-preview')
-                .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
-        @endif
+                $('#{{ $id }}').closest('.file-input')
+                    .find('.file-preview')
+                    .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
+            @endif
 
-        // Make custom style for particular scenarios (modes).
+            // Make custom style for particular scenarios (modes).
 
-        @if($presetMode == 'avatar')
-            $('#{{ $id }}').closest('.file-input')
-                .addClass('text-center')
-                .find('.file-drop-zone')
-                .addClass('border-0');
-        @endif
-    })
-
+            @if($presetMode == 'avatar')
+                $('#{{ $id }}').closest('.file-input')
+                    .addClass('text-center')
+                    .find('.file-drop-zone')
+                    .addClass('border-0');
+            @endif
+        })
+    });
 </script>
 @endpush

--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -36,36 +36,33 @@ one provided by the mentioned layout. So instead, we define a new layout.
 {{-- Add the plugin initialization code --}}
 
 @push('js')
-<script>
+<script type="module">
+    $(() => {
 
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
+        // Initialize the plugin.
 
-            // Initialize the plugin.
+        $('#{{ $id }}').fileinput( @json($config) );
 
-            $('#{{ $id }}').fileinput( @json($config) );
+        // Workaround to force setup of invalid class.
 
-            // Workaround to force setup of invalid class.
+        @if($isInvalid())
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-caption-name')
+                .addClass('is-invalid')
 
-            @if($isInvalid())
-                $('#{{ $id }}').closest('.file-input')
-                    .find('.file-caption-name')
-                    .addClass('is-invalid')
+            $('#{{ $id }}').closest('.file-input')
+                .find('.file-preview')
+                .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
+        @endif
 
-                $('#{{ $id }}').closest('.file-input')
-                    .find('.file-preview')
-                    .css('box-shadow', '0 .15rem 0.25rem rgba(255,0,0,.25)');
-            @endif
+        // Make custom style for particular scenarios (modes).
 
-            // Make custom style for particular scenarios (modes).
-
-            @if($presetMode == 'avatar')
-                $('#{{ $id }}').closest('.file-input')
-                    .addClass('text-center')
-                    .find('.file-drop-zone')
-                    .addClass('border-0');
-            @endif
-        })
-    });
+        @if($presetMode == 'avatar')
+            $('#{{ $id }}').closest('.file-input')
+                .addClass('text-center')
+                .find('.file-drop-zone')
+                .addClass('border-0');
+        @endif
+    })
 </script>
 @endpush

--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -37,6 +37,7 @@ one provided by the mentioned layout. So instead, we define a new layout.
 
 @push('js')
 <script type="module">
+
     $(() => {
 
         // Initialize the plugin.
@@ -64,5 +65,6 @@ one provided by the mentioned layout. So instead, we define a new layout.
                 .addClass('border-0');
         @endif
     })
+
 </script>
 @endpush

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -29,11 +29,11 @@
 @once
 @push('js')
 <script>
-
-    $(() => {
-        bsCustomFileInput.init();
-    })
-
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            bsCustomFileInput.init();
+        })
+    });
 </script>
 @endpush
 @endonce

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -29,9 +29,11 @@
 @once
 @push('js')
 <script type="module">
+
     $(() => {
         bsCustomFileInput.init();
     })
+
 </script>
 @endpush
 @endonce

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -28,12 +28,10 @@
 
 @once
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            bsCustomFileInput.init();
-        })
-    });
+<script type="module">
+    $(() => {
+        bsCustomFileInput.init();
+    })
 </script>
 @endpush
 @endonce

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -17,60 +17,58 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            let usrCfg = @json($config);
+<script type="module">
+    $(() => {
+        let usrCfg = @json($config);
 
-            // Check for disabled attribute (alternative to data-slider-enable).
+        // Check for disabled attribute (alternative to data-slider-enable).
 
-            @if($attributes->has('disabled'))
-                usrCfg.enabled = false;
-            @endif
+        @if($attributes->has('disabled'))
+            usrCfg.enabled = false;
+        @endif
 
-            // Check for min, max and step attributes (alternatives to
-            // data-slider-min, data-slider-max and data-slider-step).
+        // Check for min, max and step attributes (alternatives to
+        // data-slider-min, data-slider-max and data-slider-step).
 
-            @if($attributes->has('min'))
-                usrCfg.min = Number( @json($attributes['min']) );
-            @endif
+        @if($attributes->has('min'))
+            usrCfg.min = Number( @json($attributes['min']) );
+        @endif
 
-            @if($attributes->has('max'))
-                usrCfg.max = Number( @json($attributes['max']) );
-            @endif
+        @if($attributes->has('max'))
+            usrCfg.max = Number( @json($attributes['max']) );
+        @endif
 
-            @if($attributes->has('step'))
-                usrCfg.step = Number( @json($attributes['step']) );
-            @endif
+        @if($attributes->has('step'))
+            usrCfg.step = Number( @json($attributes['step']) );
+        @endif
 
-            // Check for value attribute (alternative to data-slider-value).
-            // Also, add support to auto select the previous submitted value.
+        // Check for value attribute (alternative to data-slider-value).
+        // Also, add support to auto select the previous submitted value.
 
-            @if($attributes->has('value') || ($errors->any() && $enableOldSupport))
+        @if($attributes->has('value') || ($errors->any() && $enableOldSupport))
 
-                let value = @json($getOldValue($errorKey, $attributes['value']));
+            let value = @json($getOldValue($errorKey, $attributes['value']));
 
-                if (value) {
-                    value = value.split(",").map(Number);
-                    usrCfg.value = value.length > 1 ? value : value[0];
-                }
-
-            @endif
-
-            // Initialize the plugin.
-
-            let slider = $('#{{ $id }}').bootstrapSlider(usrCfg);
-
-            // Fix height conflict when orientation is vertical.
-
-            let or = slider.bootstrapSlider('getAttribute', 'orientation');
-
-            if (or == 'vertical') {
-                $('#' + usrCfg.id).css('height', '210px');
-                slider.bootstrapSlider('relayout');
+            if (value) {
+                value = value.split(",").map(Number);
+                usrCfg.value = value.length > 1 ? value : value[0];
             }
-        })
-    });
+
+        @endif
+
+        // Initialize the plugin.
+
+        let slider = $('#{{ $id }}').bootstrapSlider(usrCfg);
+
+        // Fix height conflict when orientation is vertical.
+
+        let or = slider.bootstrapSlider('getAttribute', 'orientation');
+
+        if (or == 'vertical') {
+            $('#' + usrCfg.id).css('height', '210px');
+            slider.bootstrapSlider('relayout');
+        }
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -18,59 +18,59 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            let usrCfg = @json($config);
 
-    $(() => {
-        let usrCfg = @json($config);
+            // Check for disabled attribute (alternative to data-slider-enable).
 
-        // Check for disabled attribute (alternative to data-slider-enable).
+            @if($attributes->has('disabled'))
+                usrCfg.enabled = false;
+            @endif
 
-        @if($attributes->has('disabled'))
-            usrCfg.enabled = false;
-        @endif
+            // Check for min, max and step attributes (alternatives to
+            // data-slider-min, data-slider-max and data-slider-step).
 
-        // Check for min, max and step attributes (alternatives to
-        // data-slider-min, data-slider-max and data-slider-step).
+            @if($attributes->has('min'))
+                usrCfg.min = Number( @json($attributes['min']) );
+            @endif
 
-        @if($attributes->has('min'))
-            usrCfg.min = Number( @json($attributes['min']) );
-        @endif
+            @if($attributes->has('max'))
+                usrCfg.max = Number( @json($attributes['max']) );
+            @endif
 
-        @if($attributes->has('max'))
-            usrCfg.max = Number( @json($attributes['max']) );
-        @endif
+            @if($attributes->has('step'))
+                usrCfg.step = Number( @json($attributes['step']) );
+            @endif
 
-        @if($attributes->has('step'))
-            usrCfg.step = Number( @json($attributes['step']) );
-        @endif
+            // Check for value attribute (alternative to data-slider-value).
+            // Also, add support to auto select the previous submitted value.
 
-        // Check for value attribute (alternative to data-slider-value).
-        // Also, add support to auto select the previous submitted value.
+            @if($attributes->has('value') || ($errors->any() && $enableOldSupport))
 
-        @if($attributes->has('value') || ($errors->any() && $enableOldSupport))
+                let value = @json($getOldValue($errorKey, $attributes['value']));
 
-            let value = @json($getOldValue($errorKey, $attributes['value']));
+                if (value) {
+                    value = value.split(",").map(Number);
+                    usrCfg.value = value.length > 1 ? value : value[0];
+                }
 
-            if (value) {
-                value = value.split(",").map(Number);
-                usrCfg.value = value.length > 1 ? value : value[0];
+            @endif
+
+            // Initialize the plugin.
+
+            let slider = $('#{{ $id }}').bootstrapSlider(usrCfg);
+
+            // Fix height conflict when orientation is vertical.
+
+            let or = slider.bootstrapSlider('getAttribute', 'orientation');
+
+            if (or == 'vertical') {
+                $('#' + usrCfg.id).css('height', '210px');
+                slider.bootstrapSlider('relayout');
             }
-
-        @endif
-
-        // Initialize the plugin.
-
-        let slider = $('#{{ $id }}').bootstrapSlider(usrCfg);
-
-        // Fix height conflict when orientation is vertical.
-
-        let or = slider.bootstrapSlider('getAttribute', 'orientation');
-
-        if (or == 'vertical') {
-            $('#' + usrCfg.id).css('height', '210px');
-            slider.bootstrapSlider('relayout');
-        }
-    })
-
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -18,6 +18,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         let usrCfg = @json($config);
 
@@ -69,6 +70,7 @@
             slider.bootstrapSlider('relayout');
         }
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -18,19 +18,19 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            $('#{{ $id }}').bootstrapSwitch( @json($config) );
 
-    $(() => {
-        $('#{{ $id }}').bootstrapSwitch( @json($config) );
+            // Add support to auto select the previous submitted value in case of
+            // validation errors.
 
-        // Add support to auto select the previous submitted value in case of
-        // validation errors.
-
-        @if($errors->any() && $enableOldSupport)
-            let oldState = @json((bool)$getOldValue($errorKey));
-            $('#{{ $id }}').bootstrapSwitch('state', oldState);
-        @endif
-    })
-
+            @if($errors->any() && $enableOldSupport)
+                let oldState = @json((bool)$getOldValue($errorKey));
+                $('#{{ $id }}').bootstrapSwitch('state', oldState);
+            @endif
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -18,6 +18,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         $('#{{ $id }}').bootstrapSwitch( @json($config) );
 
@@ -29,6 +30,7 @@
             $('#{{ $id }}').bootstrapSwitch('state', oldState);
         @endif
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -17,20 +17,18 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            $('#{{ $id }}').bootstrapSwitch( @json($config) );
+<script type="module">
+    $(() => {
+        $('#{{ $id }}').bootstrapSwitch( @json($config) );
 
-            // Add support to auto select the previous submitted value in case of
-            // validation errors.
+        // Add support to auto select the previous submitted value in case of
+        // validation errors.
 
-            @if($errors->any() && $enableOldSupport)
-                let oldState = @json((bool)$getOldValue($errorKey));
-                $('#{{ $id }}').bootstrapSwitch('state', oldState);
-            @endif
-        })
-    });
+        @if($errors->any() && $enableOldSupport)
+            let oldState = @json((bool)$getOldValue($errorKey));
+            $('#{{ $id }}').bootstrapSwitch('state', oldState);
+        @endif
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -20,19 +20,19 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            $('#{{ $id }}').selectpicker( @json($config) );
 
-    $(() => {
-        $('#{{ $id }}').selectpicker( @json($config) );
+            // Add support to auto select old submitted values in case of
+            // validation errors.
 
-        // Add support to auto select old submitted values in case of
-        // validation errors.
-
-        @if($errors->any() && $enableOldSupport)
-            let oldOptions = @json(collect($getOldValue($errorKey)));
-            $('#{{ $id }}').selectpicker('val', oldOptions);
-        @endif
-    })
-
+            @if($errors->any() && $enableOldSupport)
+                let oldOptions = @json(collect($getOldValue($errorKey)));
+                $('#{{ $id }}').selectpicker('val', oldOptions);
+            @endif
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -20,6 +20,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         $('#{{ $id }}').selectpicker( @json($config) );
 
@@ -31,6 +32,7 @@
             $('#{{ $id }}').selectpicker('val', oldOptions);
         @endif
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -19,20 +19,18 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            $('#{{ $id }}').selectpicker( @json($config) );
+<script type="module">
+    $(() => {
+        $('#{{ $id }}').selectpicker( @json($config) );
 
-            // Add support to auto select old submitted values in case of
-            // validation errors.
+        // Add support to auto select old submitted values in case of
+        // validation errors.
 
-            @if($errors->any() && $enableOldSupport)
-                let oldOptions = @json(collect($getOldValue($errorKey)));
-                $('#{{ $id }}').selectpicker('val', oldOptions);
-            @endif
-        })
-    });
+        @if($errors->any() && $enableOldSupport)
+            let oldOptions = @json(collect($getOldValue($errorKey)));
+            $('#{{ $id }}').selectpicker('val', oldOptions);
+        @endif
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -21,18 +21,18 @@
 @if($errors->any() && $enableOldSupport)
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
 
-    $(() => {
+            let oldOptions = @json(collect($getOldValue($errorKey)));
 
-        let oldOptions = @json(collect($getOldValue($errorKey)));
-
-        $('#{{ $id }} option').each(function()
-        {
-            let value = $(this).val() || $(this).text();
-            $(this).prop('selected', oldOptions.includes(value));
+            $('#{{ $id }} option').each(function()
+            {
+                let value = $(this).val() || $(this).text();
+                $(this).prop('selected', oldOptions.includes(value));
+            });
         });
     });
-
 </script>
 @endpush
 @endif

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -21,6 +21,7 @@
 @if($errors->any() && $enableOldSupport)
 @push('js')
 <script type="module">
+
     $(() => {
 
         let oldOptions = @json(collect($getOldValue($errorKey)));
@@ -31,6 +32,7 @@
             $(this).prop('selected', oldOptions.includes(value));
         });
     });
+
 </script>
 @endpush
 @endif

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -20,17 +20,15 @@
 
 @if($errors->any() && $enableOldSupport)
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
+<script type="module">
+    $(() => {
 
-            let oldOptions = @json(collect($getOldValue($errorKey)));
+        let oldOptions = @json(collect($getOldValue($errorKey)));
 
-            $('#{{ $id }} option').each(function()
-            {
-                let value = $(this).val() || $(this).text();
-                $(this).prop('selected', oldOptions.includes(value));
-            });
+        $('#{{ $id }} option').each(function()
+        {
+            let value = $(this).val() || $(this).text();
+            $(this).prop('selected', oldOptions.includes(value));
         });
     });
 </script>

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -19,29 +19,27 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            $('#{{ $id }}').select2( @json($config) );
+<script type="module">
+    $(() => {
+        $('#{{ $id }}').select2( @json($config) );
 
-            // Add support to auto select old submitted values in case of
-            // validation errors.
+        // Add support to auto select old submitted values in case of
+        // validation errors.
 
-            @if($errors->any() && $enableOldSupport)
+        @if($errors->any() && $enableOldSupport)
 
-                let oldOptions = @json(collect($getOldValue($errorKey)));
+            let oldOptions = @json(collect($getOldValue($errorKey)));
 
-                $('#{{ $id }} option').each(function()
-                {
-                    let value = $(this).val() || $(this).text();
-                    $(this).prop('selected', oldOptions.includes(value));
-                });
+            $('#{{ $id }} option').each(function()
+            {
+                let value = $(this).val() || $(this).text();
+                $(this).prop('selected', oldOptions.includes(value));
+            });
 
-                $('#{{ $id }}').trigger('change');
+            $('#{{ $id }}').trigger('change');
 
-            @endif
-        })
-    });
+        @endif
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -20,6 +20,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         $('#{{ $id }}').select2( @json($config) );
 
@@ -40,6 +41,7 @@
 
         @endif
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -20,28 +20,28 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            $('#{{ $id }}').select2( @json($config) );
 
-    $(() => {
-        $('#{{ $id }}').select2( @json($config) );
+            // Add support to auto select old submitted values in case of
+            // validation errors.
 
-        // Add support to auto select old submitted values in case of
-        // validation errors.
+            @if($errors->any() && $enableOldSupport)
 
-        @if($errors->any() && $enableOldSupport)
+                let oldOptions = @json(collect($getOldValue($errorKey)));
 
-            let oldOptions = @json(collect($getOldValue($errorKey)));
+                $('#{{ $id }} option').each(function()
+                {
+                    let value = $(this).val() || $(this).text();
+                    $(this).prop('selected', oldOptions.includes(value));
+                });
 
-            $('#{{ $id }} option').each(function()
-            {
-                let value = $(this).val() || $(this).text();
-                $(this).prop('selected', oldOptions.includes(value));
-            });
+                $('#{{ $id }}').trigger('change');
 
-            $('#{{ $id }}').trigger('change');
-
-        @endif
-    })
-
+            @endif
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -19,6 +19,7 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         let usrCfg = @json($config);
 
@@ -38,6 +39,7 @@
             $('#{{ $id }}').summernote('disable');
         @endisset
     })
+
 </script>
 @endpush
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -18,28 +18,26 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            let usrCfg = @json($config);
+<script type="module">
+    $(() => {
+        let usrCfg = @json($config);
 
-            // Check for placeholder attribute.
+        // Check for placeholder attribute.
 
-            @isset($attributes['placeholder'])
-                usrCfg['placeholder'] = "{{ $attributes['placeholder'] }}";
-            @endisset
+        @isset($attributes['placeholder'])
+            usrCfg['placeholder'] = "{{ $attributes['placeholder'] }}";
+        @endisset
 
-            // Initialize the plugin.
+        // Initialize the plugin.
 
-            $('#{{ $id }}').summernote(usrCfg);
+        $('#{{ $id }}').summernote(usrCfg);
 
-            // Check for disabled attribute.
+        // Check for disabled attribute.
 
-            @isset($attributes['disabled'])
-                $('#{{ $id }}').summernote('disable');
-            @endisset
-        })
-    });
+        @isset($attributes['disabled'])
+            $('#{{ $id }}').summernote('disable');
+        @endisset
+    })
 </script>
 @endpush
 

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -19,27 +19,27 @@
 
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            let usrCfg = @json($config);
 
-    $(() => {
-        let usrCfg = @json($config);
+            // Check for placeholder attribute.
 
-        // Check for placeholder attribute.
+            @isset($attributes['placeholder'])
+                usrCfg['placeholder'] = "{{ $attributes['placeholder'] }}";
+            @endisset
 
-        @isset($attributes['placeholder'])
-            usrCfg['placeholder'] = "{{ $attributes['placeholder'] }}";
-        @endisset
+            // Initialize the plugin.
 
-        // Initialize the plugin.
+            $('#{{ $id }}').summernote(usrCfg);
 
-        $('#{{ $id }}').summernote(usrCfg);
+            // Check for disabled attribute.
 
-        // Check for disabled attribute.
-
-        @isset($attributes['disabled'])
-            $('#{{ $id }}').summernote('disable');
-        @endisset
-    })
-
+            @isset($attributes['disabled'])
+                $('#{{ $id }}').summernote('disable');
+            @endisset
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/layout/navbar-darkmode-widget.blade.php
+++ b/resources/views/components/layout/navbar-darkmode-widget.blade.php
@@ -12,64 +12,62 @@
 
 @once
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
+<script type="module">
+    $(() => {
 
-            const body = document.querySelector('body');
-            const widget = document.querySelector('li.adminlte-darkmode-widget');
-            const widgetIcon = widget.querySelector('i');
+        const body = document.querySelector('body');
+        const widget = document.querySelector('li.adminlte-darkmode-widget');
+        const widgetIcon = widget.querySelector('i');
 
-            // Get the set of classes to be toggled on the widget icon.
+        // Get the set of classes to be toggled on the widget icon.
 
-            const iconClasses = [
-                ...@json($makeIconEnabledClass()),
-                ...@json($makeIconDisabledClass())
-            ];
+        const iconClasses = [
+            ...@json($makeIconEnabledClass()),
+            ...@json($makeIconDisabledClass())
+        ];
 
-            // Add 'click' event listener for the darkmode widget.
+        // Add 'click' event listener for the darkmode widget.
 
-            widget.addEventListener('click', () => {
+        widget.addEventListener('click', () => {
 
-                // Toggle dark-mode class on the main body tag.
+            // Toggle dark-mode class on the main body tag.
 
-                body.classList.toggle('dark-mode');
+            body.classList.toggle('dark-mode');
 
-                // Support to IFrame mode: toggle dark-mode class on the body of
-                // any present iframe.
+            // Support to IFrame mode: toggle dark-mode class on the body of
+            // any present iframe.
 
-                let iframes = document.querySelectorAll('div.iframe-mode iframe');
+            let iframes = document.querySelectorAll('div.iframe-mode iframe');
 
-                iframes.forEach((f) => {
-                    b = f.contentDocument.querySelector('body');
-                    b.classList.toggle('dark-mode');
-                });
-
-                // Toggle the classes on the widget icon.
-
-                iconClasses.forEach((c) => widgetIcon.classList.toggle(c));
-
-                // Notify the server. The server will be in charge to persist
-                // the dark mode configuration over multiple request.
-
-                const fetchCfg = {
-                    headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}'},
-                    method: 'POST',
-                };
-
-                fetch(
-                    "{{ route('adminlte.darkmode.toggle') }}",
-                    fetchCfg
-                )
-                .catch((error) => {
-                    console.log(
-                        'Failed to notify server that dark mode was toggled',
-                        error
-                    );
-                });
+            iframes.forEach((f) => {
+                b = f.contentDocument.querySelector('body');
+                b.classList.toggle('dark-mode');
             });
-        })
-    });
+
+            // Toggle the classes on the widget icon.
+
+            iconClasses.forEach((c) => widgetIcon.classList.toggle(c));
+
+            // Notify the server. The server will be in charge to persist
+            // the dark mode configuration over multiple request.
+
+            const fetchCfg = {
+                headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}'},
+                method: 'POST',
+            };
+
+            fetch(
+                "{{ route('adminlte.darkmode.toggle') }}",
+                fetchCfg
+            )
+            .catch((error) => {
+                console.log(
+                    'Failed to notify server that dark mode was toggled',
+                    error
+                );
+            });
+        });
+    })
 </script>
 @endpush
 @endonce

--- a/resources/views/components/layout/navbar-darkmode-widget.blade.php
+++ b/resources/views/components/layout/navbar-darkmode-widget.blade.php
@@ -13,63 +13,63 @@
 @once
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
 
-    $(() => {
+            const body = document.querySelector('body');
+            const widget = document.querySelector('li.adminlte-darkmode-widget');
+            const widgetIcon = widget.querySelector('i');
 
-        const body = document.querySelector('body');
-        const widget = document.querySelector('li.adminlte-darkmode-widget');
-        const widgetIcon = widget.querySelector('i');
+            // Get the set of classes to be toggled on the widget icon.
 
-        // Get the set of classes to be toggled on the widget icon.
+            const iconClasses = [
+                ...@json($makeIconEnabledClass()),
+                ...@json($makeIconDisabledClass())
+            ];
 
-        const iconClasses = [
-            ...@json($makeIconEnabledClass()),
-            ...@json($makeIconDisabledClass())
-        ];
+            // Add 'click' event listener for the darkmode widget.
 
-        // Add 'click' event listener for the darkmode widget.
+            widget.addEventListener('click', () => {
 
-        widget.addEventListener('click', () => {
+                // Toggle dark-mode class on the main body tag.
 
-            // Toggle dark-mode class on the main body tag.
+                body.classList.toggle('dark-mode');
 
-            body.classList.toggle('dark-mode');
+                // Support to IFrame mode: toggle dark-mode class on the body of
+                // any present iframe.
 
-            // Support to IFrame mode: toggle dark-mode class on the body of
-            // any present iframe.
+                let iframes = document.querySelectorAll('div.iframe-mode iframe');
 
-            let iframes = document.querySelectorAll('div.iframe-mode iframe');
+                iframes.forEach((f) => {
+                    b = f.contentDocument.querySelector('body');
+                    b.classList.toggle('dark-mode');
+                });
 
-            iframes.forEach((f) => {
-                b = f.contentDocument.querySelector('body');
-                b.classList.toggle('dark-mode');
+                // Toggle the classes on the widget icon.
+
+                iconClasses.forEach((c) => widgetIcon.classList.toggle(c));
+
+                // Notify the server. The server will be in charge to persist
+                // the dark mode configuration over multiple request.
+
+                const fetchCfg = {
+                    headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}'},
+                    method: 'POST',
+                };
+
+                fetch(
+                    "{{ route('adminlte.darkmode.toggle') }}",
+                    fetchCfg
+                )
+                .catch((error) => {
+                    console.log(
+                        'Failed to notify server that dark mode was toggled',
+                        error
+                    );
+                });
             });
-
-            // Toggle the classes on the widget icon.
-
-            iconClasses.forEach((c) => widgetIcon.classList.toggle(c));
-
-            // Notify the server. The server will be in charge to persist
-            // the dark mode configuration over multiple request.
-
-            const fetchCfg = {
-                headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}'},
-                method: 'POST',
-            };
-
-            fetch(
-                "{{ route('adminlte.darkmode.toggle') }}",
-                fetchCfg
-            )
-            .catch((error) => {
-                console.log(
-                    'Failed to notify server that dark mode was toggled',
-                    error
-                );
-            });
-        });
-    })
-
+        })
+    });
 </script>
 @endpush
 @endonce

--- a/resources/views/components/layout/navbar-darkmode-widget.blade.php
+++ b/resources/views/components/layout/navbar-darkmode-widget.blade.php
@@ -13,6 +13,7 @@
 @once
 @push('js')
 <script type="module">
+
     $(() => {
 
         const body = document.querySelector('body');
@@ -68,6 +69,7 @@
             });
         });
     })
+
 </script>
 @endpush
 @endonce

--- a/resources/views/components/layout/navbar-notification.blade.php
+++ b/resources/views/components/layout/navbar-notification.blade.php
@@ -44,6 +44,7 @@
 @if (! is_null($makeUpdateUrl()) && $makeUpdatePeriod() > 0)
 @push('js')
 <script type="module">
+
     $(() => {
 
         // Method to get new notification data from the configured url.
@@ -74,6 +75,7 @@
 
         setInterval(updateNotification, {{ $makeUpdatePeriod() }}, nLink);
     })
+
 </script>
 @endpush
 @endif

--- a/resources/views/components/layout/navbar-notification.blade.php
+++ b/resources/views/components/layout/navbar-notification.blade.php
@@ -43,39 +43,37 @@
 
 @if (! is_null($makeUpdateUrl()) && $makeUpdatePeriod() > 0)
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
+<script type="module">
+    $(() => {
 
-            // Method to get new notification data from the configured url.
+        // Method to get new notification data from the configured url.
 
-            let updateNotification = (nLink) =>
-            {
-                // Make an ajax call to the configured url. The response should be
-                // an object with the new data. The supported properties are:
-                // 'label', 'label_color', 'icon_color' and 'dropdown'.
+        let updateNotification = (nLink) =>
+        {
+            // Make an ajax call to the configured url. The response should be
+            // an object with the new data. The supported properties are:
+            // 'label', 'label_color', 'icon_color' and 'dropdown'.
 
-                $.ajax({
-                    url: "{{ $makeUpdateUrl() }}"
-                })
-                .done((data) => {
-                    nLink.update(data);
-                })
-                .fail(function(jqXHR, textStatus, errorThrown) {
-                    console.log(jqXHR, textStatus, errorThrown);
-                });
-            };
+            $.ajax({
+                url: "{{ $makeUpdateUrl() }}"
+            })
+            .done((data) => {
+                nLink.update(data);
+            })
+            .fail(function(jqXHR, textStatus, errorThrown) {
+                console.log(jqXHR, textStatus, errorThrown);
+            });
+        };
 
-            // First load of the notification data.
+        // First load of the notification data.
 
-            let nLink = new _AdminLTE_NavbarNotification("{{ $id }}");
-            updateNotification(nLink);
+        let nLink = new _AdminLTE_NavbarNotification("{{ $id }}");
+        updateNotification(nLink);
 
-            // Periodically update the notification.
+        // Periodically update the notification.
 
-            setInterval(updateNotification, {{ $makeUpdatePeriod() }}, nLink);
-        })
-    });
+        setInterval(updateNotification, {{ $makeUpdatePeriod() }}, nLink);
+    })
 </script>
 @endpush
 @endif

--- a/resources/views/components/layout/navbar-notification.blade.php
+++ b/resources/views/components/layout/navbar-notification.blade.php
@@ -44,38 +44,38 @@
 @if (! is_null($makeUpdateUrl()) && $makeUpdatePeriod() > 0)
 @push('js')
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
 
-    $(() => {
+            // Method to get new notification data from the configured url.
 
-        // Method to get new notification data from the configured url.
+            let updateNotification = (nLink) =>
+            {
+                // Make an ajax call to the configured url. The response should be
+                // an object with the new data. The supported properties are:
+                // 'label', 'label_color', 'icon_color' and 'dropdown'.
 
-        let updateNotification = (nLink) =>
-        {
-            // Make an ajax call to the configured url. The response should be
-            // an object with the new data. The supported properties are:
-            // 'label', 'label_color', 'icon_color' and 'dropdown'.
+                $.ajax({
+                    url: "{{ $makeUpdateUrl() }}"
+                })
+                .done((data) => {
+                    nLink.update(data);
+                })
+                .fail(function(jqXHR, textStatus, errorThrown) {
+                    console.log(jqXHR, textStatus, errorThrown);
+                });
+            };
 
-            $.ajax({
-                url: "{{ $makeUpdateUrl() }}"
-            })
-            .done((data) => {
-                nLink.update(data);
-            })
-            .fail(function(jqXHR, textStatus, errorThrown) {
-                console.log(jqXHR, textStatus, errorThrown);
-            });
-        };
+            // First load of the notification data.
 
-        // First load of the notification data.
+            let nLink = new _AdminLTE_NavbarNotification("{{ $id }}");
+            updateNotification(nLink);
 
-        let nLink = new _AdminLTE_NavbarNotification("{{ $id }}");
-        updateNotification(nLink);
+            // Periodically update the notification.
 
-        // Periodically update the notification.
-
-        setInterval(updateNotification, {{ $makeUpdatePeriod() }}, nLink);
-    })
-
+            setInterval(updateNotification, {{ $makeUpdatePeriod() }}, nLink);
+        })
+    });
 </script>
 @endpush
 @endif

--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -39,11 +39,11 @@
 
 @push('js')
 <script>
-
-    $(() => {
-        $('#{{ $id }}').DataTable( @json($config) );
-    })
-
+    document.addEventListener("DOMContentLoaded", function() {
+        $(() => {
+            $('#{{ $id }}').DataTable( @json($config) );
+        })
+    });
 </script>
 @endpush
 

--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -38,12 +38,10 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $(() => {
-            $('#{{ $id }}').DataTable( @json($config) );
-        })
-    });
+<script type="module">
+    $(() => {
+        $('#{{ $id }}').DataTable( @json($config) );
+    })
 </script>
 @endpush
 

--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -39,9 +39,11 @@
 
 @push('js')
 <script type="module">
+
     $(() => {
         $('#{{ $id }}').DataTable( @json($config) );
     })
+
 </script>
 @endpush
 

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -1,110 +1,139 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-<head>
+    <head>
 
-    {{-- Base Meta Tags --}}
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
+        {{-- Base Meta Tags --}}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    {{-- Custom Meta Tags --}}
-    @yield('meta_tags')
+        {{-- Custom Meta Tags --}}
+        @yield('meta_tags')
 
-    {{-- Title --}}
-    <title>
-        @yield('title_prefix', config('adminlte.title_prefix', ''))
-        @yield('title', config('adminlte.title', 'AdminLTE 3'))
-        @yield('title_postfix', config('adminlte.title_postfix', ''))
-    </title>
+        {{-- Title --}}
+        <title>
+            @yield('title_prefix', config('adminlte.title_prefix', ''))
+            @yield('title', config('adminlte.title', 'AdminLTE 3'))
+            @yield('title_postfix', config('adminlte.title_postfix', ''))
+        </title>
 
-    {{-- Custom stylesheets (pre AdminLTE) --}}
-    @yield('adminlte_css_pre')
+        {{-- Custom stylesheets (pre AdminLTE) --}}
+        @yield('adminlte_css_pre')
 
-    {{-- Base Stylesheets --}}
-    @if(!config('adminlte.enabled_laravel_mix'))
-        <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
-        <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-        <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+        {{-- Base Stylesheets --}}
+        @if(config('adminlte.enabled_laravel_mix', false))
+            <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+        @elseif(config('adminlte.laravel_asset_bundling'))
+            @switch(config('adminlte.laravel_asset_bundling', false))
+                @case('mix')
+                    <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
+                @break
 
-        @if(config('adminlte.google_fonts.allowed', true))
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                @case('vite')
+                    @vite(config('adminlte.laravel_css_path', 'resources/css/app.css'))
+                @break
+
+                @case('vite_spa')
+                @break
+
+                @default
+                    <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
+                    <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
+                    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+
+                    @if(config('adminlte.google_fonts.allowed', true))
+                        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                    @endif
+            @endswitch
         @endif
-    @else
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
-    @endif
 
-    {{-- Extra Configured Plugins Stylesheets --}}
-    @include('adminlte::plugins', ['type' => 'css'])
+        {{-- Extra Configured Plugins Stylesheets --}}
+        @include('adminlte::plugins', ['type' => 'css'])
 
-    {{-- Livewire Styles --}}
-    @if(config('adminlte.livewire'))
-        @if(intval(app()->version()) >= 7)
-            @livewireStyles
-        @else
-            <livewire:styles />
+        {{-- Livewire Styles --}}
+        @if(config('adminlte.livewire'))
+            @if(intval(app()->version()) >= 7)
+                @livewireStyles
+            @else
+                <livewire:styles />
+            @endif
         @endif
-    @endif
 
-    {{-- Custom Stylesheets (post AdminLTE) --}}
-    @yield('adminlte_css')
+        {{-- Custom Stylesheets (post AdminLTE) --}}
+        @yield('adminlte_css')
 
-    {{-- Favicon --}}
-    @if(config('adminlte.use_ico_only'))
-        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-    @elseif(config('adminlte.use_full_favicon'))
-        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-        <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
-        <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
-        <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
-        <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
-        <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
-        <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
-        <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
-        <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
-        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
-        <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
-        <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
-        <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
-        <meta name="msapplication-TileColor" content="#ffffff">
-        <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
-    @endif
-
-</head>
-
-<body class="@yield('classes_body')" @yield('body_data')>
-
-    {{-- Body Content --}}
-    @yield('body')
-
-    {{-- Base Scripts --}}
-    @if(!config('adminlte.enabled_laravel_mix'))
-        <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
-        <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
-        <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-        <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
-    @else
-        <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
-    @endif
-
-    {{-- Extra Configured Plugins Scripts --}}
-    @include('adminlte::plugins', ['type' => 'js'])
-
-    {{-- Livewire Script --}}
-    @if(config('adminlte.livewire'))
-        @if(intval(app()->version()) >= 7)
-            @livewireScripts
-        @else
-            <livewire:scripts />
+        {{-- Favicon --}}
+        @if(config('adminlte.use_ico_only'))
+            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+        @elseif(config('adminlte.use_full_favicon'))
+            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+            <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
+            <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
+            <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
+            <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
+            <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
+            <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
+            <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
+            <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
+            <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
+            <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
+            <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
+            <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
+            <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
+            <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
+            <meta name="msapplication-TileColor" content="#ffffff">
+            <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
         @endif
-    @endif
 
-    {{-- Custom Scripts --}}
-    @yield('adminlte_js')
+    </head>
 
-</body>
+    <body class="@yield('classes_body')" @yield('body_data')>
+
+        {{-- Body Content --}}
+        @yield('body')
+
+        {{-- Base Scripts --}}
+        @if(config('adminlte.enabled_laravel_mix', false))
+            <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
+        @elseif(config('adminlte.laravel_asset_bundling'))
+            @switch(config('adminlte.laravel_asset_bundling'))
+                @case('mix')
+                    <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
+                @break
+
+                @case('vite')
+                    @vite(config('adminlte.laravel_js_path', 'resources/js/app.js'))
+                @break
+
+                @case('vite_spa')
+                    @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
+                @break
+
+                @default
+                    <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
+                    <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+                    <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+                    <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
+            @endswitch
+        @endif
+
+        {{-- Extra Configured Plugins Scripts --}}
+        @include('adminlte::plugins', ['type' => 'js'])
+
+        {{-- Livewire Script --}}
+        @if(config('adminlte.livewire'))
+            @if(intval(app()->version()) >= 7)
+                @livewireScripts
+            @else
+                <livewire:scripts />
+            @endif
+        @endif
+
+        {{-- Custom Scripts --}}
+        @yield('adminlte_js')
+
+    </body>
 
 </html>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -1,139 +1,139 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-    <head>
+<head>
 
-        {{-- Base Meta Tags --}}
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{-- Base Meta Tags --}}
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        {{-- Custom Meta Tags --}}
-        @yield('meta_tags')
+    {{-- Custom Meta Tags --}}
+    @yield('meta_tags')
 
-        {{-- Title --}}
-        <title>
-            @yield('title_prefix', config('adminlte.title_prefix', ''))
-            @yield('title', config('adminlte.title', 'AdminLTE 3'))
-            @yield('title_postfix', config('adminlte.title_postfix', ''))
-        </title>
+    {{-- Title --}}
+    <title>
+        @yield('title_prefix', config('adminlte.title_prefix', ''))
+        @yield('title', config('adminlte.title', 'AdminLTE 3'))
+        @yield('title_postfix', config('adminlte.title_postfix', ''))
+    </title>
 
-        {{-- Custom stylesheets (pre AdminLTE) --}}
-        @yield('adminlte_css_pre')
+    {{-- Custom stylesheets (pre AdminLTE) --}}
+    @yield('adminlte_css_pre')
 
-        {{-- Base Stylesheets --}}
-        @if(config('adminlte.enabled_laravel_mix', false))
-            <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
-        @elseif(config('adminlte.laravel_asset_bundling'))
-            @switch(config('adminlte.laravel_asset_bundling', false))
-                @case('mix')
-                    <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
-                @break
+    {{-- Base Stylesheets --}}
+    @if(config('adminlte.enabled_laravel_mix', false))
+        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+    @elseif(config('adminlte.laravel_asset_bundling'))
+        @switch(config('adminlte.laravel_asset_bundling', false))
+            @case('mix')
+                <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
+            @break
 
-                @case('vite')
-                    @vite(config('adminlte.laravel_css_path', 'resources/css/app.css'))
-                @break
+            @case('vite')
+                @vite(config('adminlte.laravel_css_path', 'resources/css/app.css'))
+            @break
 
-                @case('vite_spa')
-                @break
+            @case('vite_spa')
+            @break
 
-                @default
-                    <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
-                    <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-                    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+            @default
+                <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
+                <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
+                <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
 
-                    @if(config('adminlte.google_fonts.allowed', true))
-                        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
-                    @endif
-            @endswitch
+                @if(config('adminlte.google_fonts.allowed', true))
+                    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                @endif
+        @endswitch
+    @endif
+
+    {{-- Extra Configured Plugins Stylesheets --}}
+    @include('adminlte::plugins', ['type' => 'css'])
+
+    {{-- Livewire Styles --}}
+    @if(config('adminlte.livewire'))
+        @if(intval(app()->version()) >= 7)
+            @livewireStyles
+        @else
+            <livewire:styles />
         @endif
+    @endif
 
-        {{-- Extra Configured Plugins Stylesheets --}}
-        @include('adminlte::plugins', ['type' => 'css'])
+    {{-- Custom Stylesheets (post AdminLTE) --}}
+    @yield('adminlte_css')
 
-        {{-- Livewire Styles --}}
-        @if(config('adminlte.livewire'))
-            @if(intval(app()->version()) >= 7)
-                @livewireStyles
-            @else
-                <livewire:styles />
-            @endif
+    {{-- Favicon --}}
+    @if(config('adminlte.use_ico_only'))
+        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+    @elseif(config('adminlte.use_full_favicon'))
+        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+        <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
+        <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
+        <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
+        <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
+        <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
+        <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
+        <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
+        <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
+        <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
+        <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
+        <meta name="msapplication-TileColor" content="#ffffff">
+        <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
+    @endif
+
+</head>
+
+<body class="@yield('classes_body')" @yield('body_data')>
+
+    {{-- Body Content --}}
+    @yield('body')
+
+    {{-- Base Scripts --}}
+    @if(config('adminlte.enabled_laravel_mix', false))
+        <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
+    @elseif(config('adminlte.laravel_asset_bundling'))
+        @switch(config('adminlte.laravel_asset_bundling'))
+            @case('mix')
+                <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
+            @break
+
+            @case('vite')
+                @vite(config('adminlte.laravel_js_path', 'resources/js/app.js'))
+            @break
+
+            @case('vite_spa')
+                @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
+            @break
+
+            @default
+                <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
+                <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+                <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+                <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
+        @endswitch
+    @endif
+
+    {{-- Extra Configured Plugins Scripts --}}
+    @include('adminlte::plugins', ['type' => 'js'])
+
+    {{-- Livewire Script --}}
+    @if(config('adminlte.livewire'))
+        @if(intval(app()->version()) >= 7)
+            @livewireScripts
+        @else
+            <livewire:scripts />
         @endif
+    @endif
 
-        {{-- Custom Stylesheets (post AdminLTE) --}}
-        @yield('adminlte_css')
+    {{-- Custom Scripts --}}
+    @yield('adminlte_js')
 
-        {{-- Favicon --}}
-        @if(config('adminlte.use_ico_only'))
-            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-        @elseif(config('adminlte.use_full_favicon'))
-            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-            <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
-            <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
-            <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
-            <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
-            <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
-            <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
-            <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
-            <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
-            <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
-            <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
-            <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
-            <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
-            <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
-            <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
-            <meta name="msapplication-TileColor" content="#ffffff">
-            <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
-        @endif
-
-    </head>
-
-    <body class="@yield('classes_body')" @yield('body_data')>
-
-        {{-- Body Content --}}
-        @yield('body')
-
-        {{-- Base Scripts --}}
-        @if(config('adminlte.enabled_laravel_mix', false))
-            <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
-        @elseif(config('adminlte.laravel_asset_bundling'))
-            @switch(config('adminlte.laravel_asset_bundling'))
-                @case('mix')
-                    <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
-                @break
-
-                @case('vite')
-                    @vite(config('adminlte.laravel_js_path', 'resources/js/app.js'))
-                @break
-
-                @case('vite_spa')
-                    @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
-                @break
-
-                @default
-                    <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
-                    <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
-                    <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-                    <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
-            @endswitch
-        @endif
-
-        {{-- Extra Configured Plugins Scripts --}}
-        @include('adminlte::plugins', ['type' => 'js'])
-
-        {{-- Livewire Script --}}
-        @if(config('adminlte.livewire'))
-            @if(intval(app()->version()) >= 7)
-                @livewireScripts
-            @else
-                <livewire:scripts />
-            @endif
-        @endif
-
-        {{-- Custom Scripts --}}
-        @yield('adminlte_js')
-
-    </body>
+</body>
 
 </html>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -98,7 +98,7 @@
     @if(config('adminlte.enabled_laravel_mix', false))
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @else
-        @switch(config('adminlte.laravel_asset_bundling'))
+        @switch(config('adminlte.laravel_asset_bundling', false))
             @case('mix')
                 <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
             @break

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -22,8 +22,8 @@
     {{-- Custom stylesheets (pre AdminLTE) --}}
     @yield('adminlte_css_pre')
 
-    {{-- Base Stylesheets --}}
-    @if (config('adminlte.enabled_laravel_mix', false))
+    {{-- Base Stylesheets (depends on Laravel asset bundling tool) --}}
+    @if(config('adminlte.enabled_laravel_mix', false))
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
     @else
         @switch(config('adminlte.laravel_asset_bundling', false))
@@ -44,9 +44,8 @@
                 <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
                 <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
 
-                @if (config('adminlte.google_fonts.allowed', true))
-                    <link rel="stylesheet"
-                        href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                @if(config('adminlte.google_fonts.allowed', true))
+                    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
                 @endif
         @endswitch
     @endif
@@ -55,8 +54,8 @@
     @include('adminlte::plugins', ['type' => 'css'])
 
     {{-- Livewire Styles --}}
-    @if (config('adminlte.livewire'))
-        @if (intval(app()->version()) >= 7)
+    @if(config('adminlte.livewire'))
+        @if(intval(app()->version()) >= 7)
             @livewireStyles
         @else
             <livewire:styles />
@@ -67,7 +66,7 @@
     @yield('adminlte_css')
 
     {{-- Favicon --}}
-    @if (config('adminlte.use_ico_only'))
+    @if(config('adminlte.use_ico_only'))
         <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
     @elseif(config('adminlte.use_full_favicon'))
         <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
@@ -83,8 +82,7 @@
         <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
         <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
-        <link rel="icon" type="image/png" sizes="192x192"
-            href="{{ asset('favicons/android-icon-192x192.png') }}">
+        <link rel="icon" type="image/png" sizes="192x192" href="{{ asset('favicons/android-icon-192x192.png') }}">
         <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
@@ -97,8 +95,8 @@
     {{-- Body Content --}}
     @yield('body')
 
-    {{-- Base Scripts --}}
-    @if (config('adminlte.enabled_laravel_mix', false))
+    {{-- Base Scripts (depends on Laravel asset bundling tool) --}}
+    @if(config('adminlte.enabled_laravel_mix', false))
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
     @else
         @switch(config('adminlte.laravel_asset_bundling', false))
@@ -107,8 +105,6 @@
             @break
 
             @case('vite')
-            @break
-
             @case('vite_js_only')
             @break
 
@@ -124,8 +120,8 @@
     @include('adminlte::plugins', ['type' => 'js'])
 
     {{-- Livewire Script --}}
-    @if (config('adminlte.livewire'))
-        @if (intval(app()->version()) >= 7)
+    @if(config('adminlte.livewire'))
+        @if(intval(app()->version()) >= 7)
             @livewireScripts
         @else
             <livewire:scripts />

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -1,133 +1,133 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-    <head>
+<head>
 
-        {{-- Base Meta Tags --}}
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{-- Base Meta Tags --}}
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        {{-- Custom Meta Tags --}}
-        @yield('meta_tags')
+    {{-- Custom Meta Tags --}}
+    @yield('meta_tags')
 
-        {{-- Title --}}
-        <title>
-            @yield('title_prefix', config('adminlte.title_prefix', ''))
-            @yield('title', config('adminlte.title', 'AdminLTE 3'))
-            @yield('title_postfix', config('adminlte.title_postfix', ''))
-        </title>
+    {{-- Title --}}
+    <title>
+        @yield('title_prefix', config('adminlte.title_prefix', ''))
+        @yield('title', config('adminlte.title', 'AdminLTE 3'))
+        @yield('title_postfix', config('adminlte.title_postfix', ''))
+    </title>
 
-        {{-- Custom stylesheets (pre AdminLTE) --}}
-        @yield('adminlte_css_pre')
+    {{-- Custom stylesheets (pre AdminLTE) --}}
+    @yield('adminlte_css_pre')
 
-        {{-- Base Stylesheets --}}
-        @if (config('adminlte.enabled_laravel_mix', false))
-            <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+    {{-- Base Stylesheets --}}
+    @if (config('adminlte.enabled_laravel_mix', false))
+        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
+    @else
+        @switch(config('adminlte.laravel_asset_bundling', false))
+            @case('mix')
+                <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
+            @break
+
+            @case('vite')
+                @vite([config('adminlte.laravel_css_path', 'resources/css/app.css'), config('adminlte.laravel_js_path', 'resources/js/app.js')])
+            @break
+
+            @default
+                <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
+                <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
+                <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+
+                @if (config('adminlte.google_fonts.allowed', true))
+                    <link rel="stylesheet"
+                        href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                @endif
+        @endswitch
+    @endif
+
+    {{-- Extra Configured Plugins Stylesheets --}}
+    @include('adminlte::plugins', ['type' => 'css'])
+
+    {{-- Livewire Styles --}}
+    @if (config('adminlte.livewire'))
+        @if (intval(app()->version()) >= 7)
+            @livewireStyles
         @else
-            @switch(config('adminlte.laravel_asset_bundling', false))
-                @case('mix')
-                    <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
-                @break
-
-                @case('vite')
-                    @vite([config('adminlte.laravel_css_path', 'resources/css/app.css'), config('adminlte.laravel_js_path', 'resources/js/app.js')])
-                @break
-
-                @default
-                    <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
-                    <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-                    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
-
-                    @if (config('adminlte.google_fonts.allowed', true))
-                        <link rel="stylesheet"
-                            href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
-                    @endif
-            @endswitch
+            <livewire:styles />
         @endif
+    @endif
 
-        {{-- Extra Configured Plugins Stylesheets --}}
-        @include('adminlte::plugins', ['type' => 'css'])
+    {{-- Custom Stylesheets (post AdminLTE) --}}
+    @yield('adminlte_css')
 
-        {{-- Livewire Styles --}}
-        @if (config('adminlte.livewire'))
-            @if (intval(app()->version()) >= 7)
-                @livewireStyles
-            @else
-                <livewire:styles />
-            @endif
-        @endif
+    {{-- Favicon --}}
+    @if (config('adminlte.use_ico_only'))
+        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+    @elseif(config('adminlte.use_full_favicon'))
+        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+        <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
+        <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
+        <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
+        <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
+        <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
+        <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
+        <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
+        <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
+        <link rel="icon" type="image/png" sizes="192x192"
+            href="{{ asset('favicons/android-icon-192x192.png') }}">
+        <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
+        <meta name="msapplication-TileColor" content="#ffffff">
+        <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
+    @endif
 
-        {{-- Custom Stylesheets (post AdminLTE) --}}
-        @yield('adminlte_css')
+</head>
 
-        {{-- Favicon --}}
-        @if (config('adminlte.use_ico_only'))
-            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-        @elseif(config('adminlte.use_full_favicon'))
-            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-            <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
-            <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
-            <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
-            <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
-            <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
-            <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
-            <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
-            <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
-            <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
-            <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
-            <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
-            <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
-            <link rel="icon" type="image/png" sizes="192x192"
-                href="{{ asset('favicons/android-icon-192x192.png') }}">
-            <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
-            <meta name="msapplication-TileColor" content="#ffffff">
-            <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
-        @endif
+<body class="@yield('classes_body')" @yield('body_data')>
 
-    </head>
+    {{-- Body Content --}}
+    @yield('body')
 
-    <body class="@yield('classes_body')" @yield('body_data')>
+    {{-- Base Scripts --}}
+    @if (config('adminlte.enabled_laravel_mix', false))
+        <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
+    @else
+        @switch(config('adminlte.laravel_asset_bundling', false))
+            @case('mix')
+                <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
+            @break
 
-        {{-- Body Content --}}
-        @yield('body')
+            @case('vite')
+            @break
 
-        {{-- Base Scripts --}}
-        @if (config('adminlte.enabled_laravel_mix', false))
-            <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
+            @default
+                <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
+                <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+                <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+                <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
+        @endswitch
+    @endif
+
+    {{-- Extra Configured Plugins Scripts --}}
+    @include('adminlte::plugins', ['type' => 'js'])
+
+    {{-- Livewire Script --}}
+    @if (config('adminlte.livewire'))
+        @if (intval(app()->version()) >= 7)
+            @livewireScripts
         @else
-            @switch(config('adminlte.laravel_asset_bundling', false))
-                @case('mix')
-                    <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
-                @break
-
-                @case('vite')
-                @break
-
-                @default
-                    <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
-                    <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
-                    <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-                    <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
-            @endswitch
+            <livewire:scripts />
         @endif
+    @endif
 
-        {{-- Extra Configured Plugins Scripts --}}
-        @include('adminlte::plugins', ['type' => 'js'])
+    {{-- Custom Scripts --}}
+    @yield('adminlte_js')
 
-        {{-- Livewire Script --}}
-        @if (config('adminlte.livewire'))
-            @if (intval(app()->version()) >= 7)
-                @livewireScripts
-            @else
-                <livewire:scripts />
-            @endif
-        @endif
-
-        {{-- Custom Scripts --}}
-        @yield('adminlte_js')
-
-    </body>
+</body>
 
 </html>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -35,6 +35,10 @@
                 @vite([config('adminlte.laravel_css_path', 'resources/css/app.css'), config('adminlte.laravel_js_path', 'resources/js/app.js')])
             @break
 
+            @case('vite_js_only')
+                @vite(config('adminlte.laravel_js_path', 'resources/js/app.js'))
+            @break
+
             @default
                 <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
                 <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
@@ -103,6 +107,9 @@
             @break
 
             @case('vite')
+            @break
+
+            @case('vite_js_only')
             @break
 
             @default

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -25,7 +25,7 @@
     {{-- Base Stylesheets --}}
     @if(config('adminlte.enabled_laravel_mix', false))
         <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
-    @elseif(config('adminlte.laravel_asset_bundling'))
+    @else
         @switch(config('adminlte.laravel_asset_bundling', false))
             @case('mix')
                 <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
@@ -97,7 +97,7 @@
     {{-- Base Scripts --}}
     @if(config('adminlte.enabled_laravel_mix', false))
         <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
-    @elseif(config('adminlte.laravel_asset_bundling'))
+    @else
         @switch(config('adminlte.laravel_asset_bundling'))
             @case('mix')
                 <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -36,6 +36,7 @@
             @break
 
             @case('vite_spa')
+                @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
             @break
 
             @default
@@ -108,7 +109,6 @@
             @break
 
             @case('vite_spa')
-                @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
             @break
 
             @default

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -1,139 +1,133 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-<head>
+    <head>
 
-    {{-- Base Meta Tags --}}
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
+        {{-- Base Meta Tags --}}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    {{-- Custom Meta Tags --}}
-    @yield('meta_tags')
+        {{-- Custom Meta Tags --}}
+        @yield('meta_tags')
 
-    {{-- Title --}}
-    <title>
-        @yield('title_prefix', config('adminlte.title_prefix', ''))
-        @yield('title', config('adminlte.title', 'AdminLTE 3'))
-        @yield('title_postfix', config('adminlte.title_postfix', ''))
-    </title>
+        {{-- Title --}}
+        <title>
+            @yield('title_prefix', config('adminlte.title_prefix', ''))
+            @yield('title', config('adminlte.title', 'AdminLTE 3'))
+            @yield('title_postfix', config('adminlte.title_postfix', ''))
+        </title>
 
-    {{-- Custom stylesheets (pre AdminLTE) --}}
-    @yield('adminlte_css_pre')
+        {{-- Custom stylesheets (pre AdminLTE) --}}
+        @yield('adminlte_css_pre')
 
-    {{-- Base Stylesheets --}}
-    @if(config('adminlte.enabled_laravel_mix', false))
-        <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
-    @else
-        @switch(config('adminlte.laravel_asset_bundling', false))
-            @case('mix')
-                <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
-            @break
-
-            @case('vite')
-                @vite(config('adminlte.laravel_css_path', 'resources/css/app.css'))
-            @break
-
-            @case('vite_spa')
-                @vite([config('adminlte.laravel_js_path', 'resources/js/app.js')])
-            @break
-
-            @default
-                <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
-                <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
-                <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
-
-                @if(config('adminlte.google_fonts.allowed', true))
-                    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
-                @endif
-        @endswitch
-    @endif
-
-    {{-- Extra Configured Plugins Stylesheets --}}
-    @include('adminlte::plugins', ['type' => 'css'])
-
-    {{-- Livewire Styles --}}
-    @if(config('adminlte.livewire'))
-        @if(intval(app()->version()) >= 7)
-            @livewireStyles
+        {{-- Base Stylesheets --}}
+        @if (config('adminlte.enabled_laravel_mix', false))
+            <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_mix_css_path', 'css/app.css')) }}">
         @else
-            <livewire:styles />
+            @switch(config('adminlte.laravel_asset_bundling', false))
+                @case('mix')
+                    <link rel="stylesheet" href="{{ mix(config('adminlte.laravel_css_path', 'css/app.css')) }}">
+                @break
+
+                @case('vite')
+                    @vite([config('adminlte.laravel_css_path', 'resources/css/app.css'), config('adminlte.laravel_js_path', 'resources/js/app.js')])
+                @break
+
+                @default
+                    <link rel="stylesheet" href="{{ asset('vendor/fontawesome-free/css/all.min.css') }}">
+                    <link rel="stylesheet" href="{{ asset('vendor/overlayScrollbars/css/OverlayScrollbars.min.css') }}">
+                    <link rel="stylesheet" href="{{ asset('vendor/adminlte/dist/css/adminlte.min.css') }}">
+
+                    @if (config('adminlte.google_fonts.allowed', true))
+                        <link rel="stylesheet"
+                            href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+                    @endif
+            @endswitch
         @endif
-    @endif
 
-    {{-- Custom Stylesheets (post AdminLTE) --}}
-    @yield('adminlte_css')
+        {{-- Extra Configured Plugins Stylesheets --}}
+        @include('adminlte::plugins', ['type' => 'css'])
 
-    {{-- Favicon --}}
-    @if(config('adminlte.use_ico_only'))
-        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-    @elseif(config('adminlte.use_full_favicon'))
-        <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
-        <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
-        <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
-        <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
-        <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
-        <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
-        <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
-        <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
-        <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
-        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
-        <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
-        <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('favicons/android-icon-192x192.png') }}">
-        <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
-        <meta name="msapplication-TileColor" content="#ffffff">
-        <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
-    @endif
+        {{-- Livewire Styles --}}
+        @if (config('adminlte.livewire'))
+            @if (intval(app()->version()) >= 7)
+                @livewireStyles
+            @else
+                <livewire:styles />
+            @endif
+        @endif
 
-</head>
+        {{-- Custom Stylesheets (post AdminLTE) --}}
+        @yield('adminlte_css')
 
-<body class="@yield('classes_body')" @yield('body_data')>
+        {{-- Favicon --}}
+        @if (config('adminlte.use_ico_only'))
+            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+        @elseif(config('adminlte.use_full_favicon'))
+            <link rel="shortcut icon" href="{{ asset('favicons/favicon.ico') }}" />
+            <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('favicons/apple-icon-57x57.png') }}">
+            <link rel="apple-touch-icon" sizes="60x60" href="{{ asset('favicons/apple-icon-60x60.png') }}">
+            <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('favicons/apple-icon-72x72.png') }}">
+            <link rel="apple-touch-icon" sizes="76x76" href="{{ asset('favicons/apple-icon-76x76.png') }}">
+            <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('favicons/apple-icon-114x114.png') }}">
+            <link rel="apple-touch-icon" sizes="120x120" href="{{ asset('favicons/apple-icon-120x120.png') }}">
+            <link rel="apple-touch-icon" sizes="144x144" href="{{ asset('favicons/apple-icon-144x144.png') }}">
+            <link rel="apple-touch-icon" sizes="152x152" href="{{ asset('favicons/apple-icon-152x152.png') }}">
+            <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicons/apple-icon-180x180.png') }}">
+            <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicons/favicon-16x16.png') }}">
+            <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicons/favicon-32x32.png') }}">
+            <link rel="icon" type="image/png" sizes="96x96" href="{{ asset('favicons/favicon-96x96.png') }}">
+            <link rel="icon" type="image/png" sizes="192x192"
+                href="{{ asset('favicons/android-icon-192x192.png') }}">
+            <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
+            <meta name="msapplication-TileColor" content="#ffffff">
+            <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
+        @endif
 
-    {{-- Body Content --}}
-    @yield('body')
+    </head>
 
-    {{-- Base Scripts --}}
-    @if(config('adminlte.enabled_laravel_mix', false))
-        <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
-    @else
-        @switch(config('adminlte.laravel_asset_bundling', false))
-            @case('mix')
-                <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
-            @break
+    <body class="@yield('classes_body')" @yield('body_data')>
 
-            @case('vite')
-                @vite(config('adminlte.laravel_js_path', 'resources/js/app.js'))
-            @break
+        {{-- Body Content --}}
+        @yield('body')
 
-            @case('vite_spa')
-            @break
-
-            @default
-                <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
-                <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
-                <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
-                <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
-        @endswitch
-    @endif
-
-    {{-- Extra Configured Plugins Scripts --}}
-    @include('adminlte::plugins', ['type' => 'js'])
-
-    {{-- Livewire Script --}}
-    @if(config('adminlte.livewire'))
-        @if(intval(app()->version()) >= 7)
-            @livewireScripts
+        {{-- Base Scripts --}}
+        @if (config('adminlte.enabled_laravel_mix', false))
+            <script src="{{ mix(config('adminlte.laravel_mix_js_path', 'js/app.js')) }}"></script>
         @else
-            <livewire:scripts />
+            @switch(config('adminlte.laravel_asset_bundling', false))
+                @case('mix')
+                    <script src="{{ mix(config('adminlte.laravel_js_path', 'js/app.js')) }}"></script>
+                @break
+
+                @case('vite')
+                @break
+
+                @default
+                    <script src="{{ asset('vendor/jquery/jquery.min.js') }}"></script>
+                    <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+                    <script src="{{ asset('vendor/overlayScrollbars/js/jquery.overlayScrollbars.min.js') }}"></script>
+                    <script src="{{ asset('vendor/adminlte/dist/js/adminlte.min.js') }}"></script>
+            @endswitch
         @endif
-    @endif
 
-    {{-- Custom Scripts --}}
-    @yield('adminlte_js')
+        {{-- Extra Configured Plugins Scripts --}}
+        @include('adminlte::plugins', ['type' => 'js'])
 
-</body>
+        {{-- Livewire Script --}}
+        @if (config('adminlte.livewire'))
+            @if (intval(app()->version()) >= 7)
+                @livewireScripts
+            @else
+                <livewire:scripts />
+            @endif
+        @endif
+
+        {{-- Custom Scripts --}}
+        @yield('adminlte_js')
+
+    </body>
 
 </html>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

In config:
I changed the Laravel Mix config lines to a new patter that can be used with Vite
In that new way, the user can choose between 'mix', 'vite' and false.

In master.blade.php:
I included a switch to include the css and js files according to the config.
It is checking if the user is using the old mix config, so it is not a breaking change.

In components
I included a check to prevent scripts from running before jQuery loading finish.

**The wiki must be updated**
https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Menu-Configuration

My tests included

- Using Mix
- Using Vite

Further tests are recommended

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
