### PR TITLE
Bump Vitepress from 1.4.x to 1.6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,41 +6,38 @@
         "": {
             "license": "ISC",
             "devDependencies": {
-                "vitepress": "^1.4.0"
+                "vitepress": "^1.6.0"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+            "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+                "@algolia/autocomplete-shared": "1.17.7"
             }
         },
         "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+            "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+            "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -48,334 +45,220 @@
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+            "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
             "dev": true,
-            "license": "MIT",
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
                 "algoliasearch": ">= 4.9.1 < 6"
             }
         },
-        "node_modules/@algolia/cache-browser-local-storage": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
-            "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
+        "node_modules/@algolia/client-abtesting": {
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.3.tgz",
+            "integrity": "sha512-wPOzHYSsW+H97JkBLmnlOdJSpbb9mIiuNPycUCV5DgzSkJFaI/OFxXfZXAh1gqxK+hf0miKue1C9bltjWljrNA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/cache-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
-            "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@algolia/cache-in-memory": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
-            "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
-            "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
-            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.3.tgz",
+            "integrity": "sha512-XE3iduH9lA7iTQacDGofBQyIyIgaX8qbTRRdj1bOCmfzc9b98CoiMwhNwdTifmmMewmN0EhVF3hP8KjKWwX7Yw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.8.1.tgz",
-            "integrity": "sha512-MLX/gipPFEhJPCExsxXf9tnt+kLfWCe9JWRp1adcoVySkhzPxpIeSiWaQaOqyy0TYIgIpdeVx/emlBT9Ni8GFw==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.3.tgz",
+            "integrity": "sha512-IYRd/A/R3BXeaQVT2805lZEdWo54v39Lqa7ABOxIYnUvX2vvOMW1AyzCuT0U7Q+uPdD4UW48zksUKRixShcWxA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/client-insights": {
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.3.tgz",
+            "integrity": "sha512-QGc/bmDUBgzB71rDL6kihI2e1Mx6G6PxYO5Ks84iL3tDcIel1aFuxtRF14P8saGgdIe1B6I6QkpkeIddZ6vWQw==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
-            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.3.tgz",
+            "integrity": "sha512-zuM31VNPDJ1LBIwKbYGz/7+CSm+M8EhlljDamTg8AnDilnCpKjBebWZR5Tftv/FdWSro4tnYGOIz1AURQgZ+tQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+        "node_modules/@algolia/client-query-suggestions": {
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.3.tgz",
+            "integrity": "sha512-Nn872PuOI8qzi1bxMMhJ0t2AzVBqN01jbymBQOkypvZHrrjZPso3iTpuuLLo9gi3yc/08vaaWTAwJfPhxPwJUw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.8.1.tgz",
-            "integrity": "sha512-zy3P4fI28GfzKihUw5+L76pEedQxyLDiMsdDYEWghIz8yAnELDatPNEThyWuUk8fD0PeVoCi1M4tr1iz00fOtQ==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.3.tgz",
+            "integrity": "sha512-9+Fm1ahV8/2goSIPIqZnVitV5yHW5E5xTdKy33xnqGd45A9yVv5tTkudWzEXsbfBB47j9Xb3uYPZjAvV5RHbKA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.8.1",
-                "@algolia/requester-browser-xhr": "5.8.1",
-                "@algolia/requester-fetch": "5.8.1",
-                "@algolia/requester-node-http": "5.8.1"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/logger-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
-            "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
+        "node_modules/@algolia/ingestion": {
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.3.tgz",
+            "integrity": "sha512-5GHNTiZ3saLjTNyr6WkP5hzDg2eFFAYWomvPcm9eHWskjzXt8R0IOiW9kkTS6I6hXBwN5H9Zna5mZDSqqJdg+g==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@algolia/logger-console": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
-            "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
-            "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/logger-common": "4.24.0"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/monitoring": {
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.3.tgz",
+            "integrity": "sha512-KUWQbTPoRjP37ivXSQ1+lWMfaifCCMzTnEcEnXwAmherS5Tp7us6BAqQDMGOD4E7xyaS2I8pto6WlOzxH+CxmA==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
-            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.3.tgz",
+            "integrity": "sha512-oo/gG77xTTTclkrdFem0Kmx5+iSRFiwuRRdxZETDjwzCI7svutdbwBgV/Vy4D4QpYaX4nhY/P43k84uEowCE4Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.8.1.tgz",
-            "integrity": "sha512-x0iULVrx5PocaYBqH+G6jyEsEHf7m5FDiZW7CP8AaJdzdCzoUyx7YH6e6TSCNlkFEjwmn8uj05coN8uljCHXTg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@algolia/client-common": "5.8.1"
+                "@algolia/client-common": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/requester-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
-            "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
+        "node_modules/@algolia/requester-browser-xhr": {
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.3.tgz",
+            "integrity": "sha512-BkkW7otbiI/Er1AiEPZs1h7lxbtSO9p09jFhv3/iT8/0Yz0CY79VJ9iq+Wv1+dq/l0OxnMpBy8mozrieGA3mXQ==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "@algolia/client-common": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.8.1.tgz",
-            "integrity": "sha512-SRWGrNsKSLNYIDNlVKVkf4wxsm6h57xI+0b8JPm0wUe0ly0jymAgQU2yW2GDzNuXyiPiS7U1oWwaVGs71IT5Pw==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.3.tgz",
+            "integrity": "sha512-eAVlXz7UNzTsA1EDr+p0nlIH7WFxo7k3NMxYe8p38DH8YVWLgm2MgOVFUMNg9HCi6ZNOi/A2w/id2ZZ4sKgUOw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.8.1"
+                "@algolia/client-common": "5.20.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.8.1.tgz",
-            "integrity": "sha512-pYylr2gBsV68E88bltaVoJHIc3YNIllVmA12d+jefAcutR9ytQM7iP6dXbCYuRqF4CHF32YvZuwvqNI3J4kowA==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.3.tgz",
+            "integrity": "sha512-FqR3pQPfHfQyX1wgcdK6iyqu86yP76MZd4Pzj1y/YLMj9rRmRCY0E0AffKr//nrOFEwv6uY8BQY4fd9/6b0ZCg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.8.1"
+                "@algolia/client-common": "5.20.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/transporter": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
-            "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-            "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-            "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-            "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+            "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.8"
+                "@babel/types": "^7.26.9"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -385,49 +268,44 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.8",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-            "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+            "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.2.tgz",
-            "integrity": "sha512-vKNZepO2j7MrYBTZIGXvlUOIR+v9KRf70FApRgovWrj3GTs1EITz/Xb0AOlm1xsQBp16clVZj1SY/qaOJbQtZw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+            "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+            "dev": true
         },
         "node_modules/@docsearch/js": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.2.tgz",
-            "integrity": "sha512-pS4YZF+VzUogYrkblCucQ0Oy2m8Wggk8Kk7lECmZM60hTbaydSIhJTTiCrmoxtBqV8wxORnOqcqqOfbmkkQEcA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+            "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@docsearch/react": "3.6.2",
+                "@docsearch/react": "3.8.2",
                 "preact": "^10.0.0"
             }
         },
         "node_modules/@docsearch/react": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.2.tgz",
-            "integrity": "sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+            "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-core": "1.9.3",
-                "@algolia/autocomplete-preset-algolia": "1.9.3",
-                "@docsearch/css": "3.6.2",
-                "algoliasearch": "^4.19.1"
+                "@algolia/autocomplete-core": "1.17.7",
+                "@algolia/autocomplete-preset-algolia": "1.17.7",
+                "@docsearch/css": "3.8.2",
+                "algoliasearch": "^5.14.2"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 19.0.0",
@@ -450,15 +328,142 @@
                 }
             }
         },
