### PR TITLE
Improve Input Switch component

### DIFF
--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -20,7 +20,13 @@
 <script>
 
     $(() => {
-        $('#{{ $id }}').bootstrapSwitch( @json($config) );
+
+        let usrCfg = @json($config);
+        $('#{{ $id }}').bootstrapSwitch(usrCfg);
+
+        // Workaround to ensure correct state setup on initialization.
+
+        $('#{{ $id }}').bootstrapSwitch('state', usrCfg.state ?? false);
 
         // Add support to auto select the previous submitted value in case of
         // validation errors.

--- a/resources/views/components/form/input-switch.blade.php
+++ b/resources/views/components/form/input-switch.blade.php
@@ -9,8 +9,8 @@
 @section('input_group_item')
 
     {{-- Input Switch --}}
-    <input type="checkbox" id="{{ $id }}" name="{{ $name }}" value="true"
-        {{ $attributes->merge(['class' => $makeItemClass()]) }}>
+    <input type="checkbox" id="{{ $id }}" name="{{ $name }}"
+        {{ $attributes->merge(['class' => $makeItemClass(), 'value' => 'true']) }}>
 
 @overwrite
 

--- a/src/View/Components/Form/InputSwitch.php
+++ b/src/View/Components/Form/InputSwitch.php
@@ -24,7 +24,8 @@ class InputSwitch extends InputGroupComponent
     public function __construct(
         $name, $id = null, $label = null, $igroupSize = null, $labelClass = null,
         $fgroupClass = null, $igroupClass = null, $disableFeedback = null,
-        $errorKey = null, $config = [], $enableOldSupport = null
+        $errorKey = null, $config = [], $isChecked = null,
+        $enableOldSupport = null
     ) {
         parent::__construct(
             $name, $id, $label, $igroupSize, $labelClass, $fgroupClass,
@@ -32,6 +33,11 @@ class InputSwitch extends InputGroupComponent
         );
 
         $this->config = is_array($config) ? $config : [];
+
+        if (isset($isChecked)) {
+            $this->config['state'] = ! empty($isChecked);
+        }
+
         $this->enableOldSupport = isset($enableOldSupport);
     }
 

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -408,7 +408,39 @@ class FormComponentsTest extends TestCase
     |--------------------------------------------------------------------------
     */
 
-    public function testInputSwitchComponent()
+    public function testInputSwitchComponentCheckedState()
+    {
+        // Test the state property isn't defined when is-checked attribute
+        // isn't provided.
+
+        $component = new Components\Form\InputSwitch('name');
+
+        $this->assertArrayNotHasKey('state', $component->config);
+
+        // Test the state property is true when is-checked attribute has a
+        // truthy value.
+
+        foreach([true, 1, 'true'] as $v) {
+            $component = new Components\Form\InputSwitch(
+                'name', null, null, null, null, null, null, null, null, null, $v
+            );
+
+            $this->assertTrue($component->config['state']);
+        }
+
+        // Test the state property is false when is-checked attribute has a
+        // falsy value.
+
+        foreach([false, 0, ''] as $v) {
+            $component = new Components\Form\InputSwitch(
+                'name', null, null, null, null, null, null, null, null, null, $v
+            );
+
+            $this->assertFalse($component->config['state']);
+        }
+    }
+
+    public function testInputSwitchComponentWithErrorStyle()
     {
         $component = new Components\Form\InputSwitch(
             'name', null, null, 'lg', null, null, 'igroup-class'
@@ -438,7 +470,7 @@ class FormComponentsTest extends TestCase
         // Test component with old support enabled.
 
         $component = new Components\Form\InputSwitch(
-            'name', null, null, null, null, null, null, null, null, null, true
+            'name', null, null, null, null, null, null, null, null, null, null, true
         );
 
         $this->addInputOnCurrentRequest('name', 'foo');

--- a/tests/Components/FormComponentsTest.php
+++ b/tests/Components/FormComponentsTest.php
@@ -420,7 +420,7 @@ class FormComponentsTest extends TestCase
         // Test the state property is true when is-checked attribute has a
         // truthy value.
 
-        foreach([true, 1, 'true'] as $v) {
+        foreach ([true, 1, 'true'] as $v) {
             $component = new Components\Form\InputSwitch(
                 'name', null, null, null, null, null, null, null, null, null, $v
             );
@@ -431,7 +431,7 @@ class FormComponentsTest extends TestCase
         // Test the state property is false when is-checked attribute has a
         // falsy value.
 
-        foreach([false, 0, ''] as $v) {
+        foreach ([false, 0, ''] as $v) {
             $component = new Components\Form\InputSwitch(
                 'name', null, null, null, null, null, null, null, null, null, $v
             );


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

This PR allows specifying a custom value attribute when using the `<x-adminlte-input-switch>` component, which defaults to `'true'` when not specified. Examples:

```blade
{{-- The next component will submit 'true' when the switch is on --}}
<x-adminlte-input-switch name="example1"/>

{{-- The next component will submit '1' when the switch is on --}}
<x-adminlte-input-switch name="example1" value="1"/>
```

This will fix #1316 

Also a new `is-checked` attribute (of boolean type) was added to use as an alternative of the standard `checked`, to simplify the usage of the component for next situation:

```blade
{{-- Instead of next code --}}
@if($isCheckboxChecked)
    <x-adminlte-input-switch name="example1" checked/>
@else
    <x-adminlte-input-switch name="example1"/>
@endif

{{-- You can now simply use --}}
<x-adminlte-input-switch name="example1" is-checked="{{ $isCheckboxChecked }}"/>
```



### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
