### PR TITLE
Add support to disable darkmode routes

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -264,6 +264,7 @@ return [
     'password_reset_url' => 'password/reset',
     'password_email_url' => 'password/email',
     'profile_url' => false,
+    'disable_darkmode_routes' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,5 +18,7 @@ use JeroenNoten\LaravelAdminLte\Http\Controllers\DarkModeController;
 // Dark Mode routes.
 //-----------------------------------------------------------------------------
 
-Route::post('/darkmode/toggle', [DarkModeController::class, 'toggle'])
-    ->name('darkmode.toggle');
+if (! config('adminlte.disable_darkmode_routes', false)) {
+    Route::post('/darkmode/toggle', [DarkModeController::class, 'toggle'])
+        ->name('darkmode.toggle');
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -131,8 +131,8 @@ class ServiceProviderTest extends TestCase
     }
 
     /**
-    * Clear routes and re-register the service provider.
-    */
+     * Clear routes and re-register the service provider.
+     */
     protected function clearRoutesAndReRegisterProvider()
     {
         // Clear the current route collection.

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use JeroenNoten\LaravelAdminLte\AdminLte;
+use JeroenNoten\LaravelAdminLte\AdminLteServiceProvider;
 
 class ServiceProviderTest extends TestCase
 {
@@ -112,10 +113,39 @@ class ServiceProviderTest extends TestCase
         $this->assertTrue(isset($aliases['adminlte-modal']));
     }
 
-    public function testBootLoadRoutes()
+    public function testBootLoadDarkModeRoutes()
     {
-        // Assert the package routes names are registered.
+        // Disable dark mode routes and check.
+
+        config(['adminlte.disable_darkmode_routes' => true]);
+        $this->clearRoutesAndReRegisterProvider();
+
+        $this->assertFalse(Route::has('adminlte.darkmode.toggle'));
+
+        // Enable dark mode routes and check again.
+
+        config(['adminlte.disable_darkmode_routes' => false]);
+        $this->clearRoutesAndReRegisterProvider();
 
         $this->assertTrue(Route::has('adminlte.darkmode.toggle'));
+    }
+
+    /**
+    * Clear routes and re-register the service provider.
+    */
+    protected function clearRoutesAndReRegisterProvider()
+    {
+        // Clear the current route collection.
+
+        Route::setRoutes(new \Illuminate\Routing\RouteCollection());
+
+        // Unregister and register the provider again.
+
+        $provider = $this->app->register(AdminLteServiceProvider::class);
+        $provider->boot();
+
+        // Refresh route names after loading routes again.
+
+        Route::getRoutes()->refreshNameLookups();
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Fix #1026

Add support to disable the **darkmode routes** by using a new configuration option:

```php
'disable_darkmode_routes' => false,
```
You need to set the option to `true` in order to disable darkmode routes.

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