-        "node_modules/@esbuild/linux-x64": {
+        "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -467,106 +472,588 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "license": "MIT"
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-            "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@iconify-json/simple-icons": {
+            "version": "1.2.25",
+            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.25.tgz",
+            "integrity": "sha512-2E1/gOCO97rF6usfhhiXxwzCb+UhdEsxW3lW1Sew+xZY0COY6dp82Z/r1rUt2fWKneWjuoGcNeJHHXQyG8mIuw==",
+            "dev": true,
+            "dependencies": {
+                "@iconify/types": "*"
+            }
+        },
+        "node_modules/@iconify/types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+            "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
+            "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
+            "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
+            "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
+            "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
+            "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
+            "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
+            "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@shikijs/core": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.0.tgz",
-            "integrity": "sha512-S8sMe4q71TJAW+qG93s5VaiihujRK6rqDFqBnxqvga/3LvqHEnxqBIOPkt//IdXVtHkQWKu4nOQNk0uBGicU7Q==",
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
+            "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
+            "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
+            "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
+            "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
+            "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
+            "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
+            "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
+            "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
+            "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
+            "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
+            "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
+            "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@shikijs/core": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+            "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+            "dev": true,
             "dependencies": {
-                "@shikijs/engine-javascript": "1.22.0",
-                "@shikijs/engine-oniguruma": "1.22.0",
-                "@shikijs/types": "1.22.0",
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/engine-javascript": "2.5.0",
+                "@shikijs/engine-oniguruma": "2.5.0",
+                "@shikijs/types": "2.5.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.3"
+                "hast-util-to-html": "^9.0.4"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.0.tgz",
-            "integrity": "sha512-AeEtF4Gcck2dwBqCFUKYfsCq0s+eEbCEbkUuFou53NZ0sTGnJnJ/05KHQFZxpii5HMXbocV9URYVowOP2wH5kw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+            "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.0",
-                "@shikijs/vscode-textmate": "^9.3.0",
-                "oniguruma-to-js": "0.4.3"
+                "@shikijs/types": "2.5.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "oniguruma-to-es": "^3.1.0"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.0.tgz",
-            "integrity": "sha512-5iBVjhu/DYs1HB0BKsRRFipRrD7rqjxlWTj4F2Pf+nQSPqc3kcyqFFeZXnBMzDf0HdqaFVvhDRAGiYNvyLP+Mw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+            "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.0",
-                "@shikijs/vscode-textmate": "^9.3.0"
+                "@shikijs/types": "2.5.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@shikijs/langs": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+            "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+            "dev": true,
+            "dependencies": {
+                "@shikijs/types": "2.5.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+            "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+            "dev": true,
+            "dependencies": {
+                "@shikijs/types": "2.5.0"
             }
         },
         "node_modules/@shikijs/transformers": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.22.0.tgz",
-            "integrity": "sha512-k7iMOYuGQA62KwAuJOQBgH2IQb5vP8uiB3lMvAMGUgAMMurePOx3Z7oNqJdcpxqZP6I9cc7nc4DNqSKduCxmdg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+            "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "shiki": "1.22.0"
+                "@shikijs/core": "2.5.0",
+                "@shikijs/types": "2.5.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.0.tgz",
-            "integrity": "sha512-Fw/Nr7FGFhlQqHfxzZY8Cwtwk5E9nKDUgeLjZgt3UuhcM3yJR9xj3ZGNravZZok8XmEZMiYkSMTPlPkULB8nww==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+            "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             }
         },
         "node_modules/@shikijs/vscode-textmate": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
