### PR TITLE
Allow auth views to use dark-mode config

### DIFF
--- a/resources/views/auth/auth-page.blade.php
+++ b/resources/views/auth/auth-page.blade.php
@@ -1,19 +1,27 @@
 @extends('adminlte::master')
 
-@php( $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home') )
+@php
+    $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $dashboard_url = $dashboard_url ? route($dashboard_url) : '' )
-@else
-    @php( $dashboard_url = $dashboard_url ? url($dashboard_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $dashboard_url = $dashboard_url ? route($dashboard_url) : '';
+    } else {
+        $dashboard_url = $dashboard_url ? url($dashboard_url) : '';
+    }
+
+    $bodyClasses = ($auth_type ?? 'login') . '-page';
+
+    if (! empty(config('adminlte.layout_dark_mode', null))) {
+        $bodyClasses .= ' dark-mode';
+    }
+@endphp
 
 @section('adminlte_css')
     @stack('css')
     @yield('css')
 @stop
 
-@section('classes_body'){{ ($auth_type ?? 'login') . '-page' }}@stop
+@section('classes_body'){{ $bodyClasses }}@stop
 
 @section('body')
     <div class="{{ $auth_type ?? 'login' }}-box">


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Allows the authentication views for the `laravel/ui` legacy package to use the **dark-mode** configuration of the package.

Fix #1314 

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
