### PR TITLE
Revert type='module' on components scripts due to backward compatibility issues

### DIFF
--- a/resources/views/components/form/date-range.blade.php
+++ b/resources/views/components/form/date-range.blade.php
@@ -17,7 +17,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         let usrCfg = _AdminLTE_DateRange.parseCfg( @json($config) );

--- a/resources/views/components/form/input-color.blade.php
+++ b/resources/views/components/form/input-color.blade.php
@@ -17,7 +17,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
 

--- a/resources/views/components/form/input-date.blade.php
+++ b/resources/views/components/form/input-date.blade.php
@@ -17,7 +17,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         let usrCfg = _AdminLTE_InputDate.parseCfg( @json($config) );

--- a/resources/views/components/form/input-file-krajee.blade.php
+++ b/resources/views/components/form/input-file-krajee.blade.php
@@ -36,7 +36,7 @@ one provided by the mentioned layout. So instead, we define a new layout.
 {{-- Add the plugin initialization code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
 

--- a/resources/views/components/form/input-file.blade.php
+++ b/resources/views/components/form/input-file.blade.php
@@ -28,7 +28,7 @@
 
 @once
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         bsCustomFileInput.init();

--- a/resources/views/components/form/input-slider.blade.php
+++ b/resources/views/components/form/input-slider.blade.php
@@ -17,7 +17,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         let usrCfg = @json($config);

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -17,7 +17,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         $('#{{ $id }}').bootstrapSwitch( @json($config) );

--- a/resources/views/components/form/select-bs.blade.php
+++ b/resources/views/components/form/select-bs.blade.php
@@ -19,7 +19,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         $('#{{ $id }}').selectpicker( @json($config) );

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -20,7 +20,7 @@
 
 @if($errors->any() && $enableOldSupport)
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
 

--- a/resources/views/components/form/select2.blade.php
+++ b/resources/views/components/form/select2.blade.php
@@ -19,7 +19,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         $('#{{ $id }}').select2( @json($config) );

--- a/resources/views/components/form/text-editor.blade.php
+++ b/resources/views/components/form/text-editor.blade.php
@@ -18,7 +18,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         let usrCfg = @json($config);

--- a/resources/views/components/layout/navbar-darkmode-widget.blade.php
+++ b/resources/views/components/layout/navbar-darkmode-widget.blade.php
@@ -12,7 +12,7 @@
 
 @once
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
 

--- a/resources/views/components/layout/navbar-notification.blade.php
+++ b/resources/views/components/layout/navbar-notification.blade.php
@@ -43,7 +43,7 @@
 
 @if (! is_null($makeUpdateUrl()) && $makeUpdatePeriod() > 0)
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
 

--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -38,7 +38,7 @@
 {{-- Add plugin initialization and configuration code --}}
 
 @push('js')
-<script type="module">
+<script>
 
     $(() => {
         $('#{{ $id }}').DataTable( @json($config) );


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ISSUE
| License                 | MIT

### What's in this PR?

A previous PR that included support to Vite (see #1308 ) added the `type="module"` attribute to the script tags of the components. This was done mainly to solve the error `$ is not a function` when including `jQuery` configuration in VITE, because VITE will loads `jQuery` asynchronously.

However, that change will cause that those scripts will be deferred execution until the `DOMContentLoaded` event of the document fires. This might cause backward compatibility issues with existing code using those components, requiring also to add the `type="module"` attribute to other scripts pushed with `@push('js')`, since otherwise the pushed scripts will execute before the component's scripts.

#### Example:
When you submit a form, most of the form components have a `enable-old-support` property that is used to auto setup the `old()` value submitted within the form when there is a validation error. Some of these components that are based in plugins, like the [SelectBs](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Advanced-Forms-Components#selectbs) use `JQuery` or `Javascript` to perform this task. Now, suppose you already have a view with a `Javascript` code to inspect the value of a `SelectBs` element after a form is submitted in order to enable/disable others elements based on its value. The issue would be that the setup of the old value of the `SelectBs` will run after your value inspecting code, so the value you'll read would actually not be the one shown in the form.

> [!Important]
> Another alternative should be found if you want to use `jQuery` with the VITE bundling tool.

### Checklist

- [x] I tested these changes.