-            "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
-            "dev": true,
-            "license": "MIT"
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/hast": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
             "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -594,7 +1081,6 @@
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
             "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -610,110 +1096,100 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/web-bluetooth": {
             "version": "0.0.20",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
             "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "dev": true
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.4.tgz",
-            "integrity": "sha512-N2XSI2n3sQqp5w7Y/AN/L2XDjBIRGqXko+eDp42sydYSBeJuSm5a1sLf8zakmo8u7tA8NmBgoDLA1HeOESjp9A==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.1.tgz",
+            "integrity": "sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0",
+                "vite": "^5.0.0 || ^6.0.0",
                 "vue": "^3.2.25"
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.11.tgz",
-            "integrity": "sha512-PwAdxs7/9Hc3ieBO12tXzmTD+Ln4qhT/56S+8DvrrZ4kLDn4Z/AMUr8tXJD0axiJBS0RKIoNaR0yMuQB9v9Udg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.11",
+                "@vue/shared": "3.5.13",
                 "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.11.tgz",
-            "integrity": "sha512-pyGf8zdbDDRkBrEzf8p7BQlMKNNF5Fk/Cf/fQ6PiUz9at4OaUfyXW0dGJTo2Vl1f5U9jSLCNf0EZJEogLXoeew==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.11",
-                "@vue/shared": "3.5.11"
+                "@vue/compiler-core": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.11.tgz",
-            "integrity": "sha512-gsbBtT4N9ANXXepprle+X9YLg2htQk1sqH/qGJ/EApl+dgpUBdTv3yP7YlR535uHZY3n6XaR0/bKo0BgwwDniw==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
-                "@vue/compiler-core": "3.5.11",
-                "@vue/compiler-dom": "3.5.11",
-                "@vue/compiler-ssr": "3.5.11",
-                "@vue/shared": "3.5.11",
+                "@vue/compiler-core": "3.5.13",
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.11",
-                "postcss": "^8.4.47",
+                "postcss": "^8.4.48",
                 "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.11.tgz",
-            "integrity": "sha512-P4+GPjOuC2aFTk1Z4WANvEhyOykcvEd5bIj2KVNGKGfM745LaXGr++5njpdBTzVz5pZifdlR1kpYSJJpIlSePA==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.11",
-                "@vue/shared": "3.5.11"
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.4.6.tgz",
-            "integrity": "sha512-XipBV5k0/IfTr0sNBDTg7OBUCp51cYMMXyPxLXJZ4K/wmUeMqt8cVdr2ZZGOFq+si/jTyCYnNxeKoyev5DOUUA==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.2.tgz",
+            "integrity": "sha512-1syn558KhyN+chO5SjlZIwJ8bV/bQ1nOVTG66t2RbG66ZGekyiYNmRO7X9BJCXQqPsFHlnksqvPhce2qpzxFnA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.4.6"
+                "@vue/devtools-kit": "^7.7.2"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.4.6.tgz",
-            "integrity": "sha512-NbYBwPWgEic1AOd9bWExz9weBzFdjiIfov0yRn4DrRfR+EQJCI9dn4I0XS7IxYGdkmUJi8mFW42LLk18WsGqew==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.2.tgz",
+            "integrity": "sha512-CY0I1JH3Z8PECbn6k3TqM1Bk9ASWxeMtTCvZr7vb+CHi+X/QwQm5F1/fPagraamKMAHVfuuCbdcnNg1A4CYVWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^7.4.6",
-                "birpc": "^0.2.17",
+                "@vue/devtools-shared": "^7.7.2",
+                "birpc": "^0.2.19",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
                 "perfect-debounce": "^1.0.0",
@@ -722,123 +1198,88 @@
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.4.6.tgz",
-            "integrity": "sha512-rPeSBzElnHYMB05Cc056BQiJpgocQjY8XVulgni+O9a9Gr9tNXgPteSzFFD+fT/iWMxNuUgGKs9CuW5DZewfIg==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.2.tgz",
+            "integrity": "sha512-uBFxnp8gwW2vD6FrJB8JZLUzVb6PNRG0B0jBnHsOH8uKyva2qINY8PTF5Te4QlTbMDqU5K6qtJDr6cNsKWhbOA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.11.tgz",
-            "integrity": "sha512-Nqo5VZEn8MJWlCce8XoyVqHZbd5P2NH+yuAaFzuNSR96I+y1cnuUiq7xfSG+kyvLSiWmaHTKP1r3OZY4mMD50w==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.11"
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.11.tgz",
-            "integrity": "sha512-7PsxFGqwfDhfhh0OcDWBG1DaIQIVOLgkwA5q6MtkPiDFjp5gohVnJEahSktwSFLq7R5PtxDKy6WKURVN1UDbzA==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.11",
-                "@vue/shared": "3.5.11"
+                "@vue/reactivity": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.11.tgz",
-            "integrity": "sha512-GNghjecT6IrGf0UhuYmpgaOlN7kxzQBhxWEn08c/SQDxv1yy4IXI1bn81JgEpQ4IXjRxWtPyI8x0/7TF5rPfYQ==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.11",
-                "@vue/runtime-core": "3.5.11",
-                "@vue/shared": "3.5.11",
+                "@vue/reactivity": "3.5.13",
+                "@vue/runtime-core": "3.5.13",
+                "@vue/shared": "3.5.13",
                 "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.11.tgz",
-            "integrity": "sha512-cVOwYBxR7Wb1B1FoxYvtjJD8X/9E5nlH4VSkJy2uMA1MzYNdzAAB//l8nrmN9py/4aP+3NjWukf9PZ3TeWULaA==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.11",
-                "@vue/shared": "3.5.11"
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13"
             },
             "peerDependencies": {
-                "vue": "3.5.11"
+                "vue": "3.5.13"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.11.tgz",
-            "integrity": "sha512-W8GgysJVnFo81FthhzurdRAWP/byq3q2qIw70e0JWblzVhjgOMiC2GyovXrZTFQJnFVryYaKGP3Tc9vYzYm6PQ==",
-            "dev": true,
-            "license": "MIT"
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+            "dev": true
         },
         "node_modules/@vueuse/core": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.1.0.tgz",
