### PR TITLE
Improve auth views for legacy laravel/ui

### DIFF
--- a/resources/views/auth/auth-page.blade.php
+++ b/resources/views/auth/auth-page.blade.php
@@ -1,15 +1,16 @@
 @extends('adminlte::master')
 
 @php
-    $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home');
+    $authType = $authType ?? 'login';
+    $dashboardUrl = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home');
 
     if (config('adminlte.use_route_url', false)) {
-        $dashboard_url = $dashboard_url ? route($dashboard_url) : '';
+        $dashboardUrl = $dashboardUrl ? route($dashboardUrl) : '';
     } else {
-        $dashboard_url = $dashboard_url ? url($dashboard_url) : '';
+        $dashboardUrl = $dashboardUrl ? url($dashboardUrl) : '';
     }
 
-    $bodyClasses = ($auth_type ?? 'login') . '-page';
+    $bodyClasses = "{$authType}-page";
 
     if (! empty(config('adminlte.layout_dark_mode', null))) {
         $bodyClasses .= ' dark-mode';
@@ -24,11 +25,11 @@
 @section('classes_body'){{ $bodyClasses }}@stop
 
 @section('body')
-    <div class="{{ $auth_type ?? 'login' }}-box">
+    <div class="{{ $authType }}-box">
 
         {{-- Logo --}}
-        <div class="{{ $auth_type ?? 'login' }}-logo">
-            <a href="{{ $dashboard_url }}">
+        <div class="{{ $authType }}-logo">
+            <a href="{{ $dashboardUrl }}">
 
                 {{-- Logo Image --}}
                 @if (config('adminlte.auth_logo.enabled', false))
@@ -67,7 +68,7 @@
             @endif
 
             {{-- Card Body --}}
-            <div class="card-body {{ $auth_type ?? 'login' }}-card-body {{ config('adminlte.classes_auth_body', '') }}">
+            <div class="card-body {{ $authType }}-card-body {{ config('adminlte.classes_auth_body', '') }}">
                 @yield('auth_body')
             </div>
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,33 +1,35 @@
-@extends('adminlte::auth.auth-page', ['auth_type' => 'login'])
+@extends('adminlte::auth.auth-page', ['authType' => 'login'])
 
 @section('adminlte_css_pre')
     <link rel="stylesheet" href="{{ asset('vendor/icheck-bootstrap/icheck-bootstrap.min.css') }}">
 @stop
 
-@php( $login_url = View::getSection('login_url') ?? config('adminlte.login_url', 'login') )
-@php( $register_url = View::getSection('register_url') ?? config('adminlte.register_url', 'register') )
-@php( $password_reset_url = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset') )
+@php
+    $loginUrl = View::getSection('login_url') ?? config('adminlte.login_url', 'login');
+    $registerUrl = View::getSection('register_url') ?? config('adminlte.register_url', 'register');
+    $passResetUrl = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $login_url = $login_url ? route($login_url) : '' )
-    @php( $register_url = $register_url ? route($register_url) : '' )
-    @php( $password_reset_url = $password_reset_url ? route($password_reset_url) : '' )
-@else
-    @php( $login_url = $login_url ? url($login_url) : '' )
-    @php( $register_url = $register_url ? url($register_url) : '' )
-    @php( $password_reset_url = $password_reset_url ? url($password_reset_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $loginUrl = $loginUrl ? route($loginUrl) : '';
+        $registerUrl = $registerUrl ? route($registerUrl) : '';
+        $passResetUrl = $passResetUrl ? route($passResetUrl) : '';
+    } else {
+        $loginUrl = $loginUrl ? url($loginUrl) : '';
+        $registerUrl = $registerUrl ? url($registerUrl) : '';
+        $passResetUrl = $passResetUrl ? url($passResetUrl) : '';
+    }
+@endphp
 
 @section('auth_header', __('adminlte::adminlte.login_message'))
 
 @section('auth_body')
-    <form action="{{ $login_url }}" method="post">
+    <form action="{{ $loginUrl }}" method="post">
         @csrf
 
         {{-- Email field --}}
         <div class="input-group mb-3">
             <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                   value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
+                value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -45,7 +47,7 @@
         {{-- Password field --}}
         <div class="input-group mb-3">
             <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
-                   placeholder="{{ __('adminlte::adminlte.password') }}">
+                placeholder="{{ __('adminlte::adminlte.password') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -79,24 +81,23 @@
                 </button>
             </div>
         </div>
-
     </form>
 @stop
 
 @section('auth_footer')
     {{-- Password reset link --}}
-    @if($password_reset_url)
+    @if($passResetUrl)
         <p class="my-0">
-            <a href="{{ $password_reset_url }}">
+            <a href="{{ $passResetUrl }}">
                 {{ __('adminlte::adminlte.i_forgot_my_password') }}
             </a>
         </p>
     @endif
 
     {{-- Register link --}}
-    @if($register_url)
+    @if($registerUrl)
         <p class="my-0">
-            <a href="{{ $register_url }}">
+            <a href="{{ $registerUrl }}">
                 {{ __('adminlte::adminlte.register_a_new_membership') }}
             </a>
         </p>

--- a/resources/views/auth/passwords/confirm.blade.php
+++ b/resources/views/auth/passwords/confirm.blade.php
@@ -6,23 +6,25 @@
 
 @section('classes_body', 'lockscreen')
 
-@php( $password_reset_url = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset') )
-@php( $dashboard_url = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home') )
+@php
+    $passResetUrl = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset');
+    $dashboardUrl = View::getSection('dashboard_url') ?? config('adminlte.dashboard_url', 'home');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $password_reset_url = $password_reset_url ? route($password_reset_url) : '' )
-    @php( $dashboard_url = $dashboard_url ? route($dashboard_url) : '' )
-@else
-    @php( $password_reset_url = $password_reset_url ? url($password_reset_url) : '' )
-    @php( $dashboard_url = $dashboard_url ? url($dashboard_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $passResetUrl = $passResetUrl ? route($passResetUrl) : '';
+        $dashboardUrl = $dashboardUrl ? route($dashboardUrl) : '';
+    } else {
+        $passResetUrl = $passResetUrl ? url($passResetUrl) : '';
+        $dashboardUrl = $dashboardUrl ? url($dashboardUrl) : '';
+    }
+@endphp
 
 @section('body')
     <div class="lockscreen-wrapper">
 
         {{-- Lockscreen logo --}}
         <div class="lockscreen-logo">
-            <a href="{{ $dashboard_url }}">
+            <a href="{{ $dashboardUrl }}">
                 <img src="{{ asset(config('adminlte.logo_img')) }}" height="50">
                 {!! config('adminlte.logo', '<b>Admin</b>LTE') !!}
             </a>
@@ -42,13 +44,13 @@
             @endif
 
             <form method="POST" action="{{ route('password.confirm') }}"
-                  class="lockscreen-credentials @if(!config('adminlte.usermenu_image'))ml-0 @endif">
+                class="lockscreen-credentials @if(! config('adminlte.usermenu_image')) ml-0 @endif">
                 @csrf
 
                 <div class="input-group">
                     <input id="password" type="password" name="password"
-                           class="form-control @error('password') is-invalid @enderror"
-                           placeholder="{{ __('adminlte::adminlte.password') }}" required autofocus>
+                        class="form-control @error('password') is-invalid @enderror"
+                        placeholder="{{ __('adminlte::adminlte.password') }}" required autofocus>
 
                     <div class="input-group-append">
                         <button type="submit" class="btn">
@@ -56,7 +58,6 @@
                         </button>
                     </div>
                 </div>
-
             </form>
         </div>
 
@@ -74,7 +75,7 @@
 
         {{-- Additional links --}}
         <div class="text-center">
-            <a href="{{ $password_reset_url }}">
+            <a href="{{ $passResetUrl }}">
                 {{ __('adminlte::adminlte.i_forgot_my_password') }}
             </a>
         </div>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,12 +1,14 @@
-@extends('adminlte::auth.auth-page', ['auth_type' => 'login'])
+@extends('adminlte::auth.auth-page', ['authType' => 'login'])
 
-@php( $password_email_url = View::getSection('password_email_url') ?? config('adminlte.password_email_url', 'password/email') )
+@php
+    $passEmailUrl = View::getSection('password_email_url') ?? config('adminlte.password_email_url', 'password/email');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $password_email_url = $password_email_url ? route($password_email_url) : '' )
-@else
-    @php( $password_email_url = $password_email_url ? url($password_email_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $passEmailUrl = $passEmailUrl ? route($passEmailUrl) : '';
+    } else {
+        $passEmailUrl = $passEmailUrl ? url($passEmailUrl) : '';
+    }
+@endphp
 
 @section('auth_header', __('adminlte::adminlte.password_reset_message'))
 
@@ -18,13 +20,13 @@
         </div>
     @endif
 
-    <form action="{{ $password_email_url }}" method="post">
+    <form action="{{ $passEmailUrl }}" method="post">
         @csrf
 
         {{-- Email field --}}
         <div class="input-group mb-3">
             <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                   value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
+                value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -44,7 +46,6 @@
             <span class="fas fa-share-square"></span>
             {{ __('adminlte::adminlte.send_password_reset_link') }}
         </button>
-
     </form>
 
 @stop

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,17 +1,19 @@
-@extends('adminlte::auth.auth-page', ['auth_type' => 'login'])
+@extends('adminlte::auth.auth-page', ['authType' => 'login'])
 
-@php( $password_reset_url = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset') )
+@php
+    $passResetUrl = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $password_reset_url = $password_reset_url ? route($password_reset_url) : '' )
-@else
-    @php( $password_reset_url = $password_reset_url ? url($password_reset_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $passResetUrl = $passResetUrl ? route($passResetUrl) : '';
+    } else {
+        $passResetUrl = $passResetUrl ? url($passResetUrl) : '';
+    }
+@endphp
 
 @section('auth_header', __('adminlte::adminlte.password_reset_message'))
 
 @section('auth_body')
-    <form action="{{ $password_reset_url }}" method="post">
+    <form action="{{ $passResetUrl }}" method="post">
         @csrf
 
         {{-- Token field --}}
@@ -20,7 +22,7 @@
         {{-- Email field --}}
         <div class="input-group mb-3">
             <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                   value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
+                value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}" autofocus>
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -38,7 +40,7 @@
         {{-- Password field --}}
         <div class="input-group mb-3">
             <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
-                   placeholder="{{ __('adminlte::adminlte.password') }}">
+                placeholder="{{ __('adminlte::adminlte.password') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -56,8 +58,8 @@
         {{-- Password confirmation field --}}
         <div class="input-group mb-3">
             <input type="password" name="password_confirmation"
-                   class="form-control @error('password_confirmation') is-invalid @enderror"
-                   placeholder="{{ trans('adminlte::adminlte.retype_password') }}">
+                class="form-control @error('password_confirmation') is-invalid @enderror"
+                placeholder="{{ trans('adminlte::adminlte.retype_password') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -77,6 +79,5 @@
             <span class="fas fa-sync-alt"></span>
             {{ __('adminlte::adminlte.reset_password') }}
         </button>
-
     </form>
 @stop

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,26 +1,28 @@
-@extends('adminlte::auth.auth-page', ['auth_type' => 'register'])
+@extends('adminlte::auth.auth-page', ['authType' => 'register'])
 
-@php( $login_url = View::getSection('login_url') ?? config('adminlte.login_url', 'login') )
-@php( $register_url = View::getSection('register_url') ?? config('adminlte.register_url', 'register') )
+@php
+    $loginUrl = View::getSection('login_url') ?? config('adminlte.login_url', 'login');
+    $registerUrl = View::getSection('register_url') ?? config('adminlte.register_url', 'register');
 
-@if (config('adminlte.use_route_url', false))
-    @php( $login_url = $login_url ? route($login_url) : '' )
-    @php( $register_url = $register_url ? route($register_url) : '' )
-@else
-    @php( $login_url = $login_url ? url($login_url) : '' )
-    @php( $register_url = $register_url ? url($register_url) : '' )
-@endif
+    if (config('adminlte.use_route_url', false)) {
+        $loginUrl = $loginUrl ? route($loginUrl) : '';
+        $registerUrl = $registerUrl ? route($registerUrl) : '';
+    } else {
+        $loginUrl = $loginUrl ? url($loginUrl) : '';
+        $registerUrl = $registerUrl ? url($registerUrl) : '';
+    }
+@endphp
 
 @section('auth_header', __('adminlte::adminlte.register_message'))
 
 @section('auth_body')
-    <form action="{{ $register_url }}" method="post">
+    <form action="{{ $registerUrl }}" method="post">
         @csrf
 
         {{-- Name field --}}
         <div class="input-group mb-3">
             <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
-                   value="{{ old('name') }}" placeholder="{{ __('adminlte::adminlte.full_name') }}" autofocus>
+                value="{{ old('name') }}" placeholder="{{ __('adminlte::adminlte.full_name') }}" autofocus>
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -38,7 +40,7 @@
         {{-- Email field --}}
         <div class="input-group mb-3">
             <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                   value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}">
+                value="{{ old('email') }}" placeholder="{{ __('adminlte::adminlte.email') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -56,7 +58,7 @@
         {{-- Password field --}}
         <div class="input-group mb-3">
             <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
-                   placeholder="{{ __('adminlte::adminlte.password') }}">
+                placeholder="{{ __('adminlte::adminlte.password') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -74,8 +76,8 @@
         {{-- Confirm password field --}}
         <div class="input-group mb-3">
             <input type="password" name="password_confirmation"
-                   class="form-control @error('password_confirmation') is-invalid @enderror"
-                   placeholder="{{ __('adminlte::adminlte.retype_password') }}">
+                class="form-control @error('password_confirmation') is-invalid @enderror"
+                placeholder="{{ __('adminlte::adminlte.retype_password') }}">
 
             <div class="input-group-append">
                 <div class="input-group-text">
@@ -95,13 +97,12 @@
             <span class="fas fa-user-plus"></span>
             {{ __('adminlte::adminlte.register') }}
         </button>
-
     </form>
 @stop
 
 @section('auth_footer')
     <p class="my-0">
-        <a href="{{ $login_url }}">
+        <a href="{{ $loginUrl }}">
             {{ __('adminlte::adminlte.i_already_have_a_membership') }}
         </a>
     </p>

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::auth.auth-page', ['auth_type' => 'login'])
+@extends('adminlte::auth.auth-page', ['authType' => 'login'])
 
 @section('auth_header', __('adminlte::adminlte.verify_message'))
 
@@ -17,7 +17,7 @@
         @csrf
         <button type="submit" class="btn btn-link p-0 m-0 align-baseline">
             {{ __('adminlte::adminlte.verify_request_another') }}
-        </button>.
+        </button>
     </form>
 
 @stop


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Improve the set of authentication views that are used with the legacy `laravel/ui` package.
- Enforce usage of `@php ... @endphp` blocks.
- Enforce usage of camel case variables with php.

### Checklist

- [x] I tested these changes.