### PR TITLE
Docs: use_route_url and password routes

### DIFF
--- a/docs/sections/configuration/basic_configuration.md
+++ b/docs/sections/configuration/basic_configuration.md
@@ -196,6 +196,9 @@ The next configuration options provides a way to setup the urls for the login, r
 
   Whether to use `route()` instead of the `url()` Laravel method when internally generating the urls.
 
+> [!Caution]
+> Note that when set to `true`, the next set of URLs should be defined by using route names. For example: `password.email` on __`password_email_url`__, `password.update` on __`password_reset_url`__.
+
 - __`dashboard_url`__
 
   Changes the dashboard/logo URL. This URL will be used, for example, when clicking on the upper left logo.

--- a/docs/sections/configuration/basic_configuration.md
+++ b/docs/sections/configuration/basic_configuration.md
@@ -197,7 +197,7 @@ The next configuration options provides a way to setup the urls for the login, r
   Whether to use `route()` instead of the `url()` Laravel method when internally generating the urls.
 
 > [!Caution]
-> Note that when set to `true`, the next set of URLs should be defined by using route names. For example: `password.email` on __`password_email_url`__, `password.update` on __`password_reset_url`__.
+> When set to `true`, the next set of URLs should be defined by using route names. For example: `password.email` on __`password_email_url`__, `password.update` on __`password_reset_url`__, etc.
 
 - __`dashboard_url`__
 
@@ -223,13 +223,9 @@ The next configuration options provides a way to setup the urls for the login, r
 
   Changes the password reset URL. This url should point to the view that displays the password reset form. Set this option to `false` or `null` to hide the password reset link shown on the login view.
 
-  Note that when `use_route_url` is set to `true` this value must be changed to `password.update`.
-
 - __`password_email_url`__
 
   Changes the password email URL. This url should point to the view that displays the send reset link form.
-
-  Note that when `use_route_url` is set to `true` this value must be changed to `password.email`.
 
 - __`profile_url`__
 

--- a/docs/sections/configuration/basic_configuration.md
+++ b/docs/sections/configuration/basic_configuration.md
@@ -220,9 +220,13 @@ The next configuration options provides a way to setup the urls for the login, r
 
   Changes the password reset URL. This url should point to the view that displays the password reset form. Set this option to `false` or `null` to hide the password reset link shown on the login view.
 
+  Note that when `use_route_url` is set to `true` this value must be changed to `password.update`.
+
 - __`password_email_url`__
 
   Changes the password email URL. This url should point to the view that displays the send reset link form.
+
+  Note that when `use_route_url` is set to `true` this value must be changed to `password.email`.
 
 - __`profile_url`__
 


### PR DESCRIPTION
Added additional notes about password related routes when `use_route_url` is set to true

| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Extended notes for password-related routes when setting ´use_route_url´ to _true_

Minor docs update, no issues related.

### Checklist

- [x] I tested these changes.
- [ ] I have linked the related issues. 