-            "integrity": "sha512-P6dk79QYA6sKQnghrUz/1tHi0n9mrb/iO1WTMk/ElLmTyNqgDeSZ3wcDf6fRBGzRJbeG1dxzEOvLENMjr+E3fg==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.7.0.tgz",
+            "integrity": "sha512-jtK5B7YjZXmkGNHjviyGO4s3ZtEhbzSgrbX+s5o+Lr8i2nYqNyHuPVOeTdM1/hZ5Tkxg/KktAuAVDDiHMraMVA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.20",
-                "@vueuse/metadata": "11.1.0",
-                "@vueuse/shared": "11.1.0",
-                "vue-demi": ">=0.14.10"
+                "@vueuse/metadata": "12.7.0",
+                "@vueuse/shared": "12.7.0",
+                "vue": "^3.5.13"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@vueuse/core/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@vueuse/integrations": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.1.0.tgz",
-            "integrity": "sha512-O2ZgrAGPy0qAjpoI2YR3egNgyEqwG85fxfwmA9BshRIGjV4G6yu6CfOPpMHAOoCD+UfsIl7Vb1bXJ6ifrHYDDA==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.7.0.tgz",
+            "integrity": "sha512-IEq7K4bCl7mn3uKJaWtNXnd1CAPaHLUMuyj5K1/k/pVcItt0VONZW8xiGxdIovJcQjkzOHjImhX5t6gija+0/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vueuse/core": "11.1.0",
-                "@vueuse/shared": "11.1.0",
-                "vue-demi": ">=0.14.10"
+                "@vueuse/core": "12.7.0",
+                "@vueuse/shared": "12.7.0",
+                "vue": "^3.5.13"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -896,148 +1337,49 @@
                 }
             }
         },
