### PR TITLE
Improve style on Datatables component when using responsive extension

### DIFF
--- a/resources/views/components/tool/datatable.blade.php
+++ b/resources/views/components/tool/datatable.blade.php
@@ -47,7 +47,7 @@
 </script>
 @endpush
 
-{{-- Add CSS styling --}}
+{{-- Add CSS styling for beautify option --}}
 
 @isset($beautify)
     @push('css')
@@ -59,3 +59,20 @@
     </style>
     @endpush
 @endisset
+
+{{-- Improve CSS styling when using responsive extension --}}
+
+@if(! empty($config['responsive']))
+    @once
+    @push('css')
+    <style type="text/css">
+        .dataTable .child .dtr-details {
+            width: 100%;
+        }
+        .dataTable .child .dtr-data {
+            float: right;
+        }
+    </style>
+    @endpush
+    @endonce
+@endif


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Improve the `CSS` style of [Datatables component](https://github.com/jeroennoten/Laravel-AdminLTE/wiki/Tool-Components#datatables) when using it with the [responsive extension](https://datatables.net/extensions/responsive/). As an example check next image from before and after applying this PR:

#### Before
![384152371-a2f03faa-c0d8-4fa8-ac99-4bb9b2147898](https://github.com/user-attachments/assets/479f3387-bd3b-4be6-a6d5-4c6c3d591434)

#### After
![384152425-5a85f838-5ff6-4540-871a-c1bc99155234](https://github.com/user-attachments/assets/92370020-5b23-43af-986a-fe2598586892)

Related to #1319 

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
