### PR TITLE
Fix composer 2 dependency on scrutinizer CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,16 @@ build:
     environment:
         php: 7.3.0
 
+    dependencies:
+        before:
+            # Download latest Composer installer
+            - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            - php composer-setup.php --install-dir=$HOME/bin --filename=composer
+            - php -r "unlink('composer-setup.php');"
+            - $HOME/bin/composer --version
+        override:
+            - $HOME/bin/composer install --no-interaction --prefer-dist --optimize-autoloader
+
     nodes:
         analysis:
             tests:


### PR DESCRIPTION
| Question                | Answer
| ----------------------- | -----------------------
| Pull request type       | ISSUE
| License                 | MIT

### What's in this PR?

A better fix to use **composer 2** with **Scrutinizer CI**. The current code contains a harcoded hash that is not adequate, because it needs to be updated on each new version of composer. So, we avoid verifying the composer installer and just trust `TLS`

### Checklist

- [x] I tested these changes.