-        "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@vueuse/metadata": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.1.0.tgz",
-            "integrity": "sha512-l9Q502TBTaPYGanl1G+hPgd3QX5s4CGnpXriVBR5fEZ/goI6fvDaVmIl3Td8oKFurOxTmbXvBPSsgrd6eu6HYg==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.7.0.tgz",
+            "integrity": "sha512-4VvTH9mrjXqFN5LYa5YfqHVRI6j7R00Vy4995Rw7PQxyCL3z0Lli86iN4UemWqixxEvYfRjG+hF9wL8oLOn+3g==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.1.0.tgz",
-            "integrity": "sha512-YUtIpY122q7osj+zsNMFAfMTubGz0sn5QzE5gPzAIiCmtt2ha3uQUY1+JPyL4gRCTsLPX82Y9brNbo/aqlA91w==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.7.0.tgz",
+            "integrity": "sha512-coLlUw2HHKsm7rPN6WqHJQr18WymN4wkA/3ThFaJ4v4gWGWAQQGK+MJxLuJTBs4mojQiazlVWAKNJNpUWGRkNw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "vue-demi": ">=0.14.10"
+                "vue": "^3.5.13"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@vueuse/shared/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
             }
         },
         "node_modules/algoliasearch": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
-            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+            "version": "5.20.3",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.3.tgz",
+            "integrity": "sha512-iNC6BGvipaalFfDfDnXUje8GUlW5asj0cTMsZJwO/0rhsyLx1L7GZFAY8wW+eQ6AM4Yge2p5GSE5hrBlfSD90Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-account": "4.24.0",
-                "@algolia/client-analytics": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-personalization": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/recommend": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
+                "@algolia/client-abtesting": "5.20.3",
+                "@algolia/client-analytics": "5.20.3",
+                "@algolia/client-common": "5.20.3",
+                "@algolia/client-insights": "5.20.3",
+                "@algolia/client-personalization": "5.20.3",
+                "@algolia/client-query-suggestions": "5.20.3",
+                "@algolia/client-search": "5.20.3",
+                "@algolia/ingestion": "1.20.3",
+                "@algolia/monitoring": "1.20.3",
+                "@algolia/recommend": "5.20.3",
+                "@algolia/requester-browser-xhr": "5.20.3",
+                "@algolia/requester-fetch": "5.20.3",
+                "@algolia/requester-node-http": "5.20.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/birpc": {
@@ -1045,7 +1387,6 @@
             "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
             "integrity": "sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
@@ -1055,7 +1396,6 @@
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1066,7 +1406,6 @@
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
             "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1077,7 +1416,6 @@
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1088,7 +1426,6 @@
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
             "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1099,7 +1436,6 @@
             "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
             "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-what": "^4.1.8"
             },
