### PR TITLE
Fix Favicon Path for MsApplication

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -85,7 +85,7 @@
         <link rel="icon" type="image/png" sizes="192x192" href="{{ asset('favicons/android-icon-192x192.png') }}">
         <link rel="manifest" crossorigin="use-credentials" href="{{ asset('favicons/manifest.json') }}">
         <meta name="msapplication-TileColor" content="#ffffff">
-        <meta name="msapplication-TileImage" content="{{ asset('favicon/ms-icon-144x144.png') }}">
+        <meta name="msapplication-TileImage" content="{{ asset('favicons/ms-icon-144x144.png') }}">
     @endif
 
 </head>


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ISSUE
| License                 | MIT

### What's in this PR?

Fix the `favicon` path for the meta tag **"msapplication-TileImage"**.

Fix #1341 

### Checklist

- [x] I tested these changes.
- [x] I have linked the related issues.
