### PR TITLE
Allow customizing field to use with login procedure

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -139,7 +139,7 @@ return [
     'usermenu_image' => false,
     'usermenu_desc' => false,
     'usermenu_profile_url' => false,
-
+    
     /*
     |--------------------------------------------------------------------------
     | Layout
@@ -265,7 +265,7 @@ return [
     'password_email_url' => 'password/email',
     'profile_url' => false,
     'disable_darkmode_routes' => false,
-
+    'username_field' => 'email', // This to use it inside LoginController username() return Config('adminlte.usernamefield')
     /*
     |--------------------------------------------------------------------------
     | Laravel Asset Bundling

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,6 +6,7 @@
 
 @php( $login_url = View::getSection('login_url') ?? config('adminlte.login_url', 'login') )
 @php( $register_url = View::getSection('register_url') ?? config('adminlte.register_url', 'register') )
+@php( $username = config('adminlte.username_field', 'email') )
 @php( $password_reset_url = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset') )
 
 @if (config('adminlte.use_route_url', false))
@@ -26,8 +27,8 @@
 
         {{-- Email field --}}
         <div class="input-group mb-3">
-            <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                   value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
+            <input type="{{ $username }}" name="{{ $username }}" class="form-control @error($username) is-invalid @enderror"
+                   value="{{ old($username) }}" placeholder="{{ __('adminlte::adminlte.username') }}" autofocus>
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -35,7 +36,7 @@
                 </div>
             </div>
 
-            @error('email')
+            @error($username)
                 <span class="invalid-feedback" role="alert">
                     <strong>{{ $message }}</strong>
                 </span>


### PR DESCRIPTION
| Question             | Answer
| ----------------------- | -----------------------
| Pull request type |  ENHANCEMENT 
| License                 | MIT

### What's in this PR?

<!-- Explain what the changes in this Pull Request (PR) do. -->
I don't want to use `Email` as field to login, I want to customize it, so I have add to adminlte config `username_field` in this package in view `login.blade.php` also change the field of username. Before it was only email now it has been able to customize.

Developer must add new function in LoginController:
```php
protected function username() {
    return config('adminlte.username_field');
}
```

### Checklist

- [ ] I tested these changes.