@@ -1114,15 +1450,13 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -1132,7 +1466,6 @@
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
             "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "dequal": "^2.0.0"
             },
@@ -1141,12 +1474,17 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/emoji-regex-xs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+            "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+            "dev": true
+        },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -1160,7 +1498,6 @@
             "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -1197,15 +1534,13 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/focus-trap": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-            "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+            "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tabbable": "^6.2.0"
             }
@@ -1216,7 +1551,6 @@
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1226,11 +1560,10 @@
             }
         },
         "node_modules/hast-util-to-html": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-            "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+            "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
@@ -1239,7 +1572,7 @@
                 "hast-util-whitespace": "^3.0.0",
                 "html-void-elements": "^3.0.0",
                 "mdast-util-to-hast": "^13.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "stringify-entities": "^4.0.0",
                 "zwitch": "^2.0.4"
@@ -1254,7 +1587,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
             "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
             },
@@ -1267,15 +1599,13 @@
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
             "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/html-void-elements": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
             "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1286,7 +1616,6 @@
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
             "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.13"
             },
@@ -1295,11 +1624,10 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.11",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-            "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
@@ -1316,7 +1644,6 @@
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
             "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/mdast": "^4.0.0",
@@ -1334,9 +1661,9 @@
             }
         },
         "node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "dev": true,
             "funding": [
                 {
@@ -1348,16 +1675,15 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
             "dev": true,
             "funding": [
                 {
@@ -1368,13 +1694,12 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
             "dev": true,
             "funding": [
                 {
@@ -1386,7 +1711,6 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-encode": "^2.0.0",
@@ -1394,9 +1718,9 @@
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "dev": true,
             "funding": [
                 {
@@ -1407,13 +1731,12 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+            "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
             "dev": true,
             "funding": [
                 {
@@ -1424,27 +1747,24 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/minisearch": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.0.tgz",
-            "integrity": "sha512-tv7c/uefWdEhcu6hvrfTihflgeEi2tN6VV7HJnCjK6VxM75QQJh4t9FwJCsA2EsRS8LCnu3W87CuGPWMocOLCA==",
-            "dev": true,
-            "license": "MIT"
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
+            "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
+            "dev": true
         },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
                 {
@@ -1452,7 +1772,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -1460,37 +1779,33 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
+        "node_modules/oniguruma-to-es": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+            "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "regex": "^4.3.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
+                "emoji-regex-xs": "^1.0.0",
+                "regex": "^6.0.1",
+                "regex-recursion": "^6.0.2"
             }
         },
         "node_modules/perfect-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true
         },
         "node_modules/postcss": {
-            "version": "8.4.47",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "dev": true,
             "funding": [
                 {
@@ -1506,10 +1821,9 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.0",
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
             "engines": {
@@ -1517,47 +1831,60 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.24.2",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-            "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+            "version": "10.26.2",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.2.tgz",
+            "integrity": "sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
             }
         },
         "node_modules/property-information": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
+            "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/regex": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.3.tgz",
-            "integrity": "sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+            "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-recursion": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+            "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+            "dev": true,
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+            "dev": true
         },
         "node_modules/rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/rollup": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-            "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+            "version": "4.34.8",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
+            "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
             },
@@ -1569,45 +1896,48 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.24.0",
-                "@rollup/rollup-android-arm64": "4.24.0",
-                "@rollup/rollup-darwin-arm64": "4.24.0",
-                "@rollup/rollup-darwin-x64": "4.24.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-                "@rollup/rollup-linux-arm64-musl": "4.24.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-musl": "4.24.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-                "@rollup/rollup-win32-x64-msvc": "4.24.0",
+                "@rollup/rollup-android-arm-eabi": "4.34.8",
+                "@rollup/rollup-android-arm64": "4.34.8",
+                "@rollup/rollup-darwin-arm64": "4.34.8",
+                "@rollup/rollup-darwin-x64": "4.34.8",
+                "@rollup/rollup-freebsd-arm64": "4.34.8",
+                "@rollup/rollup-freebsd-x64": "4.34.8",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
+                "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
+                "@rollup/rollup-linux-arm64-gnu": "4.34.8",
+                "@rollup/rollup-linux-arm64-musl": "4.34.8",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
+                "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
+                "@rollup/rollup-linux-s390x-gnu": "4.34.8",
+                "@rollup/rollup-linux-x64-gnu": "4.34.8",
+                "@rollup/rollup-linux-x64-musl": "4.34.8",
+                "@rollup/rollup-win32-arm64-msvc": "4.34.8",
+                "@rollup/rollup-win32-ia32-msvc": "4.34.8",
+                "@rollup/rollup-win32-x64-msvc": "4.34.8",
                 "fsevents": "~2.3.2"
             }
         },
         "node_modules/search-insights": {
-            "version": "2.17.2",
-            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
-            "integrity": "sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==",
+            "version": "2.17.3",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+            "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/shiki": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.0.tgz",
-            "integrity": "sha512-/t5LlhNs+UOKQCYBtl5ZsH/Vclz73GIqT2yQsCBygr8L/ppTdmpL4w3kPLoZJbMKVWtoG77Ue1feOjZfDxvMkw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+            "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "1.22.0",
-                "@shikijs/engine-javascript": "1.22.0",
-                "@shikijs/engine-oniguruma": "1.22.0",
-                "@shikijs/types": "1.22.0",
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/core": "2.5.0",
+                "@shikijs/engine-javascript": "2.5.0",
+                "@shikijs/engine-oniguruma": "2.5.0",
+                "@shikijs/langs": "2.5.0",
+                "@shikijs/themes": "2.5.0",
+                "@shikijs/types": "2.5.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             }
         },
@@ -1616,7 +1946,6 @@
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1626,7 +1955,6 @@
             "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
             "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1637,7 +1965,6 @@
             "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
             "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1647,7 +1974,6 @@
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
             "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "character-entities-html4": "^2.0.0",
                 "character-entities-legacy": "^3.0.0"
@@ -1658,11 +1984,10 @@
             }
         },
         "node_modules/superjson": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
-            "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+            "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "copy-anything": "^3.0.2"
             },
@@ -1674,25 +1999,13 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
             "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
+            "dev": true
         },
         "node_modules/trim-lines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
             "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1703,7 +2016,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
             "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -1717,7 +2029,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
             "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -1731,7 +2042,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
             "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -1745,7 +2055,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
             "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0",
@@ -1761,7 +2070,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
             "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0"
@@ -1776,7 +2084,6 @@
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
             "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "vfile-message": "^4.0.0"
@@ -1791,7 +2098,6 @@
             "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
             "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-stringify-position": "^4.0.0"
@@ -1806,7 +2112,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
             "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -1862,29 +2167,29 @@
             }
         },
         "node_modules/vitepress": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.4.0.tgz",
