### PR TITLE
Update .scrutinizer.yml to use composer 2

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         php: 7.3.0
 
     dependencies:
-         before:
+        before:
             # Download and verify latest Composer installer
             - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             - php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }"


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | <!-- ISSUE -->
| License                 | MIT

### What's in this PR?

Fix `scrutinizer` to install **version 2** of `composer` before its processing, due to end support for **version 1** of composer at `2025-09-01`.

### Checklist

- [x] I tested these changes.
