### PR TITLE
Add nav-icon class to sidebar menu item icons to improve style

### DIFF
--- a/resources/views/partials/sidebar/menu-item-link.blade.php
+++ b/resources/views/partials/sidebar/menu-item-link.blade.php
@@ -4,7 +4,7 @@
        href="{{ $item['href'] }}" @isset($item['target']) target="{{ $item['target'] }}" @endisset
        {!! $item['data-compiled'] ?? '' !!}>
 
-        <i class="{{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
+        <i class="nav-icon {{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
             isset($item['icon_color']) ? 'text-'.$item['icon_color'] : ''
         }}"></i>
 

--- a/resources/views/partials/sidebar/menu-item-treeview-menu.blade.php
+++ b/resources/views/partials/sidebar/menu-item-treeview-menu.blade.php
@@ -4,7 +4,7 @@
     <a class="nav-link {{ $item['class'] }} @isset($item['shift']) {{ $item['shift'] }} @endisset"
        href="" {!! $item['data-compiled'] ?? '' !!}>
 
-        <i class="{{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
+        <i class="nav-icon {{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
             isset($item['icon_color']) ? 'text-'.$item['icon_color'] : ''
         }}"></i>
 


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ENHANCEMENT
| License                 | MIT

### What's in this PR?

Adds the missing `nav-icon` class to icons of the sidebar menu items to improve their style.

### Checklist

- [x] I tested these changes.