-            "integrity": "sha512-JXCv4EsKTDyAFb6C/UjZr7nsGAzZ6mafVk2rx7rG5o8N+B/4QstIk+iEOe/9dKoU6V624UIC6g1pZ+K63rxhlw==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
+            "integrity": "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@docsearch/css": "^3.6.2",
-                "@docsearch/js": "^3.6.2",
-                "@shikijs/core": "^1.22.0",
-                "@shikijs/transformers": "^1.22.0",
-                "@shikijs/types": "^1.22.0",
+                "@docsearch/css": "3.8.2",
+                "@docsearch/js": "3.8.2",
+                "@iconify-json/simple-icons": "^1.2.21",
+                "@shikijs/core": "^2.1.0",
+                "@shikijs/transformers": "^2.1.0",
+                "@shikijs/types": "^2.1.0",
                 "@types/markdown-it": "^14.1.2",
-                "@vitejs/plugin-vue": "^5.1.4",
-                "@vue/devtools-api": "^7.4.6",
-                "@vue/shared": "^3.5.11",
-                "@vueuse/core": "^11.1.0",
-                "@vueuse/integrations": "^11.1.0",
-                "focus-trap": "^7.6.0",
+                "@vitejs/plugin-vue": "^5.2.1",
+                "@vue/devtools-api": "^7.7.0",
+                "@vue/shared": "^3.5.13",
+                "@vueuse/core": "^12.4.0",
+                "@vueuse/integrations": "^12.4.0",
+                "focus-trap": "^7.6.4",
                 "mark.js": "8.11.1",
-                "minisearch": "^7.1.0",
-                "shiki": "^1.22.0",
-                "vite": "^5.4.8",
-                "vue": "^3.5.11"
+                "minisearch": "^7.1.1",
+                "shiki": "^2.1.0",
+                "vite": "^5.4.14",
+                "vue": "^3.5.13"
             },
             "bin": {
                 "vitepress": "bin/vitepress.js"
@@ -1903,17 +2208,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.11.tgz",
-            "integrity": "sha512-/8Wurrd9J3lb72FTQS7gRMNQD4nztTtKPmuDuPuhqXmmpD6+skVjAeahNpVzsuky6Sy9gy7wn8UadqPtt9SQIg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.11",
-                "@vue/compiler-sfc": "3.5.11",
-                "@vue/runtime-dom": "3.5.11",
-                "@vue/server-renderer": "3.5.11",
-                "@vue/shared": "3.5.11"
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-sfc": "3.5.13",
+                "@vue/runtime-dom": "3.5.13",
+                "@vue/server-renderer": "3.5.13",
+                "@vue/shared": "3.5.13"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -1929,7 +2233,6 @@
             "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
             "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "vitepress": "^1.4.0"
+        "vitepress": "^1.6.0"
     }
 }


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Bump **Vitepress** (the tool used to generate the documentation) from 1.4.x to 1.6.x.

### Checklist

- [x] I tested these changes.